### PR TITLE
Pin libbpf version

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,12 +8,13 @@ updates:
     schedule:
       interval: "daily"
 
-    # Enable version updates for libbpf submodules
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    # Check the go modules for updates every day (weekdays)
-    schedule:
-      interval: "daily"
+  # Our libbpf version tight to libbpf-go right now, so it needs to be upgraded together.
+  # Enable version updates for libbpf submodules
+  # - package-ecosystem: "gitsubmodule"
+  #   directory: "/"
+  #   # Check the go modules for updates every day (weekdays)
+  #   schedule:
+  #     interval: "daily"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Parca libbpf version tight to libbpf-go right now, so it needs to be upgraded together. 

libbpf-go version https://github.com/parca-dev/parca-agent/blob/433779305d362e617d587fed7a73ce3e7ab32740/go.mod#L7


https://github.com/libbpf/libbpf/commits/v0.6.1