### PR TITLE
deploy/main: use labels vs. annotations for pod-security settings

### DIFF
--- a/deploy/main.jsonnet
+++ b/deploy/main.jsonnet
@@ -4,7 +4,7 @@ function(version='v0.0.1-alpha.3')
     kind: 'Namespace',
     metadata: {
       name: 'parca',
-      annotations: {
+      labels: {
         'pod-security.kubernetes.io/enforce': 'privileged',
         'pod-security.kubernetes.io/audit': 'privileged',
         'pod-security.kubernetes.io/warn': 'privileged',

--- a/deploy/openshift.jsonnet
+++ b/deploy/openshift.jsonnet
@@ -4,7 +4,7 @@ function(version='v0.0.1-alpha.3')
     kind: 'Namespace',
     metadata: {
       name: 'parca',
-      annotations: {
+      labels: {
         'pod-security.kubernetes.io/enforce': 'privileged',
         'pod-security.kubernetes.io/audit': 'privileged',
         'pod-security.kubernetes.io/warn': 'privileged',


### PR DESCRIPTION
Fixes https://github.com/parca-dev/parca.dev/issues/31

Side note: I regenerated manifests but these are not checked it (assuming this is vendored elsewhere). Please let me know if there is some generation target that I might have missed.

Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>