### PR TITLE
docker: Fix arm64 build

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -2,7 +2,9 @@
 setup:
 	rustup show
 	# we need to do this as we're using an external LLVM. See: https://github.com/aya-rs/bpf-linker#using-external-llvm
-	cargo install --git https://github.com/aya-rs/bpf-linker --tag v0.9.4 --no-default-features --features system-llvm -- bpf-linker
+	# TODO(vadorovsky): Remove the LLVM_SYS_140_PREFIX variable once
+	# https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/22 is merged.
+	LLVM_SYS_140_PREFIX=/usr/lib/llvm-14 cargo install --git https://github.com/aya-rs/bpf-linker --tag v0.9.4 --no-default-features --features system-llvm -- bpf-linker
 
 .PHONY: build
 build:


### PR DESCRIPTION
Before this change, the arm64 build of bpf-linker was failing with:

```
Could not determine LLVM version from llvm-config.
```

The upstream llvm-sys fix is here:

https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/22

Until it gets merged and released, we need to define LLVM_SYS_140_PREFIX
as a workaround.

Co-authored-by: Vaishali Thakkar <me.vaishalithakkar@gmail.com>
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>
Signed-off-by: Vaishali Thakkar <me.vaishalithakkar@gmail.com>