### PR TITLE
pkg/maps: Skip more pseudo-paths and anonymous mappings 

### DIFF
--- a/pkg/maps/maps.go
+++ b/pkg/maps/maps.go
@@ -91,8 +91,8 @@ func (c *PidMappingFileCache) mappingForPid(pid uint32) ([]*profile.Mapping, err
 	for _, m := range mapping {
 		// Try our best to have the BuildID.
 		if m.BuildID == "" {
-			// TODO(brancz): These need special cases.
-			if m.File == "[vdso]" || m.File == "[vsyscall]" {
+			// TODO(brancz): These need special cases. See pseudo-paths in proc's man page
+			if m.File == "[vdso]" || m.File == "[vsyscall]" || m.File == "[stack]" || m.File == "[heap]" || m.File == "" {
 				continue
 			}
 


### PR DESCRIPTION
This should prevent trying to access the root symlink because the m.File is empty.
```
level=warn ts=2022-03-02T15:50:14.508461455Z caller=maps.go:102 msg="failed to read obj build ID" obj=/proc/12497/root err="failed to open elf: read /proc/12497/root: is a directory"
``` 

(Hopefully)
Fixes: #82 
