### PR TITLE
Remove default systemd cgroup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Flags:
                                   socket. Leave this empty to use the defaults.
       --profiling-duration=10s    The agent profiling duration to use. Leave
                                   this empty to use the defaults.
-      --systemd-cgroup-path="/sys/fs/cgroup/systemd/system.slice"
+      --systemd-cgroup-path=STRING
                                   The cgroupfs path to a systemd slice.
 ```
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -79,7 +79,7 @@ type flags struct {
 	TempDir            string            `kong:"help='Temporary directory path to use for object files.',default='/tmp'"`
 	SocketPath         string            `kong:"help='The filesystem path to the container runtimes socket. Leave this empty to use the defaults.'"`
 	ProfilingDuration  time.Duration     `kong:"help='The agent profiling duration to use. Leave this empty to use the defaults.',default='10s'"`
-	SystemdCgroupPath  string            `kong:"help='The cgroupfs path to a systemd slice.',default='/sys/fs/cgroup/systemd/system.slice'"`
+	SystemdCgroupPath  string            `kong:"help='The cgroupfs path to a systemd slice.'"`
 }
 
 func getExternalLabels(flagExternalLabels map[string]string, flagNode string) model.LabelSet {


### PR DESCRIPTION
There was a previous commit which wired up this flag throughout the
codebase, however that code didn't take into account that this flag
has a default parameter. Remove the default and let the user set it
if it's really necessary.