### PR TITLE
Add Golang build information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
       - -trimpath
       - -v
     ldflags:
-      - main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`
+      - main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.goArch={{.Runtime.Goarch}}
   - main: ./cmd/debug-info/
     id: "debug-info"
     binary: parca-debug-info
@@ -37,7 +37,7 @@ builds:
       - -trimpath
       - -v
     ldflags:
-      - main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`
+      - main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.Date}} -X main.goArch={{.Runtime.Goarch}}
 archives:
   - replacements:
       linux: Linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
       - -trimpath
       - -v
     ldflags:
-      - main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.goArch={{.Runtime.Goarch}}
+      - main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.Date}} -X main.goArch={{.Runtime.Goarch}}
   - main: ./cmd/debug-info/
     id: "debug-info"
     binary: parca-debug-info

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -60,7 +60,6 @@ var (
 	version string
 	commit  string
 	date    string
-	builtBy string
 	goArch  string
 )
 
@@ -127,7 +126,6 @@ func main() {
 		"version", version,
 		"commit", commit,
 		"date", date,
-		"builtBy", builtBy,
 		"config", fmt.Sprint(flags),
 		"arch", goArch,
 	)

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildinfo
+
+import (
+	"errors"
+	"runtime/debug"
+)
+
+type buildInfo struct {
+	GoArch, GoOs, VcsRevision, VcsTime string
+	VcsModified                        bool
+}
+
+func FetchBuildInfo() (*buildInfo, error) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, errors.New("can't read the build info")
+	}
+
+	buildInfo := buildInfo{}
+
+	for _, setting := range bi.Settings {
+		key := setting.Key
+		value := setting.Value
+
+		switch key {
+		case "GOARCH":
+			buildInfo.GoArch = value
+		case "GOOS":
+			buildInfo.GoOs = value
+		case "vcs.revision":
+			buildInfo.VcsRevision = value
+		case "vcs.time":
+			buildInfo.VcsTime = value
+		case "vcs.modified":
+			buildInfo.VcsModified = value == "true"
+		}
+	}
+
+	return &buildInfo, nil
+}


### PR DESCRIPTION
This commit adds some small wrapper to gather the Go build
information we care about and shows some of these values
during the initialisation of the agent.

Having this information is useful to understand the precise
version that people run.

Now it shows both the commit and the date when it was built
as well as the architecture:
```
$ sudo dist/parca-agent --node=test --systemd-units=docker.service --log-level=debug --kubernetes=false --insecure

ts=2022-04-13T11:38:14.915638561Z caller=main.go:119 msg=starting... node=test store=
level=debug ts=2022-04-13T11:38:14.915780145Z caller=main.go:120 msg="parca-agent initialized" version= commit=d7870a66fa1aa31a9555ba9bb66a6574a5898a17 date=2022-04-13T11:36:50Z builtBy= config="{debug :7071 test map[]    true 10s false 1 false  [docker.service] /tmp  10s  false}" arch=arm64
```

Some possible follow-ups:
- Show this info in `--help`
- Add this information to our BPF code