### PR TITLE
ebpf: Increase stack depth to 128

### DIFF
--- a/parca-agent.bpf.c
+++ b/parca-agent.bpf.c
@@ -27,7 +27,7 @@
 #endif
 
 #define MAX_STACK_ADDRESSES 1024          // Max amount of different stack trace addresses to buffer in the Map
-#define MAX_STACK_DEPTH     20            // Max depth of each stack trace to track
+#define MAX_STACK_DEPTH     128           // Max depth of each stack trace to track
 
 #define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries) \
 struct bpf_map_def SEC("maps") _name = { \


### PR DESCRIPTION
I noticed some odd stacks that were cut off exactly at the 20 depth mark. Hopefully, this will be a better default.

![Screenshot from 2021-09-21 11-05-41](https://user-images.githubusercontent.com/4546722/134143597-f3bcc725-b834-454d-beb0-2764f2cd7d6a.png)
