### PR TITLE
*: Add bpf as a dependency for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 .PHONY: test
 ifndef DOCKER
-test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
+test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
 	$(go_env) go test -v $(shell go list ./... | grep -v "pkg/internal/pprof")
 else
 test: $(DOCKER_BUILDER)


### PR DESCRIPTION
The test target requires that the parca-agent.bpf.o file has been
created. Make this easier by making it a dependency so it is
automatically built if not already before running the tests.