### PR TITLE
*: Add explicit shell to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all
 all: bpf build
 
+SHELL := /bin/bash
+
 # tools:
 CMD_LLC ?= llc
 CMD_CLANG ?= clang


### PR DESCRIPTION
Similar to https://github.com/parca-dev/parca/pull/494 the default shell
in Make in `/bin/sh` which does not implement `source`. Specify
`/bin/bash` specfically which does implement that command.