### PR TITLE
profiler: Fix index out of range

### DIFF
--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -765,10 +765,10 @@ func (p *CgroupProfiler) writeProfile(ctx context.Context, prof *profile.Profile
 		i              = 0
 	)
 	for key, value := range p.Labels() {
-		labelOldFormat[i] = &profilestorepb.Label{
+		labelOldFormat = append(labelOldFormat, &profilestorepb.Label{
 			Name:  string(key),
 			Value: string(value),
-		}
+		})
 		i++
 	}
 


### PR DESCRIPTION
```
panic: runtime error: index out of range [0] with length 0

goroutine 82 [running]:
github.com/parca-dev/parca-agent/pkg/profiler.(*CgroupProfiler).writeProfile(0x2040000bb8c0, {0x2790780, 0x204000846120}, 0x3f3d360?)
	github.com/parca-dev/parca-agent/pkg/profiler/profiler.go:772 +0xa24
github.com/parca-dev/parca-agent/pkg/profiler.(*CgroupProfiler).profileLoop(0x2040000bb8c0, {0x2790780, 0x204000846120}, {0x0?, 0x23f4010?, 0x3f0bb80?})
	github.com/parca-dev/parca-agent/pkg/profiler/profiler.go:521 +0xe44
github.com/parca-dev/parca-agent/pkg/profiler.(*CgroupProfiler).Run(0x2040000bb8c0, {0x2790780, 0x20400080fe00})
	github.com/parca-dev/parca-agent/pkg/profiler/profiler.go:377 +0xe40
github.com/parca-dev/parca-agent/pkg/target.(*ProfilerPool).Sync.func1()
	github.com/parca-dev/parca-agent/pkg/target/profiler_pool.go:155 +0x40
created by github.com/parca-dev/parca-agent/pkg/target.(*ProfilerPool).Sync
	github.com/parca-dev/parca-agent/pkg/target/profiler_pool.go:154 +0x43c
```

cc @kakkoyun @Sylfrena 