### PR TITLE
Makefile: Fix pushing container manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,11 +209,11 @@ container:
 
 .PHONY: push-container
 push-container:
-	podman manifest push $(OUT_DOCKER):$(VERSION)
+	podman manifest push --all $(OUT_DOCKER):$(VERSION) docker://$(OUT_DOCKER):$(VERSION)
 
 .PHONY: push-quay-container
 push-quay-container:
-	podman manifest push $(OUT_DOCKER):$(VERSION) quay.io/parca/parca-agent:$(VERSION)
+	podman manifest push --all $(OUT_DOCKER):$(VERSION) docker://quay.io/parca/parca-agent:$(VERSION)
 
 .PHONY: internal/pprof
 internal/pprof:


### PR DESCRIPTION
Should fix
```
Run make push-container
podman manifest push ghcr.io/parca-dev/parca-agent:main-1110c48a
Error: accepts 2 arg(s), received 1
make: *** [Makefile:212: push-container] Error 125
Error: Process completed with exit code 2.
```
https://github.com/parca-dev/parca-agent/runs/5393544962?check_suite_focus=true