### PR TITLE
deploy/lib: remove unnecessary mounts

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -33,6 +33,7 @@ local defaults = {
 
   securityContext:: {
     privileged: true,
+    readOnlyRootFilesystem: true,
   },
 
   podMonitor: false,
@@ -134,19 +135,10 @@ function(params) {
       ],
       allowedHostPaths+: [
         {
-          pathPrefix: '/proc',
-        },
-        {
           pathPrefix: '/sys',
         },
         {
-          pathPrefix: '/',
-        },
-        {
-          pathPrefix: '/lib',
-        },
-        {
-          pathPrefix: '/etc',
+          pathPrefix: '/lib/modules',
         },
       ],
     },
@@ -248,16 +240,6 @@ function(params) {
           mountPath: '/tmp',
         },
         {
-          name: 'root',
-          mountPath: '/host/root',
-          readOnly: true,
-        },
-        {
-          name: 'proc',
-          mountPath: '/host/proc',
-          readOnly: true,
-        },
-        {
           name: 'run',
           mountPath: '/run',
         },
@@ -329,17 +311,6 @@ function(params) {
               {
                 name: 'tmp',
                 emptyDir: {},
-              },
-              {
-                name: 'root',
-                hostPath: {
-                  path: '/',
-                },
-              },
-              {
-                name: 'proc',
-                hostPath:
-                  { path: '/proc' },
               },
               {
                 name: 'run',


### PR DESCRIPTION
Fixes #115

List of changes:
- Removed mount for `/` directory and removed access in PSP
- Removed mount for `/proc` directory as it is not needed due to `hostPID: true` setting
- Removed access to `/etc` directory in PSP
- Made root FS in container read-only to increase the security aspect of a highly privileged pod.