### PR TITLE
discovery: Sanitize Kubernetes label names

### DIFF
--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -118,7 +118,7 @@ func buildPod(pod *v1.Pod, containers []*k8s.ContainerDefinition) *target.Group 
 
 	// Expose shared labels
 	for k, v := range pod.ObjectMeta.Labels {
-		tg.Labels[model.LabelName(k)] = model.LabelValue(strutil.SanitizeLabelName(v))
+		tg.Labels[model.LabelName(strutil.SanitizeLabelName(k))] = model.LabelValue(v)
 	}
 
 	for _, container := range containers {


### PR DESCRIPTION
Take two ...

Turns out in #318 I incorrectly sanitized the label-values not the label-names. Label values can be anything, they do not have to be sanitized.