### PR TITLE
deploy: Remove localtime mount

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -277,10 +277,6 @@ function(params) {
           name: 'bpffs',
           mountPath: '/sys/fs/bpf',
         },
-        {
-          name: 'localtime',
-          mountPath: '/etc/localtime',
-        },
       ],
       env: [
         {
@@ -373,12 +369,6 @@ function(params) {
                 name: 'debugfs',
                 hostPath: {
                   path: '/sys/kernel/debug',
-                },
-              },
-              {
-                name: 'localtime',
-                hostPath: {
-                  path: '/etc/localtime',
                 },
               },
             ],


### PR DESCRIPTION
This mount is unnecessary, it was left over from debugging.

Closes https://github.com/parca-dev/parca/issues/346