### PR TITLE
discovery: Support systems without systemd

### DIFF
--- a/pkg/containerutils/containerutils.go
+++ b/pkg/containerutils/containerutils.go
@@ -114,6 +114,12 @@ func GetCgroupPaths(pid int) (string, string, error) {
 			if err != nil {
 				break
 			}
+			// Fallback in case the system the agent is running on doesn't run systemd
+			if strings.Contains(line, ":perf_event:") {
+				cgroupPathV1 = strings.SplitN(line, ":", 3)[2]
+				cgroupPathV1 = strings.TrimSuffix(cgroupPathV1, "\n")
+				continue
+			}
 			if strings.HasPrefix(line, "1:name=systemd:") {
 				cgroupPathV1 = strings.TrimPrefix(line, "1:name=systemd:")
 				cgroupPathV1 = strings.TrimSuffix(cgroupPathV1, "\n")


### PR DESCRIPTION
Before this commit, we only supported discovering cgroups via systemd by
reading /proc/$PID/cgroup:
```
[...]
1:name=systemd:/kubepods/burstable/pod1fa4240d-10d4-494f-88d2-80a639e26ac5/de86e0bfc1f648084db99ead71c756df43ec7e936342144c61d58961859a564b
[...]
```

On systems running openrc for instance, that line doesn't exist. Instead
we have:
```
1:name=openrc:/docker
```

With this, parca-agent would discover the __cgroup_path__ for the job to
be `/sys/fs/cgroup/perf_event`, leading to parca-agent profiling
everything for every pod.

This commit adds logic to support discovering the cgroup via perf_event.
If the system is running systemd, it'll always fall back to using that
line as it is the second from the last.

Fixes #268