### PR TITLE
parca-agent: specify error code directly

### DIFF
--- a/parca-agent.bpf.c
+++ b/parca-agent.bpf.c
@@ -19,6 +19,7 @@
 #include <bpf_tracing.h>
 #include <bpf_core_read.h>
 #include <bpf_endian.h>
+#include <asm-generic/errno.h>
 
 #if defined(bpf_target_x86)
 #define PT_REGS_PARM6(ctx)  ((ctx)->r9)
@@ -77,8 +78,7 @@ bpf_map_lookup_or_try_init(void *map, const void *key, const void *init)
 		return val;
 
 	err = bpf_map_update_elem(map, key, init, BPF_NOEXIST);
-    // 17 == EEXIST
-	if (err && err != -17)
+	if (err && err != -EEXIST)
 		return 0;
 
 	return bpf_map_lookup_elem(map, key);


### PR DESCRIPTION
A small improvement in code readability.

By importing error code definitions (`asm-generic/errno-base.h`) you can get rit of comment and clearly define where this error code comes from.