### PR TITLE
profiler: Use a buffer pool for write profiles

### DIFF
--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -137,6 +137,8 @@ type CgroupProfiler struct {
 
 	target            model.LabelSet
 	profilingDuration time.Duration
+
+	profileBufferPool sync.Pool
 }
 
 func NewCgroupProfiler(
@@ -172,7 +174,13 @@ func NewCgroupProfiler(
 				Help:        "Number of missing profile stacks",
 				ConstLabels: map[string]string{"target": target.String()},
 			},
-			[]string{"type"}),
+			[]string{"type"},
+		),
+		profileBufferPool: sync.Pool{
+			New: func() interface{} {
+				return bytes.NewBuffer(nil)
+			},
+		},
 	}
 }
 
@@ -589,7 +597,11 @@ func (p *CgroupProfiler) normalizeAddress(m *profile.Mapping, pid uint32, addr u
 }
 
 func (p *CgroupProfiler) sendProfile(ctx context.Context, prof *profile.Profile) error {
-	buf := bytes.NewBuffer(nil)
+	buf := p.profileBufferPool.Get().(*bytes.Buffer)
+	defer func() {
+		buf.Reset()
+		p.profileBufferPool.Put(buf)
+	}()
 	if err := prof.Write(buf); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Use a buffer pool for write profiles to reduce redundant allocations

cc @Sylfrena @v-thakkar @javierhonduco 