### PR TITLE
chore: configure entire toolchain in rust-toolchain.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,7 @@ jobs:
           go-version: ^1.18
 
       - name: Set up Rust
-        run: |
-          rustup set profile minimal
-          rustup component add rustfmt clippy
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0
@@ -74,9 +72,7 @@ jobs:
           go-version: ^1.18
 
       - name: Set up Rust
-        run: |
-          rustup set profile minimal
-          rustup component add rustfmt clippy
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
           go-version: ^1.18
 
       - name: Set up Rust
+        # Yes, oddly `rustup show` installs the toolchain (:
+        # https://github.com/rust-lang/rustup/issues/2686
         run: rustup show
 
       - name: Rust Cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,9 +47,7 @@ jobs:
           go-version: ^1.18
 
       - name: Set up Rust
-        run: |
-          rustup set profile minimal
-          rustup component add rustfmt clippy
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,7 @@ jobs:
           go-version: ^1.18
 
       - name: Set up Rust
-        run: |
-          rustup set profile minimal
-          rustup component add rustfmt clippy
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,7 @@ jobs:
           go-version: ^1.18
 
       - name: Set up Rust
-        run: |
-          rustup set profile minimal
-          rustup component add rustfmt clippy
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main\n\
 deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main\n\
 " > /etc/apt/sources.list
 
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 # NOTICE: -o Acquire::Check-Valid-Until="false" added as a mitigation, see https://github.com/parca-dev/parca-agent/issues/10 for further details.
 RUN apt-get -o Acquire::Check-Valid-Until="false" update -y && \
@@ -25,9 +25,9 @@ WORKDIR /parca-agent
 
 # Install Rust
 COPY rust-toolchain.toml /parca-agent
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain none -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup component add clippy
+RUN rustup show
 
 ARG ARCH
 ENV GOOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,7 @@ deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main\n\
 deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main\n\
 " >> /etc/apt/sources.list
 
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
       apt-get install --no-install-recommends -y clang-14 llvm-14 make gcc coreutils elfutils binutils zlib1g-dev libelf-dev ca-certificates netbase && \
@@ -17,9 +17,9 @@ WORKDIR /app
 
 # Install Rust
 COPY rust-toolchain.toml /app
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain none -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup component add clippy
+RUN rustup show
 
 
 COPY go.mod go.sum /app/

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -1,6 +1,6 @@
 .PHONY: setup
 setup:
-	rustup component add rust-src
+	rustup show
 	cargo install bpf-linker
 
 .PHONY: build

--- a/bpf/README.md
+++ b/bpf/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Install the rust toolchain with `rust-src` (channel defined in the root `rust-toolchain.toml` file): `rustup component add rust-src`
+1. Install the rust toolchain as defined in the root `rust-toolchain.toml` file: `rustup show`
 1. Install bpf-linker: `cargo install bpf-linker`
 
 ## Build eBPF

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel="nightly-2022-05-23"
+channel = "nightly-2022-05-23"
+components = [ "rustfmt", "clippy", "rust-src" ]
+profile = "minimal"


### PR DESCRIPTION
I figured we can simplify further, the toolchain can be fully configured from `rust-toolchain.toml`:
https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

And yes, oddly `rustup show` installs the toolchain :upside_down_face: