### PR TITLE
make-containers: Add -euo pipefail flags

### DIFF
--- a/make-containers.sh
+++ b/make-containers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +x
+set +euxo pipefail
 
 MANIFEST="$1"
 ARCHS=('arm64' 'amd64')


### PR DESCRIPTION
Add a bunch of flags so that the script fails immediately
and explicitly in case of command failures.

Signed-off-by: Vaishali Thakkar <me.vaishalithakkar@gmail.com>