### PR TITLE
pkg/containerutils/containerd: Automatically discover k3s containerd

### DIFF
--- a/pkg/containerutils/containerd/containerd.go
+++ b/pkg/containerutils/containerd/containerd.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	DEFAULT_SOCKET_PATH = "/run/containerd/containerd.sock"
-	DEFAULT_TIMEOUT     = 2 * time.Second
+	DEFAULT_SOCKET_PATH     = "/run/containerd/containerd.sock"
+	DEFAULT_K3S_SOCKET_PATH = "/run/k3s/containerd/containerd.sock"
+	DEFAULT_TIMEOUT         = 2 * time.Second
 )
 
 type ContainerdClient struct {

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -112,7 +112,12 @@ func newCRIClient(logger log.Logger, node *v1.Node, socketPath string) (containe
 		return docker.NewDockerClient(socketPath)
 	case "containerd":
 		if socketPath == "" {
-			socketPath = containerd.DEFAULT_SOCKET_PATH
+			if _, err := os.Stat(containerd.DEFAULT_SOCKET_PATH); err == nil {
+				socketPath = containerd.DEFAULT_SOCKET_PATH
+			}
+			if _, err := os.Stat(containerd.DEFAULT_K3S_SOCKET_PATH); err == nil {
+				socketPath = containerd.DEFAULT_K3S_SOCKET_PATH
+			}
 		}
 		return containerd.NewContainerdClient(socketPath)
 	case "cri-o":


### PR DESCRIPTION
Previously the k3s containerd socket had to be explicitly configured,
however, similar to the standard Kubernetes containerd configuration k3s
has a (different) standard location as well. In order to not force users
to make special changes for k3s, this patch automatically attempts
discovering the k3s path as well.