### PR TITLE
Add e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,3 +258,8 @@ dev/up: deploy/manifests
 .PHONY: dev/down
 dev/down:
 	source ./scripts/local-dev.sh && down
+
+.PHONY: test-e2e $(driver)
+test-e2e:
+	cd deploy; source ./../e2e/local-e2e.sh && run $(driver)
+	go test -v $(shell go list ./e2e | grep "e2e")

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test/profiler: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf test/profiler
-	$(go_env) go test -run '[^TestIntegrationGRPC]' -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler")
+	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler")
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)
@@ -262,4 +262,4 @@ dev/down:
 .PHONY: test-e2e $(driver)
 test-e2e:
 	cd deploy; source ./../e2e/local-e2e.sh && run $(driver)
-	go test -v $(shell go list ./e2e | grep "e2e")
+	go test -tags=integration -v $(shell go list -tags=integration ./e2e)

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test/profiler: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf test/profiler
-	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler")
+	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler" | grep -v "e2e")
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)
@@ -262,4 +262,4 @@ dev/down:
 .PHONY: test-e2e $(driver)
 test-e2e:
 	cd deploy; source ./../e2e/local-e2e.sh && run $(driver)
-	go test -tags=integration -v $(shell go list -tags=integration ./e2e)
+	go test -v $(shell go list ./e2e)

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test/profiler: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf test/profiler
-	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler")
+	$(go_env) go test -run '[^TestIntegrationGRPC]' -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler")
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)

--- a/deploy/e2e.jsonnet
+++ b/deploy/e2e.jsonnet
@@ -1,0 +1,42 @@
+function(version='v0.0.1-alpha.3')
+  local ns = {
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: {
+      name: 'parca',
+      labels: {
+        'pod-security.kubernetes.io/enforce': 'privileged',
+        'pod-security.kubernetes.io/audit': 'privileged',
+        'pod-security.kubernetes.io/warn': 'privileged',
+      },
+    },
+  };
+
+  local agent = (import 'parca-agent/parca-agent.libsonnet')({
+    name: 'parca-agent',
+    namespace: ns.metadata.name,
+    version: version,
+    image: 'localhost:5000/parca-agent:' + version,
+    // This assumes there's a running parca in the cluster.
+    stores: ['parca.parca.svc.cluster.local:7070'],
+    insecure: true,
+    insecureSkipVerify: true,
+    //   token: "<token>",
+    //   stores: [
+    //     'grpc.polarsignals.com:443',
+    //   ],
+    tempDir: '/tmp',
+    // Available Options:
+    //   samplingRatio: 0.5,
+    //   Docs for usage of Label Selector
+    //   https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+    //   podLabelSelector: 'app=my-web-app,version=v1',
+  });
+
+  {
+    '0namespace': ns,
+  } + {
+    ['parca-agent-' + name]: agent[name]
+    for name in std.objectFields(agent)
+    if agent[name] != null
+  }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-// +build integration
-
 package e2e
 
 import (

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 // Copyright 2022 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +10,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build integration
+// +build integration
+
 package e2e
 
 import (

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 // Copyright 2022 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
+)
+
+func TestGRPC(t *testing.T) {
+	conn, err := grpc.Dial("127.0.0.1:7070", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	c := pb.NewQueryServiceClient(conn)
+	ctx := context.Background()
+
+	queryRequest := &pb.QueryRangeRequest{
+		Query: `parca_agent_cpu:samples:count:cpu:nanoseconds:delta{container="parca-agent"}`,
+		Start: timestamppb.New(timestamp.Time(0)),
+		End:   timestamppb.New(timestamp.Time(9223372036854775807)),
+		Limit: 10,
+	}
+
+	resp, err := c.QueryRange(ctx, queryRequest)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Series)
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -25,7 +25,7 @@ import (
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
 )
 
-func TestGRPC(t *testing.T) {
+func TestIntegrationGRPC(t *testing.T) {
 	conn, err := grpc.Dial("127.0.0.1:7070", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()

--- a/e2e/local-e2e.sh
+++ b/e2e/local-e2e.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+################################################################################
+#
+# This script is meant to be run from the root of this project
+#
+################################################################################
+
+set -euo pipefail
+
+function run() {
+  # Driver set to docker by default if not specified
+  DRIVER=${1-docker}
+
+  minikube_up $DRIVER
+  generate_manifests
+  deploy
+}
+
+# Create local minikube cluster and deploys the dev env for parca and parca agent
+function minikube_up(){
+  # can be virtualbox, vmwarefusion, kvm2, vmware, none, docker, podman, ssh
+  DRIVER=$1
+
+  echo "Spinning up a parca dev cluster"
+  minikube start -p parca-e2e \
+    --container-runtime=docker \
+    --insecure-registry="localhost:5000"\
+    --driver=$DRIVER \
+    --kubernetes-version=v1.22.3 \
+    --cpus=4 \
+    --memory=16gb \
+    --disk-size=20gb \
+    --docker-opt dns=8.8.8.8 \
+    --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
+
+  eval $(minikube -p parca-e2e docker-env)
+}
+
+# Delete minikube instance
+function minikube_down(){
+  echo "Deleting parca-e2e cluster"
+  minikube delete -p parca-e2e
+}
+
+# Configure clusters to run latest commit in Parca agent
+function deploy() {
+  SERVER_LATEST_VERSION=$(curl -s https://api.github.com/repos/parca-dev/parca/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")' | xargs echo -n)
+  echo "Server version: $SERVER_LATEST_VERSION"
+
+  if ! check_ns_parca; then
+    kubectl create namespace parca
+  fi
+
+  kubectl apply -f https://github.com/parca-dev/parca/releases/download/"$SERVER_LATEST_VERSION"/kubernetes-manifest.yaml
+  kubectl -n parca rollout status deployment/parca --timeout=2m
+
+  kubectl apply -f ./manifests/local/manifest-e2e.yaml
+  kubectl -n parca rollout status daemonset/parca-agent --timeout=2m
+
+  echo "Connecting to Parca and Parca agent"
+
+  kubectl port-forward -n parca service/parca 7070 &
+  kubectl port-forward -n parca $(kubectl get po -n parca | grep parca-agent | awk '{print $1;}') 7071:7071 &
+}
+
+function vendor() {
+  jb install
+}
+
+function check_ns_parca() {
+ ns_status=$(kubectl get ns parca)
+ if [ $? -ne 0 ]; then
+   return 1
+ fi
+ echo "namespace parca already present"
+}
+
+# Build image with latest commit
+function generate_manifests() {
+  if [ -z ${GITHUB_BRANCH_NAME+x} ]; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)-
+  else
+    BRANCH=$(GITHUB_BRANCH_NAME)
+  fi
+
+  if [ -z ${GITHUB_SHA+x} ]; then
+    COMMIT=$(git describe --no-match --dirty --always --abbrev=8)
+  else
+    COMMIT=$(echo $(GITHUB_SHA) | cut -c1-8)
+  fi
+
+  if [ -z ${RELEASE_TAG+x} ]; then
+    VERSION=$(git describe --tags 2>/dev/null || echo '$(BRANCH)$(COMMIT)')
+  else
+    VERSION=$RELEASE_TAG
+  fi
+
+  rm -rf manifests/local
+  mkdir -p manifests/local
+
+  jsonnet --tla-str version="$VERSION" -J vendor e2e.jsonnet -m manifests/local | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}'
+  awk 'BEGINFILE {print "---"}{print}' manifests/local/* > manifests/local/manifest-e2e.yaml
+
+  # docker.io/golang:1.18.1-bullseye
+  GOLANG_BASE='docker.io/golang@sha256:ee752bc53c628ff789bacefb714cff721701042ffa9eb736f7b2ed4e9f2bdab6'
+
+  # docker.io/debian:bullseye-slim
+  DEBIAN_BASE='docker.io/debian@sha256:fa4209bc498f3cf557c7d448f295d300aed44e7fd296fdd480a8ff5785cca305'
+
+  docker build -t localhost:5000/parca-agent:"$VERSION" \
+     --build-arg GOLANG_BASE="$GOLANG_BASE" \
+     --build-arg DEBIAN_BASE="$DEBIAN_BASE" ./..
+}

--- a/e2e/local-e2e.sh
+++ b/e2e/local-e2e.sh
@@ -9,8 +9,8 @@
 set -euo pipefail
 
 function run() {
-  # Driver set to docker by default if not specified
-  DRIVER=${1-docker}
+  # Driver set to virtualbox by default if not specified
+  DRIVER=${1-virtualbox}
 
   minikube_up $DRIVER
   generate_manifests
@@ -102,13 +102,12 @@ function generate_manifests() {
   jsonnet --tla-str version="$VERSION" -J vendor e2e.jsonnet -m manifests/local | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}'
   awk 'BEGINFILE {print "---"}{print}' manifests/local/* > manifests/local/manifest-e2e.yaml
 
-  # docker.io/golang:1.18.1-bullseye
-  GOLANG_BASE='docker.io/golang@sha256:ee752bc53c628ff789bacefb714cff721701042ffa9eb736f7b2ed4e9f2bdab6'
-
-  # docker.io/debian:bullseye-slim
-  DEBIAN_BASE='docker.io/debian@sha256:fa4209bc498f3cf557c7d448f295d300aed44e7fd296fdd480a8ff5785cca305'
+  GOLANG_BASE=golang:1.18.3-bullseye
+  DEBIAN_BASE=debian:bullseye-slim
+  LINUX_ARCH=$(uname -p)
 
   docker build -t localhost:5000/parca-agent:"$VERSION" \
      --build-arg GOLANG_BASE="$GOLANG_BASE" \
-     --build-arg DEBIAN_BASE="$DEBIAN_BASE" ./..
+     --build-arg DEBIAN_BASE="$DEBIAN_BASE"  \
+     --build-arg LINUX_ARCH=$LINUX_ARCH  ./..
 }

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	google.golang.org/grpc v1.47.0
+	google.golang.org/protobuf v1.28.0
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1
@@ -146,7 +147,6 @@ require (
 	google.golang.org/api v0.70.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220317150908-0efb43f6373e // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect


### PR DESCRIPTION
Very early version, so excuse the lazy shell scripting, plus need to add a lot more test cases. 

Use `make dev/e2e`  from root of the repo to run the tests.

Fixes #317

cc @v-thakkar @javierhonduco 