### PR TITLE
fix: set profile duration to real measurement

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -265,7 +265,7 @@ func main() {
 					statusPage.ActiveProfilers = append(statusPage.ActiveProfilers, template.ActiveProfiler{
 						Type:         profileType,
 						Labels:       labelSet,
-						LastTakenAgo: time.Since(profiler.LastProfileTakenAt()),
+						LastTakenAgo: time.Since(profiler.LastSuccessfulProfileStartedAt()),
 						Error:        profiler.LastError(),
 						Link:         fmt.Sprintf("/query?%s", q.Encode()),
 					})

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -572,7 +572,7 @@ func (p *CgroupProfiler) buildProfile(
 			Unit: "count",
 		}},
 		TimeNanos:     captureTime.UnixNano(),
-		DurationNanos: int64(p.profilingDuration),
+		DurationNanos: int64(time.Since(captureTime)),
 
 		// We sample at 100Hz, which is every 10 Million nanoseconds.
 		PeriodType: &profile.ValueType{

--- a/pkg/target/profiler_pool.go
+++ b/pkg/target/profiler_pool.go
@@ -41,7 +41,8 @@ type Target struct {
 
 type Profiler interface {
 	Labels() model.LabelSet
-	LastProfileTakenAt() time.Time
+	LastSuccessfulProfileStartedAt() time.Time
+	NextProfileStartedAt() time.Time
 	LastError() error
 	Stop()
 }


### PR DESCRIPTION
Hello there, I am looking at the "good first issues" :wave:

I may be completely wrong, but I am trying to get to know the internals, so it looks like it is simply a matter of measuring `time.Since(captureTime)` in `buildProfile()`, set from here:

https://github.com/parca-dev/parca-agent/blob/4dcd283d602a97325cc2a5371634686196946fb5/pkg/profiler/profiler.go#L390-L391

The exact collection of the samples starting/finishing _slightly_ later/earlier, adding `start := time.Now()` before the BPF Maps loop:

https://github.com/parca-dev/parca-agent/blob/4dcd283d602a97325cc2a5371634686196946fb5/pkg/profiler/profiler.go#L415-L416

And measuring `duration := time.Since(start)` after exiting the loop, then pass it down to `buildProfile()` should also work.

The former is much simpler (1 line change), but I wonder how accurate we can/want/need to be

Closes #375