### PR TITLE
ksym: Move prometheus cache stats to the ksym package

### DIFF
--- a/pkg/ksym/ksym_test.go
+++ b/pkg/ksym/ksym_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/parca-dev/parca-agent/pkg/testutil"
@@ -57,7 +58,10 @@ ffffffff8f6d1780 b xfrm_napi_dev
 		}),
 		fastCache:      make(map[uint64]string),
 		updateDuration: time.Minute * 5,
-		mtx:            &sync.RWMutex{},
+		metrics: newMetrics(
+			prometheus.NewRegistry(),
+		),
+		mtx: &sync.RWMutex{},
 	}
 
 	addr1 := uint64(0xffffffff8f6d14a4) + 1

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -60,7 +60,7 @@ func NewManager(
 		logger:            logger,
 		reg:               reg,
 		externalLabels:    externalLabels,
-		ksymCache:         ksym.NewKsymCache(logger),
+		ksymCache:         ksym.NewKsymCache(logger, reg),
 		writeClient:       writeClient,
 		debugInfoClient:   debugInfoClient,
 		profilingDuration: profilingDuration,


### PR DESCRIPTION
Addressing feedback from https://github.com/parca-dev/parca-agent/pull/387

**Test plan**
```
parca_agent_profiler_kernel_symbolizer_cache_total{type="hits"} 639
parca_agent_profiler_kernel_symbolizer_cache_total{type="misses"} 580
```