### PR TITLE
debuginfo: remove `.debuginfo.stripped` binaries

### DIFF
--- a/pkg/debuginfo/extract.go
+++ b/pkg/debuginfo/extract.go
@@ -116,6 +116,8 @@ func (e *Extractor) Extract(ctx context.Context, buildID, filePath string) (stri
 	}
 
 	outFile := path.Join(e.tmpDir, fmt.Sprintf("%s.debuginfo", buildID))
+	strippedFile := fmt.Sprintf("%s.stripped", outFile)
+
 	var cmd *exec.Cmd
 	switch {
 	case hasDWARF:
@@ -124,7 +126,7 @@ func (e *Extractor) Extract(ctx context.Context, buildID, filePath string) (stri
 			if err := os.Remove(file); err != nil {
 				level.Warn(e.logger).Log("msg", "failed to remove temporary file", "file", file, "err", err)
 			}
-		}(fmt.Sprintf("%s.stripped", buildID))
+		}(strippedFile)
 	case isGo:
 		cmd = e.objcopy(ctx, filePath, outFile, toRemove)
 	case hasSymtab:


### PR DESCRIPTION
We are not removing the `debuginfo.stripped` object file:

```
level=debug ts=2022-04-25T15:28:01.4489913Z caller=extract.go:152 component=debuginfo component=extractor msg="running external binary utility command" cmd="eu-strip --strip-debug -f /tmp/9479b311aa7cd2529685da47d4f6e855734db786.debuginfo -o /tmp/9479b311aa7cd2529685da47d4f6e855734db786.debuginfo.stripped /proc/1037819/root/app/parca-demo"
level=warn ts=2022-04-25T15:28:01.45394735Z caller=extract.go:125 component=debuginfo component=extractor msg="failed to remove temporary file" file=9479b311aa7cd2529685da47d4f6e855734db786.stripped err="remove 9479b311aa7cd2529685da47d4f6e855734db786.stripped: no such file or directory"
```

```shell
$ ls /tmp/9479b311aa7cd2529685da47d4f6e855734db786.debuginfo*
/tmp/9479b311aa7cd2529685da47d4f6e855734db786.debuginfo.stripped
```

With this PR:

```
level=debug ts=2022-04-25T15:56:18.711126963Z caller=extract.go:184 component=debuginfo component=extractor msg="using eu-strip" file=/proc/1037819/root/app/parca-demo
level=debug ts=2022-04-25T15:56:18.711390052Z caller=extract.go:154 component=debuginfo component=extractor msg="running external binary utility command" cmd="eu-strip --strip-debug -f /tmp/9479b311aa7cd2529685da47d4f6e855734db786.debuginfo -o /tmp/9479b311aa7cd2529685da47d4f6e855734db786.debuginfo.stripped /proc/1037819/root/app/parca-demo"
level=debug ts=2022-04-25T15:56:18.759918997Z caller=debuginfo.go:95 component=debuginfo buildid=9479b311aa7cd2529685da47d4f6e855734db786 path=/proc/1037819/root/app/parca-demo msg="debug information has already been uploaded or exists in server"
```

```shell
$ ls /tmp/
$
```

Fixes #339 