### PR TITLE
pkg/agent: Fix accidental infinite retry

### DIFF
--- a/pkg/agent/write_client.go
+++ b/pkg/agent/write_client.go
@@ -74,17 +74,17 @@ func (b *Batcher) Run(ctx context.Context) error {
 
 func (b *Batcher) batchLoop(ctx context.Context) error {
 	b.mtx.Lock()
-	defer b.mtx.Unlock()
+	batch := b.series
+	b.series = []*profilestorepb.RawProfileSeries{}
+	b.mtx.Unlock()
 
 	if _, err := b.writeClient.WriteRaw(
 		ctx,
-		&profilestorepb.WriteRawRequest{Series: b.series},
+		&profilestorepb.WriteRawRequest{Series: batch},
 	); err != nil {
 		level.Error(b.logger).Log("msg", "Writeclient failed to send profiles", "err", err)
 		return err
 	}
-
-	b.series = []*profilestorepb.RawProfileSeries{}
 
 	return nil
 }


### PR DESCRIPTION
We have unintentionally built a retry mechanism in our request batching code, that will indefinitely retry if an error occurs. Before this patch whenever a batch fails to send, we will not reset the batch, so we will indefinitely retry the current batch if it continues to error. If a batch causes an out of order insert on the server-side for example, then this will retry forever,
since this will never not be out of order.