### PR TITLE
pkg/agent: Rename profile series name to `parca_agent_cpu`

### DIFF
--- a/pkg/agent/profile.go
+++ b/pkg/agent/profile.go
@@ -149,7 +149,7 @@ func (p *CgroupProfiler) Labels() []*profilestorepb.Label {
 	labels := append(p.target.Labels(),
 		&profilestorepb.Label{
 			Name:  "__name__",
-			Value: "cpu",
+			Value: "parca_agent_cpu",
 		})
 	for key, value := range p.externalLabels {
 		labels = append(labels, &profilestorepb.Label{


### PR DESCRIPTION
Follow up to https://github.com/parca-dev/parca/pull/123, to make sure the profile name is distinguishable from others and rendered as a human-readable name in Parca's frontend.