### PR TITLE
Tiltfile: Add new internal/ folder to list of Docker dependencies

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,7 +5,17 @@ docker_prune_settings(num_builds=5)
 docker_build(
     'parca.io/parca/parca-agent:dev', '',
      dockerfile='Dockerfile.dev',
-     only=['./cmd', './pkg', './3rdparty', './go.mod', './go.sum', './parca-agent.bpf.c', './vmlinux.h', './Makefile'],
+     only=[
+         './3rdparty',
+         './Makefile',
+         './cmd',
+         './go.mod',
+         './go.sum',
+         './internal',
+         './parca-agent.bpf.c',
+         './pkg',
+         './vmlinux.h',
+     ],
 )
 k8s_yaml('deploy/tilt/parca-agent-daemonSet.yaml')
 k8s_resource('parca-agent', port_forwards=[7071])


### PR DESCRIPTION
Tilt watches the files in the only list and also only copies these for building the image in minikube. 
That's why we need to add `./internal` to that list now after newly creating it.