### PR TITLE
containerutils: Speculative mem leak fix

### DIFF
--- a/pkg/containerutils/containerutils.go
+++ b/pkg/containerutils/containerutils.go
@@ -56,11 +56,15 @@ uint64_t get_cgroupid(char *path) {
 
   h->handle_bytes = 8;
   err = name_to_handle_at(AT_FDCWD, path, (struct file_handle *)h, &mount_id, 0);
-  if (err != 0)
+  if (err != 0) {
+    free(h);
     return 0;
+  }
 
-  if (h->handle_bytes != 8)
+  if (h->handle_bytes != 8) {
+    free(h);
     return 0;
+  }
 
   ret = h->cgid;
   free(h);


### PR DESCRIPTION
This looks like a memory leak. Release the file_handle on all
branches out. Consider using x/sys/unix for a wrapped version
of this method.

Also is there a specific reason to allocate this on the heap?