### PR TITLE
pkg/agent: Support cgroups v2 unified, add basic test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,15 @@ test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)
 endif
 
+.PHONY: test-run
+ifndef DOCKER
+test-run: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
+	$(go_env) go test -race -exec 'sudo -E' -v $(GOPKG) -run $(RUN)
+else
+test-run: $(DOCKER_BUILDER)
+	$(call docker_builder_make,$@)
+endif
+
 .PHONY: vet
 ifndef DOCKER
 vet: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
-	$(go_env) go test -v $(shell go list ./... | grep -v "pkg/internal/pprof")
+	$(go_env) go test -exec 'sudo -E' -v $(shell go list ./... | grep -v "pkg/internal/pprof")
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kong v0.2.22
 	github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0
 	github.com/cespare/xxhash/v2 v2.1.2
+	github.com/containerd/cgroups v1.0.2
 	github.com/containerd/containerd v1.5.7 // indirect
 	github.com/docker/docker v20.10.11+incompatible
 	github.com/go-kit/log v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340/go.mod h1:s5q4S
 github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
 github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
+github.com/containerd/cgroups v1.0.2 h1:mZBclaSgNDfPWtfhj2xJY28LZ9nYIgzB0pwSURPl6JM=
+github.com/containerd/cgroups v1.0.2/go.mod h1:qpbpJ1jmlqsR9f2IyaLPsdkCdnt0rbDVqIDlhuu5tRY=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
@@ -388,9 +390,11 @@ github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
+github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -714,8 +718,10 @@ github.com/gocql/gocql v0.0.0-20200526081602-cd04bd7f22a7/go.mod h1:DL0ekTmBSTdl
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/pkg/agent/profile_test.go
+++ b/pkg/agent/profile_test.go
@@ -1,0 +1,80 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/containerd/cgroups"
+	"github.com/go-kit/log"
+	"github.com/parca-dev/parca-agent/pkg/debuginfo"
+	"github.com/parca-dev/parca-agent/pkg/ksym"
+)
+
+func TestCgroupProfiler(t *testing.T) {
+	var (
+		gotSample = make(chan struct{})
+
+		// Put this here specifically so we only close over the t and gotsample variables
+		// and don't bloat this closure with a bunch of variables.
+		sink = func(r Record) {
+			if len(r.Profile.Sample) == 0 {
+				t.Fatal("expected at least one sample")
+			}
+			gotSample <- struct{}{}
+		}
+
+		unit           = "upower.service" // Ensure we profile a noisy and ubiquitous process.
+		logger         = log.NewNopLogger()
+		ksymCache      = ksym.NewKsymCache(logger)
+		ctx            = context.Background()
+		duration       = time.Second * 10
+		errCh          = make(chan error)
+		externalLabels = map[string]string{"systemdunit": unit}
+	)
+
+	f, err := os.CreateTemp(os.TempDir(), "test.tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seems backwards but since defers stack this will
+	// close first then remove.
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	p := NewCgroupProfiler(
+		logger,
+		externalLabels,
+		ksymCache,
+		NewNoopProfileStoreClient(),
+		debuginfo.NewNoopClient(),
+		&SystemdUnitTarget{
+			Name:       unit,
+			NodeName:   "testnode",
+			cgroupMode: cgroups.Mode(),
+		},
+		duration,
+		sink,
+		f.Name(),
+	)
+	if p == nil {
+		t.Fatal("expected a non-nil profiler")
+	}
+
+	// Start the profiler. Run in separate goroutine so we can
+	// assert since this operation blocks.
+	go func(errc chan error) { errc <- p.Run(ctx) }(errCh)
+
+	t.Log("waiting for profiler to collect data")
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-gotSample:
+		// Nothing to do here, just break out of the select.
+	case <-time.After(duration + time.Second): // Allow enough time for profiling to complete.
+		t.Fatal("timed out waiting for profiler to run")
+	}
+}


### PR DESCRIPTION
This patch adds support for the cgroups v2 unified filesystem. We now
attempt to detect at runtime which version of cgroup the host is using
and adapt appropriately.

Additionally this patch adds a small sanity check test for the profiler.
For now it only asserts that we have indeed received some profiling
sample data, in the future we can add more assertions.

Fixes #23