### PR TITLE
debuginfo: Change the order of debuginfo file discovery

### DIFF
--- a/pkg/debuginfo/debuginfo.go
+++ b/pkg/debuginfo/debuginfo.go
@@ -151,6 +151,7 @@ func (di *DebugInfo) exists(ctx context.Context, buildID, filePath string) bool 
 }
 
 func (di *DebugInfo) debugInfoFilePath(ctx context.Context, buildID string, objFile *objectfile.MappedObjectFile) (string, bool) {
+	logger := log.With(di.logger, "buildid", buildID, "path", objFile.Path)
 	type result struct {
 		path          string
 		shouldCleanup bool
@@ -160,27 +161,24 @@ func (di *DebugInfo) debugInfoFilePath(ctx context.Context, buildID string, objF
 		return res.path, res.shouldCleanup
 	}
 
-	dbgInfoPath, err := di.Extract(ctx, buildID, objFile.Path)
+	// First, check whether debuginfos have been installed separately,
+	// typically in /usr/lib/debug, so we try to discover if there is a debuginfo file,
+	// that has the same build ID as the object.
+	dbgInfoPath, err := di.Find(ctx, objFile.BuildID, objFile.Root())
+	if err == nil && dbgInfoPath != "" {
+		level.Debug(logger).Log("msg", "found debug information in /usr/lib/debug")
+		di.debugInfoFileCache.Put(buildID, result{dbgInfoPath, false})
+		return dbgInfoPath, false
+	}
+	level.Debug(logger).Log("msg", "failed to find debug information on the system", "err", err)
+
+	dbgInfoPath, err = di.Extract(ctx, buildID, objFile.Path)
 	if err == nil && dbgInfoPath != "" {
 		di.debugInfoFileCache.Put(buildID, result{dbgInfoPath, true})
 		return dbgInfoPath, true
 	}
-
 	// err != nil || dbgInfoPath == ""
-	level.Debug(di.logger).Log(
-		"msg", "failed to extract debug information",
-		"buildid", buildID, "path", objFile.Path, "err", err,
-	)
+	level.Debug(di.logger).Log("msg", "failed to extract debug information", "err", err)
 
-	// The object does not have debug symbols, but maybe debuginfos
-	// have been installed separately, typically in /usr/lib/debug, so
-	// we try to discover if there is a debuginfo file, that has the
-	// same build ID as the object.
-	dbgInfoPath, err = di.Find(ctx, objFile.BuildID, objFile.Root())
-	if err != nil {
-		level.Warn(di.logger).Log("msg", "failed to find debug info on the system", "err", err)
-	}
-	// Even if finder returns empty string, it doesn't matter extractor already failed.
-	di.debugInfoFileCache.Put(buildID, result{path: dbgInfoPath, shouldCleanup: false})
-	return dbgInfoPath, false
+	return "", false
 }

--- a/pkg/debuginfo/extract.go
+++ b/pkg/debuginfo/extract.go
@@ -95,14 +95,6 @@ func (e *Extractor) Extract(ctx context.Context, buildID, filePath string) (stri
 		return "", fmt.Errorf("failed to create temp dir for debug information extraction: %w", err)
 	}
 
-	hasSymtab, err := hasSymbols(filePath)
-	if err != nil {
-		level.Debug(e.logger).Log(
-			"msg", "failed to determine whether file has symbol sections",
-			"file", filePath, "err", err,
-		)
-	}
-
 	hasDWARF, err := elfutils.HasDWARF(filePath)
 	if err != nil {
 		level.Debug(e.logger).Log(
@@ -114,6 +106,14 @@ func (e *Extractor) Extract(ctx context.Context, buildID, filePath string) (stri
 	isGo, err := elfutils.IsSymbolizableGoObjFile(filePath)
 	if err != nil {
 		level.Debug(e.logger).Log("msg", "failed to determine if binary is a Go binary", "path", filePath, "err", err)
+	}
+
+	hasSymtab, err := hasSymbols(filePath)
+	if err != nil {
+		level.Debug(e.logger).Log(
+			"msg", "failed to determine whether file has symbol sections",
+			"file", filePath, "err", err,
+		)
 	}
 
 	toRemove, err := sectionsToRemove(filePath)


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Previous order:

1) Check the binary itself for debug info
  a) Check symtab + dynsym
  b) Check DWARF 
  c) Check gopclntab
2) Check /usr/lib/debug

New order:

1) Check /usr/lib/debug
2) Check the binary itself for debug info
  a) Check DWARF
  b) Check gopclntab
  c) Check symtab + dynsym

If we already have it locally downloaded, no need to try to process running binary. Besides, we try to extract (c) symtab/dynsym as a last resort, which we don't have a corresponding code in server (yet).
