### PR TITLE
Make the container runtime's socket path configurable via flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Flags:
                                 SystemD units to profile on this node.
       --temp-dir="/tmp"         Temporary directory path to use for object
                                 files.
+      --socket-path=STRING      The filesystem path to the container runtimes
+                                socket. Leave this empty to use the defaults.
 ```
 
 ### SystemD

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -69,6 +69,7 @@ type flags struct {
 	PodLabelSelector   string            `kong:"help='Label selector to control which Kubernetes Pods to select.'"`
 	SystemdUnits       []string          `kong:"help='SystemD units to profile on this node.'"`
 	TempDir            string            `kong:"help='Temporary directory path to use for object files.',default='/tmp'"`
+	SocketPath         string            `kong:"help='The filesystem path to the container runtimes socket. Leave this empty to use the defaults.'"`
 }
 
 func main() {
@@ -128,6 +129,7 @@ func main() {
 			wc,
 			dc,
 			flags.TempDir,
+			flags.SocketPath,
 		)
 		if err != nil {
 			level.Error(logger).Log("err", err)

--- a/pkg/agent/podmanager.go
+++ b/pkg/agent/podmanager.go
@@ -172,11 +172,12 @@ func NewPodManager(
 	writeClient profilestorepb.ProfileStoreServiceClient,
 	debugInfoClient debuginfo.Client,
 	tmp string,
+	socketPath string,
 ) (*PodManager, error) {
 	createdChan := make(chan *v1.Pod)
 	deletedChan := make(chan string)
 
-	k8sClient, err := k8s.NewK8sClient(logger, nodeName)
+	k8sClient, err := k8s.NewK8sClient(logger, nodeName, socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("create k8s client: %w", err)
 	}


### PR DESCRIPTION
On k3s the socket is available on `/run/k3s/containerd/containerd.sock` which isn't the usual default. Need a flag to configure the path to the socket in some cases.