### PR TITLE
profiler: Increase rlimit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containerd/cgroups v1.0.3
 	github.com/containerd/containerd v1.6.2
 	github.com/docker/docker v20.10.14+incompatible
+	github.com/dustin/go-humanize v1.0.0
 	github.com/go-kit/log v0.2.0
 	github.com/goburrow/cache v0.1.4
 	github.com/google/pprof v0.0.0-20220218203455-0368bd9e19a7
@@ -72,7 +73,6 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/go-delve/delve v1.8.2 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -645,12 +645,12 @@ func (p *CgroupProfiler) bumpMemlockRlimit() error {
 	}
 
 	// RLIMIT_MEMLOCK is 0x8.
-	if err := syscall.Setrlimit(0x8, &rLimit); err != nil {
+	if err := syscall.Setrlimit(unix.RLIMIT_MEMLOCK, &rLimit); err != nil {
 		return fmt.Errorf("failed to increase rlimit: %w", err)
 	}
 
 	rLimit = syscall.Rlimit{}
-	if err := syscall.Getrlimit(0x8, &rLimit); err != nil {
+	if err := syscall.Getrlimit(unix.RLIMIT_MEMLOCK, &rLimit); err != nil {
 		return fmt.Errorf("failed to get rlimit: %w", err)
 	}
 	level.Debug(p.logger).Log("msg", "increased max memory locked rlimit", "limit", humanize.Bytes(rLimit.Cur))

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -33,6 +33,7 @@ import (
 	"C" //nolint:typecheck
 
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/pprof/profile"
@@ -58,6 +59,8 @@ var bpfObj []byte
 const (
 	stackDepth       = 127 // Always needs to be sync with MAX_STACK_DEPTH in parca-agent.bpf.c
 	doubleStackDepth = 254
+
+	defaultRlimit = 1024 << 20 // ~1GB
 )
 
 type bpfMaps struct {
@@ -238,6 +241,11 @@ func (p *CgroupProfiler) Run(ctx context.Context) error {
 		return fmt.Errorf("new bpf module: %w", err)
 	}
 	defer m.Close()
+
+	// Always need to be used after bpf.NewModuleFromBufferArgs to avoid limit override.
+	if err := p.bumpMemlockRlimit(); err != nil {
+		return fmt.Errorf("bump memlock rlimit: %w", err)
+	}
 
 	if err := m.BPFLoadObject(); err != nil {
 		return fmt.Errorf("load bpf object: %w", err)
@@ -627,4 +635,25 @@ func (p *CgroupProfiler) sendProfile(ctx context.Context, prof *profile.Profile)
 	})
 
 	return err
+}
+
+// bumpMemlockRlimit increases the current memlock limit to a value more reasonable for the profiler's needs.
+func (p *CgroupProfiler) bumpMemlockRlimit() error {
+	rLimit := syscall.Rlimit{
+		Cur: uint64(defaultRlimit),
+		Max: uint64(defaultRlimit),
+	}
+
+	// RLIMIT_MEMLOCK is 0x8.
+	if err := syscall.Setrlimit(0x8, &rLimit); err != nil {
+		return fmt.Errorf("failed to increase rlimit: %w", err)
+	}
+
+	rLimit = syscall.Rlimit{}
+	if err := syscall.Getrlimit(0x8, &rLimit); err != nil {
+		return fmt.Errorf("failed to get rlimit: %w", err)
+	}
+	level.Debug(p.logger).Log("msg", "increased max memory locked rlimit", "limit", humanize.Bytes(rLimit.Cur))
+
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Until we have the following feature lands in the libbpf, we need a way to increase rlimit. libbpf-go sets it to 512MB when the module loaded, however I always hits this limit whenever I change something regarding BPF maps so, I'm introducing a way to increase it and also by default this Pr increases that limit to 1024MB.

Check out rlimits if you ever encounter `operation not permitted` error.

cc @javierhonduco @v-thakkar @Sylfrena 