### PR TITLE
testutil: Introduce package and move fs fakes there

### DIFF
--- a/pkg/maps/maps_test.go
+++ b/pkg/maps/maps_test.go
@@ -14,35 +14,18 @@
 package maps
 
 import (
-	"bytes"
-	"io"
-	"io/fs"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
 	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca-agent/pkg/testutil"
 )
-
-type fakefile struct {
-	content io.Reader
-}
-
-func (f *fakefile) Stat() (fs.FileInfo, error) { return nil, nil }
-func (f *fakefile) Read(b []byte) (int, error) { return f.content.Read(b) }
-func (f *fakefile) Close() error               { return nil }
-
-type fakefs struct {
-	data map[string][]byte
-}
-
-func (f *fakefs) Open(name string) (fs.File, error) {
-	return &fakefile{content: bytes.NewBuffer(f.data[name])}, nil
-}
 
 func testCache() *PidMappingFileCache {
 	return &PidMappingFileCache{
-		fs: &fakefs{map[string][]byte{
+		fs: testutil.NewFakeFS(map[string][]byte{
 			"/proc/2043862/maps": []byte(`
 00400000-00464000 r-xp 00000000 fd:01 2106801                            /main
 00464000-004d4000 r--p 00064000 fd:01 2106801                            /main
@@ -65,7 +48,7 @@ c000000000-c004000000 rw-p 00000000 00:00 0
 7ffc30dd1000-7ffc30dd3000 r-xp 00000000 00:00 0                          [vdso]
 ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
 			`),
-		}},
+		}),
 		logger:     log.NewNopLogger(),
 		cache:      map[uint32][]*profile.Mapping{},
 		pidMapHash: map[uint32]uint64{},

--- a/pkg/testutil/fs.go
+++ b/pkg/testutil/fs.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+)
+
+type fakefile struct {
+	content io.Reader
+}
+
+func (f *fakefile) Stat() (fs.FileInfo, error) { return nil, nil }
+func (f *fakefile) Read(b []byte) (int, error) { return f.content.Read(b) }
+func (f *fakefile) Close() error               { return nil }
+
+type fakefs struct {
+	data map[string][]byte
+}
+
+func (f *fakefs) Open(name string) (fs.File, error) {
+	return &fakefile{content: bytes.NewBuffer(f.data[name])}, nil
+}
+
+type errorfs struct{ err error }
+
+func (f *errorfs) Open(name string) (fs.File, error) {
+	return nil, f.err
+}
+
+func NewFakeFS(files map[string][]byte) fs.FS {
+	return &fakefs{files}
+}
+
+func NewErrorFS(err error) fs.FS {
+	return &errorfs{err}
+}


### PR DESCRIPTION
I started building code to parse /tmp/perf-${pid}.map and copied the same code for the test. Introduce a testutil package instead of introducing one more copy.