### PR TITLE
.gitattributes: Mark some files as gen / 3rd party

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+3rdparty/ linguist-vendored	
+vmlinux.h linguist-generated
+internal/pprof/ linguist-vendored
+internal/go/ linguist-vendored


### PR DESCRIPTION
So linguist doesn't tally them https://github.com/github/linguist/blob/master/docs/overrides.md

cc/ @kakkoyun 