### PR TITLE
Bump libbpfgo + add regression tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,13 @@ $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@)
 endif
 
+test/profiler: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
+	sudo $(go_env) go test -v $(shell go list ./... | grep "pkg/profiler") $(SANITIZER)
+
 .PHONY: test
 ifndef DOCKER
-test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
-	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof")
+test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf test/profiler
+	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler")
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/alecthomas/kong v0.5.0
-	github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0
+	github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0.0.20220503131840-80f44303d40f
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/containerd/cgroups v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/apache/arrow/go/arrow v0.0.0-20200601151325-b2287a20f230/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/arrow/go/arrow v0.0.0-20200923215132-ac86123a3f01/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
-github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0 h1:BpW7qxkveYXx8TCtvYWIvmliPqaTCz/IYs1i+Gyj0MQ=
-github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0.0.20220503131840-80f44303d40f h1:bxSHMCb6xtrSUoCZtS0Lw9J4zPuN32NVg7aVlKKp+k0=
+github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0.0.20220503131840-80f44303d40f/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/profiler/profiler_test.go
+++ b/pkg/profiler/profiler_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package profiler
+
+import (
+	"syscall"
+	"testing"
+	"unsafe"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The intent of these tests is to ensure that the BPF library we use,
+// (libbpfgo in this case) behaves in the way we expect.
+
+func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
+	t.Helper()
+
+	m, err := bpf.NewModuleFromBufferArgs(bpf.NewModuleArgs{
+		BPFObjBuff: bpfObj,
+		BPFObjName: "parca",
+	})
+	require.NoError(t, err)
+
+	err = m.BPFLoadObject()
+	require.NoError(t, err)
+
+	return m, nil
+}
+
+func TestDeleteNonExistentKeyReturnsEnoent(t *testing.T) {
+	m, err := SetUpBpfProgram(t)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+	bpfMap, err := m.GetMap("counts")
+	require.NoError(t, err)
+
+	stackID := int32(1234)
+
+	// Delete should fail as the key doesn't exist.
+	err = bpfMap.DeleteKey(unsafe.Pointer(&stackID))
+	require.Error(t, err)
+	require.ErrorIs(t, err, syscall.ENOENT)
+}
+
+func TestDeleteExistentKey(t *testing.T) {
+	m, err := SetUpBpfProgram(t)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+	bpfMap, err := m.GetMap("counts")
+	require.NoError(t, err)
+
+	stackID := int32(1234)
+
+	// Insert some element that will be later deleted.
+	value := []byte{'a'}
+	err = bpfMap.Update(unsafe.Pointer(&stackID), unsafe.Pointer(&value[0]))
+	require.NoError(t, err)
+
+	// Delete should work.
+	err = bpfMap.DeleteKey(unsafe.Pointer(&stackID))
+	require.NoError(t, err)
+}
+
+func TestGetValueAndDeleteBatchWithEmptyMap(t *testing.T) {
+	m, err := SetUpBpfProgram(t)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+	bpfMap, err := m.GetMap("counts")
+	require.NoError(t, err)
+
+	keys := make([]stackCountKey, bpfMap.GetMaxEntries())
+	countKeysPtr := unsafe.Pointer(&keys[0])
+	nextCountKey := uintptr(1)
+	batchSize := bpfMap.GetMaxEntries()
+	values, err := bpfMap.GetValueAndDeleteBatch(countKeysPtr, nil, unsafe.Pointer(&nextCountKey), batchSize)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(values))
+}
+
+func TestGetValueAndDeleteBatchFewerElementsThanCount(t *testing.T) {
+	m, err := SetUpBpfProgram(t)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+	bpfMap, err := m.GetMap("counts")
+	require.NoError(t, err)
+
+	stackID := int32(1234)
+
+	// Insert some element that will be later deleted.
+	value := []byte{'a'}
+	err = bpfMap.Update(unsafe.Pointer(&stackID), unsafe.Pointer(&value[0]))
+	require.NoError(t, err)
+
+	// Request more elements than we have, this should return and delete everything.
+	keys := make([]stackCountKey, bpfMap.GetMaxEntries())
+	countKeysPtr := unsafe.Pointer(&keys[0])
+	nextCountKey := uintptr(1)
+	batchSize := bpfMap.GetMaxEntries()
+	values, err := bpfMap.GetValueAndDeleteBatch(countKeysPtr, nil, unsafe.Pointer(&nextCountKey), batchSize)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(values))
+}
+
+func TestGetValueAndDeleteBatchExactElements(t *testing.T) {
+	m, err := SetUpBpfProgram(t)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+	bpfMap, err := m.GetMap("counts")
+	require.NoError(t, err)
+
+	stackID := int32(1234)
+
+	// Insert some element that will be later deleted.
+	value := []byte{'a'}
+	err = bpfMap.Update(unsafe.Pointer(&stackID), unsafe.Pointer(&value[0]))
+	require.NoError(t, err)
+
+	// Request exactly the elements we have.
+	keys := make([]stackCountKey, 1)
+	countKeysPtr := unsafe.Pointer(&keys[0])
+	nextCountKey := uintptr(1)
+	batchSize := uint32(1)
+	values, err := bpfMap.GetValueAndDeleteBatch(countKeysPtr, nil, unsafe.Pointer(&nextCountKey), batchSize)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(values))
+}


### PR DESCRIPTION
### Bump libbpfgo:

Ran:
```
$ go get github.com/aquasecurity/libbpfgo@80f44303d40f3e65702de30d4976ada883e79fe2
```

Changes from the version we have until this pinned revision: https://github.com/aquasecurity/libbpfgo/compare/v0.2.5-libbpf-0.7.0...80f44303d40f3e65702de30d4976ada883e79fe2.

This fixes a number of issues that were affecting us, including:
- Batch APIs not collecting partial results https://github.com/aquasecurity/libbpfgo/commit/64458ba5a32013dda2d4f88838dde8456922333d fixed by @kakkoyun 
- Deletion APIs not checking for errors properly, both batch and single key (https://github.com/aquasecurity/libbpfgo/pull/160, tracked in https://github.com/aquasecurity/libbpfgo/issues/159). In the case of batched APIs it resulted in them not working properly rather than returning partial results
- Expose strict mode libbpf APIs to ease migrations https://github.com/aquasecurity/libbpfgo/pull/160

### Add libbpfgo map tests:
To ensure that the libbpfgo invariants hold true. Adding these tests
will also help us with library upgrades, as well as configuration
changes in the way libbpf deals with errors, etc.

**Test plan**:
```
$ make test_profiler
sudo -E GOOS=linux GOARCH=arm64 CC=clang CGO_CFLAGS="-I /home/vagrant/work/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/vagrant/work/parca-agent/dist/libbpf/libbpf.a" go test -v github.com/parca-dev/parca-agent/pkg/profiler
=== RUN   TestDeleteNonExistentKeyReturnsEnoent
--- PASS: TestDeleteNonExistentKeyReturnsEnoent (0.00s)
=== RUN   TestDeleteExistentKey
--- PASS: TestDeleteExistentKey (0.00s)
=== RUN   TestGetValueAndDeleteBatchWithEmptyMap
--- PASS: TestGetValueAndDeleteBatchWithEmptyMap (0.00s)
=== RUN   TestGetValueAndDeleteBatchFewerElementsThanCount
--- PASS: TestGetValueAndDeleteBatchFewerElementsThanCount (0.00s)
=== RUN   TestGetValueAndDeleteBatchExactElements
--- PASS: TestGetValueAndDeleteBatchExactElements (0.00s)
PASS
ok      github.com/parca-dev/parca-agent/pkg/profiler   (cached)
```

With ASAN:
```
$ make test_profiler ENABLE_ASAN=yes
sudo -E GOOS=linux GOARCH=arm64 CC=clang CGO_CFLAGS="-I /home/vagrant/work/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/vagrant/work/parca-agent/dist/libbpf/libbpf.a" go test -v github.com/parca-dev/parca-agent/pkg/profiler -asan
=== RUN   TestDeleteNonExistentKeyReturnsEnoent
--- PASS: TestDeleteNonExistentKeyReturnsEnoent (0.00s)
=== RUN   TestDeleteExistentKey
--- PASS: TestDeleteExistentKey (0.00s)
=== RUN   TestGetValueAndDeleteBatchWithEmptyMap
--- PASS: TestGetValueAndDeleteBatchWithEmptyMap (0.00s)
=== RUN   TestGetValueAndDeleteBatchFewerElementsThanCount
--- PASS: TestGetValueAndDeleteBatchFewerElementsThanCount (0.00s)
=== RUN   TestGetValueAndDeleteBatchExactElements
--- PASS: TestGetValueAndDeleteBatchExactElements (0.00s)
PASS
ok      github.com/parca-dev/parca-agent/pkg/profiler   0.047s
```


