### PR TITLE
deploy: Add external-label support

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -28,6 +28,7 @@ local defaults = {
   },
 
   podLabelSelector:: {},
+  externalLabels:: {},
 
   securityContext:: {
     privileged: true,
@@ -222,6 +223,11 @@ function(params) {
       ) + (
         if pa.config.tempDir != '' then [
           '--temp-dir=' + pa.config.tempDir,
+        ] else []
+      ) + (
+        if std.length(pa.config.externalLabels) > 0 then [
+          '--external-label=%s=%s' % [labelName, pa.config.externalLabels[labelName]]
+          for labelName in std.objectFields(pa.config.externalLabels)
         ] else []
       ),
       securityContext: pa.config.securityContext,


### PR DESCRIPTION
Looking forward to installing parca in a multi-cluster setup. Support for external-labels in the jsonnet library would be great 🙂 