### PR TITLE
deploy/lib/parca-agent: unify metadata across all objects

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -40,23 +40,22 @@ function(params) {
   // Combine the defaults and the passed params to make the component's config.
   config:: defaults + params,
 
+  metadata:: {
+    name: pa.config.name,
+    namespace: pa.config.namespace,
+    labels: pa.config.commonLabels,
+  },
+
   serviceAccount: {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-    metadata: {
-      name: pa.config.name,
-      namespace: pa.config.namespace,
-      labels: pa.config.commonLabels,
-    },
+    metadata: pa.metadata,
   },
 
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: {
-      name: pa.config.name,
-      namespace: pa.config.namespace,
-    },
+    metadata: pa.metadata,
     subjects: [{
       kind: 'ServiceAccount',
       name: pa.config.name,
@@ -72,10 +71,7 @@ function(params) {
   clusterRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: {
-      name: pa.config.name,
-      labels: pa.config.commonLabels,
-    },
+    metadata: pa.metadata,
     rules: [
       {
         apiGroups: [''],
@@ -93,9 +89,7 @@ function(params) {
   podSecurityPolicy: {
     apiVersion: 'policy/v1beta1',
     kind: 'PodSecurityPolicy',
-    metadata: {
-      name: pa.config.name,
-    },
+    metadata: pa.metadata,
     spec: {
       allowPrivilegeEscalation: true,
       allowedCapabilities: ['*'],
@@ -154,11 +148,7 @@ function(params) {
   role: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
-    metadata: {
-      name: pa.config.name,
-      namespace: pa.config.namespace,
-      labels: pa.config.commonLabels,
-    },
+    metadata: pa.metadata,
     rules: [
       {
         apiGroups: [
@@ -180,11 +170,7 @@ function(params) {
   roleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
-    metadata: {
-      name: pa.config.name,
-      namespace: pa.config.namespace,
-      labels: pa.config.commonLabels,
-    },
+    metadata: pa.metadata,
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'Role',
@@ -299,11 +285,7 @@ function(params) {
     {
       apiVersion: 'apps/v1',
       kind: 'DaemonSet',
-      metadata: {
-        name: pa.config.name,
-        namespace: pa.config.namespace,
-        labels: pa.config.commonLabels,
-      },
+      metadata: pa.metadata,
       spec: {
         selector: {
           matchLabels: {


### PR DESCRIPTION
Use a hidden top-level `metadata` variable to unify metadata across all deployed objects.