### PR TITLE
Only set the profile name to the kind

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -149,7 +149,7 @@ func (p *CgroupProfiler) Stop() {
 func (p *CgroupProfiler) Labels() []*profilestorepb.Label {
 	return append(p.target.Labels(), &profilestorepb.Label{
 		Name:  "__name__",
-		Value: "cpu_samples",
+		Value: "cpu",
 	})
 }
 


### PR DESCRIPTION
The server-side structures the sample type(s) and kinds.

Goes hand-in-hand with https://github.com/parca-dev/parca/pull/46