### PR TITLE
cmd/parca-agent: Register stream interceptor for recording metrics

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -476,6 +476,9 @@ func grpcConn(reg prometheus.Registerer, flags flags) (*grpc.ClientConn, error) 
 		grpc.WithUnaryInterceptor(
 			met.UnaryClientInterceptor(),
 		),
+		grpc.WithStreamInterceptor(
+			met.StreamClientInterceptor(),
+		),
 	}
 	if flags.Insecure {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))


### PR DESCRIPTION
While we were already recording metrics for unary methods, we seem to
have forgotten to do the same for streaming methods.