### PR TITLE
makefile: do not show errors while removing bpf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ mostlyclean:
 
 .PHONY: clean
 clean:
-	rm $(OUT_BPF)
+	rm -f $(OUT_BPF)
 	-FILE="$(docker_builder_file)" ; \
 	if [ -r "$$FILE" ] ; then \
 		$(CMD_DOCKER) rmi "$$(< $$FILE)" ; \


### PR DESCRIPTION
The `-f` option ignores nonexistent files (https://linux.die.net/man/1/rm)