### PR TITLE
Makefile: remove unused `GOPKGS` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,6 @@ LIBBPF_OBJ := $(OUT_DIR)/libbpf/libbpf.a
 OUT_DOCKER ?= ghcr.io/parca-dev/parca-agent
 DOCKER_BUILDER ?= parca-agent-builder
 
-GOPKGS := $(shell go list ./... | grep -v "internal/pprof")
-
 # DOCKER_BUILDER_KERN_SRC(/BLD) is where the docker builder looks for kernel headers
 DOCKER_BUILDER_KERN_BLD ?= $(if $(shell readlink $(KERN_BLD_PATH)),$(shell readlink $(KERN_BLD_PATH)),$(KERN_BLD_PATH))
 DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink $(KERN_SRC_PATH)),$(shell readlink $(KERN_SRC_PATH)),$(KERN_SRC_PATH))


### PR DESCRIPTION
Spotted this as running `make` is very slow on my network-attached
disk and found that it's due to `go list ./...` taking a couple of
seconds in the worst in case in my machine.

I really need to optimise my setup, but let's remove this variable
as it's unused anyways :D

```
$ time make aaaa
make: *** No rule to make target 'aaaa'.  Stop.

real	0m1.394s
user	0m0.521s
sys	0m0.517s

```

```
$ time make aaaa
make: *** No rule to make target 'aaaa'.  Stop.

real	0m0.304s
user	0m0.031s
sys	0m0.050s
```