### PR TITLE
bpf: Add some basic metadata

### DIFF
--- a/parca-agent.bpf.c
+++ b/parca-agent.bpf.c
@@ -23,6 +23,9 @@
 #include <bpf_helpers.h>
 #include <bpf_tracing.h>
 
+volatile const char bpf_metadata_name[] SEC(".rodata") =
+    "parca-agent (https://github.com/parca-dev/parca-agent)";
+
 #if defined(bpf_target_x86)
 #define PT_REGS_PARM6(ctx) ((ctx)->r9)
 #elif defined(bpf_target_arm64)


### PR DESCRIPTION
The BPF metadata feature [see commit](https://github.com/torvalds/linux/commit/ffa915f46193b6be780483c8d31cc53f093f6d9a) allows
to define variables that start with the `bpf_metadata_` prefix that can be read with
several tools, including `bpftool`:

```
$ sudo bpftool prog | grep perf -A20
1832: perf_event  name do_sample  tag 6ce6efa2110df18f  gpl
	loaded_at 2022-04-13T08:15:16-0700  uid 0
	xlated 416B  jited 432B  memlock 4096B  map_ids 3489,3490,3492
	btf_id 1409
	pids parca_agent_by_(470302)
	metadata:
		name = "parca-agent (https://github.com/parca-dev/parca-agent)"
		version = "v0.7.0"
```

By exposing a name for our BPF program, as well as the version[1], we can quickly find out
which exact program and version of the BPF code we are running.

Under the hood, they are backed by an BPF array:

```
$ sudo bpftool map dump id 3492
[{
        "value": {
            ".rodata": [{
                    "bpf_metadata_name": "parca-agent (https://github.com/parca-dev/parca-agent)"
                },{
                    "bpf_metadata_version": "v0.7.0"
                }
            ]
        }
    }
]
```

[1]: Right now we are just replicating the git tag which we will have to manually update.
Once `.rodata` support [lands in libbpfgo](https://github.com/aquasecurity/libbpfgo/issues/27) we will
be able to replace it with the actual Git revision!