### PR TITLE
cmd/parca-agent: SystemD => Cgroup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ $ cd parca-agent
 
 $ make
 
-$ sudo dist/parca-agent --node=test --systemd-units=docker.service --log-level=debug --kubernetes=false --insecure
+$ sudo dist/parca-agent --node=test --cgroups=docker.service --log-level=debug --kubernetes=false --insecure
 ```
 
 The generated profiles can be seen at http://localhost:7071 .

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The collected data can be viewed locally via HTTP endpoints and then be configur
 It discovers targets through:
 
 * **Kubernetes**: Discovering all the containers on the node the Parca agent is running on. (On by default, but can be disabled using `--kubernetes=false`)
-* **systemd**: A list of systemd units to be profiled on a node can be configured for the Parca agent to pick up. (Use the `--systemd-units` flag to list the units to profile, eg. `--systemd-units=docker.service` to profile the docker daemon)
+* **systemd**: A list of Cgroups to be profiled on a node can be configured for the Parca agent to pick up. (Use the `--cgroups` flag to indicate the Cgroups to profile, eg. `--cgroups=docker.service` to profile the docker daemon)
 
 ## Requirements
 
@@ -88,22 +88,26 @@ Flags:
       --pod-label-selector=STRING
                                   Label selector to control which Kubernetes
                                   Pods to select.
+      --cgroups=CGROUPS,...       Cgroups to profile on this node.
       --systemd-units=SYSTEMD-UNITS,...
-                                  systemd units to profile on this node.
+                                  [deprecated, use --cgroups instead] systemd
+                                  units to profile on this node.
       --temp-dir="/tmp"           Temporary directory path to use for processing
                                   object files.
       --socket-path=STRING        The filesystem path to the container runtimes
                                   socket. Leave this empty to use the defaults.
       --profiling-duration=10s    The agent profiling duration to use. Leave
                                   this empty to use the defaults.
+      --cgroup-path=STRING        The cgroupfs path.
       --systemd-cgroup-path=STRING
-                                  The cgroupfs path to a systemd slice.
+                                  [deprecated, use --cgroup-path] The cgroupfs
+                                  path to a systemd slice.
       --debug-info-disable        Disable debuginfo collection.
 ```
 
-### systemd
+### Cgroups
 
-To discover systemd units, the names must be passed to the agent. For example, to profile the docker daemon pass `--systemd-units=docker.service`.
+To profile Cgroups, their names must be passed to the agent. For example, to profile the docker daemon pass `--cgroups=docker.service`.
 
 ### Sampling
 

--- a/pkg/discovery/systemd.go
+++ b/pkg/discovery/systemd.go
@@ -13,6 +13,9 @@
 
 package discovery
 
+// TODO(javierhonduco): Rename this discovery mechanism to a Cgroups as it's
+// a more suitable name.
+
 import (
 	"bufio"
 	"context"

--- a/scripts/local-run.sh
+++ b/scripts/local-run.sh
@@ -42,7 +42,7 @@ trap 'kill $(jobs -p); exit 0' EXIT
         dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec --continue -- \
             $PARCA_AGENT \
             --node=systemd-test \
-            --systemd-units=docker.service \
+            --cgroups=docker.service \
             --log-level=debug \
             --kubernetes=false \
             --store-address=localhost:7070 \
@@ -50,7 +50,7 @@ trap 'kill $(jobs -p); exit 0' EXIT
     else
         sudo $PARCA_AGENT \
             --node=systemd-test \
-            --systemd-units=docker.service \
+            --cgroups=docker.service \
             --log-level=debug \
             --kubernetes=false \
             --store-address=localhost:7070 \


### PR DESCRIPTION
The currently named SystemD discovery mechanism is a bit of a misnomer as in reality we
are just dealing with Cgroups.

The Cgroups I have been profiling both in this PR and in other PRs was ran with Docker
or Podman without any issues.

This is the first PR in https://github.com/parca-dev/parca-agent/issues/400

**Test plan**
```
$ GODEBUG=cgocheck=2 make ENABLE_ASAN=yes && sudo dist/parca-agent --node=test --log-level=debug --kubernetes=false --insecure --systemd-units=docker-b8873e261a9fb63e83d3d865a8780066e12e55b2f7eb8f6ac87db0b08444c6a8.scope
mkdir -p dist/parca-agent.bpf
cp $(find parca-agent.bpf.c dist/libbpf/usr/include/bpf 3rdparty/include -type f) dist/parca-agent.bpf
go mod tidy -compat=1.17

find dist -exec touch -t 202101010000.00 {} +
GOOS=linux GOARCH=arm64 CC=clang CGO_CFLAGS="-I /home/vagrant/work/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/vagrant/work/parca-agent/dist/libbpf/libbpf.a" go build -asan -trimpath -v -o dist/parca-agent ./cmd/parca-agent
find dist -exec touch -t 202101010000.00 {} +
go build -asan -trimpath -v -o dist/debug-info ./cmd/debug-info
ts=2022-05-12T09:07:52.376145627Z caller=main.go:129 msg=starting... node=test store=
level=debug ts=2022-05-12T09:07:52.376370351Z caller=main.go:130 msg="parca-agent initialized" version= commit=3e168add8a57dbb67cb788292e20b1feaa11ed3d date=2022-05-06T13:34:32Z config="{debug :7071 test map[]    true 10s false 1 false  [] [docker-b8873e261a9fb63e83d3d865a8780066e12e55b2f7eb8f6ac87db0b08444c6a8.scope] /tmp  10s   false}" arch=arm64
level=debug ts=2022-05-12T09:07:52.376937245Z caller=discovery_manager.go:188 msg="starting provider" provider=systemd/0 subs=[systemd]
level=debug ts=2022-05-12T09:07:52.377193435Z caller=main.go:406 msg="starting discovery manager"
level=debug ts=2022-05-12T09:07:52.377210397Z caller=main.go:373 msg="starting batch write client"
level=debug ts=2022-05-12T09:07:52.377231278Z caller=main.go:417 msg="starting target manager"
level=debug ts=2022-05-12T09:07:53.377777135Z caller=systemd.go:89 discovery=systemd msg="running systemd manager" units=1
level=debug ts=2022-05-12T09:07:54.377999994Z caller=systemd.go:89 discovery=systemd msg="running systemd manager" units=1
level=debug ts=2022-05-12T09:07:55.378453036Z caller=systemd.go:89 discovery=systemd msg="running systemd manager" units=1
level=debug ts=2022-05-12T09:07:56.378030189Z caller=systemd.go:89 discovery=systemd msg="running systemd manager" units=1
level=debug ts=2022-05-12T09:07:57.378189866Z caller=systemd.go:89 discovery=systemd msg="running systemd manager" units=1
```