### PR TITLE
[WIP] Extend network timeout for aya dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN go mod download -modcacherw
 
 COPY Makefile /parca-agent/
 COPY bpf /parca-agent/bpf
-RUN make -C bpf setup
+RUN make -C bpf setup --network-timeout 100000
 RUN make bpf
 
 COPY . /parca-agent


### PR DESCRIPTION
arm64 network is slow because of container in container mode
and cargo fails to install certain packages if they're big.
Let's increase it.

Signed-off-by: Vaishali Thakkar <me.vaishalithakkar@gmail.com>