### PR TITLE
chore: add shell.nix file for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,10 @@ simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Dock
 2. If it is your first time using Nix, you might need to configure a `nixpkgs` channel:
 
     ```console
-    # On Linux
+    ## On Linux
     $ nix-channel --add https://nixos.org/channels/nixos-22.05 nixpkgs
 
-    # On MacOS
+    ## On MacOS
     $ nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
 
     $ nix-channel --update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,12 @@ Install the following dependencies (Instructions are linked for each dependency)
 
 - [Go](https://golang.org/doc/install)
 - [Rust](https://www.rust-lang.org/tools/install)
-- [Node](https://nodejs.org/en/download/)
 - [Docker](https://docs.docker.com/engine/install/)
 - [minikube](https://kubernetes.io/docs/tasks/tools/#minikube)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [LLVM](https://apt.llvm.org/)
 
-    ```bash
+    ```console
     $ sudo apt-get update
 
     $ sudo apt-get install make clang llvm libbpf-dev libelf-dev
@@ -38,21 +37,21 @@ simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Dock
 
 1. Download and install Nix via [official installer](https://nixos.org/download.html#download-nix) or using a package manager, for example on Debian/Ubuntu:
 
-    ```bash
-    sudo apt-get update
-    sudo apt-get install nix-setup-systemd
-    sudo adduser "${USER}" nix-users
+    ```console
+    $ sudo apt-get update
+    $ sudo apt-get install nix-setup-systemd
+    $ sudo adduser "${USER}" nix-users
     ```
 
 2. If it is your first time using Nix, you might need to configure a `nixpkgs` channel:
 
-    ```bash
+    ```console
     # On Linux
-    nix-channel --add https://nixos.org/channels/nixos-22.05 nixpkgs
+    $ nix-channel --add https://nixos.org/channels/nixos-22.05 nixpkgs
     # On MacOS
-    nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
+    $ nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
 
-    nix-channel --update
+    $ nix-channel --update
     ```
 
 Some extra configuration may be required to use all the features of Nix
@@ -63,19 +62,16 @@ like adding `${HOME}/.nix-profile/bin` to your `PATH`, but `nix-shell` should be
 Fork the [parca-agent](https://github.com/parca-dev/parca-agent) and [parca](https://github.com/parca-dev/parca) repositories on GitHub.
 Clone the repositories on to your machine.
 
-```
-$ git clone git@github.com:parca-dev/parca.git
-
+```console
 $ git clone git@github.com:parca-dev/parca-agent.git
 ```
 
-## **Run parca-agent**
-
+## Run parca-agent
 
 Code changes can be tested locally by building parca-agent and running it to profile systemd units.
 The following code snippet profiles the docker daemon, i.e. `docker.service` systemd unit:
 
-```
+```console
 $ cd parca-agent
 
 $ make
@@ -87,46 +83,21 @@ The generated profiles can be seen at http://localhost:7071 .
 
 **Note**: Currently, parca-agent has systemd discovery support for Cgroup v1 only.
 
-## **Working with parca server**
+## Working with parca server
 
-To launch parca-agent locally with the [parca server](https://github.com/parca-dev/parca#development), first copy your parca-agent repository (where you have made changes) to `parca/tmp/`:
+Clone the parca server repository and copy the parca-agent repository (where you have made changes) to `parca/tmp/`:
 
-```
+```console
+$ git clone git@github.com:parca-dev/parca.git
+
 $ cp -Rf parca-agent parca/tmp/parca-agent
 ```
 
-Go to the project directory and compile parca:
-
-```
-$ cd parca
-
-$ make build
-```
-
-Run the binary locally.
-
-```
-./bin/parca
-```
-Once compiled the server ui can be seen at http://localhost:7070.
-
-
-To profile all containers using Kubernetes, the parca-agent can be run alongside parca-server and parca-ui using Tilt.
-
-```
-$ cp -Rf parca-agent parca/tmp/parca-agent
-
-$ cd parca
-
-$ make dev/up
-
-$ tilt up
-```
+Then follow [the server's `CONTRIBUTING.md`](https://github.com/parca-dev/parca/blob/main/CONTRIBUTING.md#prerequisites) to get your development Kubernetes cluster running (via Tilt).
 
 Test your changes by running:
-```
-$ cd parca && make go/test
 
+```console
 $ cd parca-agent && make test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,31 +35,6 @@ Install the following dependencies (Instructions are linked for each dependency)
 Alternatively, [Nix](https://nixos.org/download.html#download-nix) can be used to avoid installing system packages,
 simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Docker and VirtualBox are required to be installed as system packages.
 
-1. Download and install Nix via [official installer](https://nixos.org/download.html#download-nix) or using a package manager, for example on Debian/Ubuntu:
-
-    ```console
-    $ sudo apt-get update
-
-    $ sudo apt-get install nix-setup-systemd
-
-    $ sudo adduser "${USER}" nix-users
-    ```
-
-2. If it is your first time using Nix, you might need to configure a `nixpkgs` channel:
-
-    ```console
-    ## On Linux
-    $ nix-channel --add https://nixos.org/channels/nixos-22.05 nixpkgs
-
-    ## On MacOS
-    $ nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
-
-    $ nix-channel --update
-    ```
-
-Some extra configuration may be required to use all the features of Nix
-like adding `${HOME}/.nix-profile/bin` to your `PATH`, but `nix-shell` should be ready for use.
-
 # Getting Started
 
 Fork the [parca-agent](https://github.com/parca-dev/parca-agent) and [parca](https://github.com/parca-dev/parca) repositories on GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,30 @@ Install the following dependencies (Instructions are linked for each dependency)
     $ sudo apt-get install make clang llvm libbpf-dev libelf-dev
      ```
 
+Alternatively, [Nix](https://nixos.org/download.html#download-nix) can be used to avoid installing system packages,
+simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Docker and VirtualBox are required to be installed as system packages.
+
+1. Download and install Nix via [official installer](https://nixos.org/download.html#download-nix) or using a package manager, for example on Debian/Ubuntu:
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install nix-setup-systemd
+    sudo adduser "${USER}" nix-users
+    ```
+
+2. If it is your first time using Nix, you might need to configure a `nixpkgs` channel:
+
+    ```bash
+    # On Linux
+    nix-channel --add https://nixos.org/channels/nixos-22.05 nixpkgs
+    # On MacOS
+    nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
+
+    nix-channel --update
+    ```
+
+Some extra configuration may be required to use all the features of Nix
+like adding `${HOME}/.nix-profile/bin` to your `PATH`, but `nix-shell` should be ready for use.
 
 # Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Dock
 
     ```console
     $ sudo apt-get update
+
     $ sudo apt-get install nix-setup-systemd
+
     $ sudo adduser "${USER}" nix-users
     ```
 
@@ -48,6 +50,7 @@ simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Dock
     ```console
     # On Linux
     $ nix-channel --add https://nixos.org/channels/nixos-22.05 nixpkgs
+
     # On MacOS
     $ nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell rec {
+  name = "parca-agent";
+
+  packages = with pkgs; [
+    clang
+    gnumake
+    go_1_18
+    kubectl
+    libbpf
+    libelf
+    llvm
+    minikube
+    nodejs-16_x
+    rustup
+    zlib.static
+  ] ++ (lib.optional stdenv.isLinux [ glibc glibc.static ]);
+
+  shellHook = ''
+    export PATH="''${PROJECT_ROOT}/bin:''${CARGO_HOME}/bin:''${PATH}"
+    rustup show >/dev/null
+  '';
+
+  PROJECT_ROOT = builtins.toString ./.;
+  CARGO_HOME = "${PROJECT_ROOT}/tmp/cargo";
+  GOBIN = "${PROJECT_ROOT}/bin";
+  RUSTUP_HOME = "${PROJECT_ROOT}/tmp/rustup";
+  RUST_BACKTRACE = 1;
+}
+

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,6 @@ pkgs.mkShell rec {
     libelf
     llvm
     minikube
-    nodejs-16_x
     rustup
     zlib.static
   ] ++ (lib.optional stdenv.isLinux [ glibc glibc.static ]);


### PR DESCRIPTION
This adds a `shell.nix` file to manage the development dependencies, this is my first attempt at using it in project. The idea is to contain as much as possible the dependencies within the repository and avoid spilling on the system or even the user's home.

I added instructions about how to use it in the `CONTRIBUTING.md`, including basics on how to install Nix even though it is out of the scope of `parca-agent`.

It sets a few environment variables to keep things within the repository like Go and Rust binaries, we can add more or remove if that causes troubles.

Once `nix-shell` has been run and with #447 to configure the Rust toolchain, only a couple more commands are needs to build the agent, basically you are ready to work with:

```console
$ nix-shell
[nix-shell:/path/to/parca-agent]$ cargo install bpf-linker # shellHook seems to run before the dependencies like glibc are available
[nix-shell:/path/to/parca-agent]$ make
```

`direnv` can also be use to enter the shell automatically and use your own shell if different from `bash`.

I have only tested the agent local build, not the full parca setup. On NixOS and an Ubuntu VM (both package install and Nix installer script)

Some references:
* https://nixos.wiki/wiki/Development_environment_with_nix-shell
* https://nixos.org/manual/nix/stable/expressions/expression-syntax.html
* https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell
* https://nixos.wiki/wiki/Rust#Installation_via_rustup
* https://nixos.wiki/wiki/Go#Compile_go_program_with_static_compile_flag