### PR TITLE
Add boot time checks for external dependencies

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -174,16 +173,13 @@ func main() {
 				}
 
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-				cmd := exec.CommandContext(ctx, c, "--help")
-				var stdout, stderr bytes.Buffer
-				cmd.Stdout = &stdout
-				cmd.Stderr = &stderr
-				if err := cmd.Run(); err != nil {
+				if out, err := exec.CommandContext(ctx, c, "--help").CombinedOutput(); err != nil {
 					cancel()
 					level.Error(logger).Log(
 						"msg", "failed to check whether external dependency is healthy",
 						"err", err,
 						"cmd", c,
+						"output", string(out),
 					)
 					os.Exit(1)
 				}


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>\

Thanks, @javierhonduco for the idea.

cc @v-thakkar 

### Example errors:

1. `level=error ts=2022-05-31T15:51:24.74057947Z caller=main.go:178 msg="failed to check whether external dependency is healthy" err="exit status 127" cmd=eu-strip output="eu-strip: error while loading shared libraries: libelf.so.1: cannot open shared object file: No such file or directory\n"`
2. `level=error ts=2022-05-31T15:14:27.640210588Z caller=main.go:168 msg="failed to find external dependency in the PATH; make sure it is installed and added to the PATH" cmd=objcopy`