### PR TITLE
profiler: Keep track of stack unwinding failures

### DIFF
--- a/parca-agent.bpf.c
+++ b/parca-agent.bpf.c
@@ -98,16 +98,18 @@ int do_sample(struct bpf_perf_event_data *ctx) {
     return 0;
 
   // create map key
-  stack_count_key_t key = {.pid = tgid};
+  stack_count_key_t key = {
+      .pid = tgid,
+      .user_stack_id = 0,
+      .kernel_stack_id = 0,
+  };
 
   // get user stack id
-  key.user_stack_id = 0;
   int stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
   if (stack_id >= 0)
     key.user_stack_id = stack_id;
 
   // get kernel stack id
-  key.kernel_stack_id = 0;
   int kernel_stack_id = bpf_get_stackid(ctx, &stack_traces, 0);
   if (kernel_stack_id >= 0)
     key.kernel_stack_id = kernel_stack_id;

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -425,12 +425,12 @@ func (p *CgroupProfiler) profileLoop(ctx context.Context, captureTime time.Time)
 		// Twice the stack depth because we have a user and a potential Kernel stack.
 		// Read order matters, since we read from the key buffer.
 		stack := [doubleStackDepth]uint64{}
-		userErr := p.readUserStack(r, stack)
+		userErr := p.readUserStack(r, &stack)
 		if userErr != nil {
 			// TODO(kakkoyun): Handle unrecoverable errors, such as buffer read errors.
 			level.Debug(p.logger).Log("msg", "failed to read user stack", "err", userErr)
 		}
-		kernelErr := p.readKernelStack(r, stack)
+		kernelErr := p.readKernelStack(r, &stack)
 		if kernelErr != nil {
 			// TODO(kakkoyun): Handle unrecoverable errors, such as buffer read errors.
 			level.Debug(p.logger).Log("msg", "failed to read kernel stack", "err", kernelErr)
@@ -612,7 +612,7 @@ func (p *CgroupProfiler) profileLoop(ctx context.Context, captureTime time.Time)
 	return nil
 }
 
-func (p *CgroupProfiler) readUserStack(r *bytes.Buffer, stack [254]uint64) error {
+func (p *CgroupProfiler) readUserStack(r *bytes.Buffer, stack *[254]uint64) error {
 	userStackIDBytes := make([]byte, 4)
 	if _, err := io.ReadFull(r, userStackIDBytes); err != nil {
 		return fmt.Errorf("read user stack ID bytes: %w", err)
@@ -637,7 +637,7 @@ func (p *CgroupProfiler) readUserStack(r *bytes.Buffer, stack [254]uint64) error
 	return nil
 }
 
-func (p *CgroupProfiler) readKernelStack(r *bytes.Buffer, stack [254]uint64) error {
+func (p *CgroupProfiler) readKernelStack(r *bytes.Buffer, stack *[254]uint64) error {
 	kernelStackIDBytes := make([]byte, 4)
 	if _, err := io.ReadFull(r, kernelStackIDBytes); err != nil {
 		return fmt.Errorf("read kernel stack ID bytes: %w", err)

--- a/scripts/local-run.sh
+++ b/scripts/local-run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+################################################################################
+#
+# This script is meant to be run from the root of this project with the Makefile
+#
+################################################################################
+
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+PARCA=${PARCA:-../parca/bin/parca}
+PARCA_AGENT=${PARCA_AGENT:-./dist/parca-agent}
+DEBUG=${DEBUG:-false}
+
+trap 'kill $(jobs -p); exit 0' EXIT
+
+(
+    $PARCA --config-path="../parca/parca.yaml"
+) &
+
+(
+    if [ "$DEBUG" = true ]; then
+        dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec --continue -- \
+            $PARCA_AGENT \
+            --node=systemd-test \
+            --systemd-units=docker.service \
+            --log-level=debug \
+            --kubernetes=false \
+            --store-address=localhost:7070 \
+            --insecure
+    else
+        sudo $PARCA_AGENT \
+            --node=systemd-test \
+            --systemd-units=docker.service \
+            --log-level=debug \
+            --kubernetes=false \
+            --store-address=localhost:7070 \
+            --insecure
+    fi
+)


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

As a pre-work to #346, add metrics to keep track of stack unwinding failures.

cc @v-thakkar 