### PR TITLE
systemd: Deal with non-resolvable units and slice locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Flags:
                                   socket. Leave this empty to use the defaults.
       --profiling-duration=10s    The agent profiling duration to use. Leave
                                   this empty to use the defaults.
+      --systemd-cgroup-path="/sys/fs/cgroup/systemd/system.slice"
+                                  The cgroupfs path to a systemd slice.
 ```
 
 ### systemd

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -72,6 +72,7 @@ type flags struct {
 	TempDir            string            `kong:"help='Temporary directory path to use for object files.',default='/tmp'"`
 	SocketPath         string            `kong:"help='The filesystem path to the container runtimes socket. Leave this empty to use the defaults.'"`
 	ProfilingDuration  time.Duration     `kong:"help='The agent profiling duration to use. Leave this empty to use the defaults.',default='10s'"`
+	SystemdCgroupPath  string            `kong:"help='The cgroupfs path to a systemd slice.',default='/sys/fs/cgroup/systemd/system.slice'"`
 }
 
 func main() {
@@ -160,6 +161,7 @@ func main() {
 			dc,
 			flags.TempDir,
 			flags.ProfilingDuration,
+			flags.SystemdCgroupPath,
 		)
 		targetSources = append(targetSources, sm)
 	}


### PR DESCRIPTION
My system.slice on OpenSUSE tumbleweed seems to be at a different place. Also don't fail to render the status page when a unit can not be resolved.