### PR TITLE
deploy/lib/parca-agent: pin pods to amd64 architecture

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -322,6 +322,7 @@ function(params) {
             serviceAccountName: pa.serviceAccount.metadata.name,
             nodeSelector: {
               'kubernetes.io/os': 'linux',
+              'kubernetes.io/arch': 'amd64',
             },
             tolerations: [
               {


### PR DESCRIPTION
Since current containers are x86-64 specific, imho it would be good to pin DaemonSet pods only to that CPU architecture'