### PR TITLE
eBPF: Remove the use of deprecated bpf_map_def

### DIFF
--- a/parca-agent.bpf.c
+++ b/parca-agent.bpf.c
@@ -34,24 +34,20 @@
 // Max depth of each stack trace to track
 #define MAX_STACK_DEPTH 127
 
-#define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries)            \
-  struct bpf_map_def SEC("maps") _name = {                                     \
-      .type = _type,                                                           \
-      .key_size = sizeof(_key_type),                                           \
-      .value_size = sizeof(_value_type),                                       \
-      .max_entries = _max_entries,                                             \
-  };
+#define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries)	       \
+  struct {								       \
+      __uint(type, _type);						       \
+      __uint(max_entries, _max_entries);				       \
+      __type(key, _key_type);						       \
+      __type(value, _value_type);					       \
+  } _name SEC(".maps");
 
 // Stack Traces are slightly different
 // in that the value is 1 big byte array
 // of the stack addresses
-#define BPF_STACK_TRACE(_name, _max_entries)                                   \
-  struct bpf_map_def SEC("maps") _name = {                                     \
-      .type = BPF_MAP_TYPE_STACK_TRACE,                                        \
-      .key_size = sizeof(u32),                                                 \
-      .value_size = sizeof(size_t) * MAX_STACK_DEPTH,                          \
-      .max_entries = _max_entries,                                             \
-  };
+typedef __u64 stack_trace_type[MAX_STACK_DEPTH];
+#define BPF_STACK_TRACE(_name, _max_entries)				       \
+  BPF_MAP(_name, BPF_MAP_TYPE_STACK_TRACE, u32, stack_trace_type, _max_entries);
 
 #define BPF_HASH(_name, _key_type, _value_type)                                \
   BPF_MAP(_name, BPF_MAP_TYPE_HASH, _key_type, _value_type, 10240);


### PR DESCRIPTION
`struct bpf_map_def` is deprecated in libbpf. So let's use BTF enabled definitions instead.

Fixes #294 

Signed-off-by: Vaishali Thakkar <me.vaishalithakkar@gmail.com>