### PR TITLE
build(deps): use llvm-14 from Debian snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,8 @@ deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-updates main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-backports main\n\
 deb http://snapshot.debian.org/archive/debian-security/20220420T025302Z bullseye-security main\n\
+deb http://snapshot.debian.org/archive/debian/20220420T025302Z sid main\n\
 " > /etc/apt/sources.list
-
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-
-RUN echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main\n" > /etc/apt/sources.list.d/llvm.list
 
 # NOTICE: -o Acquire::Check-Valid-Until="false" added as a mitigation, see https://github.com/parca-dev/parca-agent/issues/10 for further details.
 RUN apt-get -o Acquire::Check-Valid-Until="false" update -y && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,11 +8,8 @@ deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-updates main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-backports main\n\
 deb http://snapshot.debian.org/archive/debian-security/20220420T025302Z bullseye-security main\n\
+deb http://snapshot.debian.org/archive/debian/20220420T025302Z sid main\n\
 " > /etc/apt/sources.list
-
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-
-RUN echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main\n" > /etc/apt/sources.list.d/llvm.list
 
 RUN apt-get -o Acquire::Check-Valid-Until="false" update -y && \
      apt-get install --no-install-recommends -yq llvm-14-dev libclang-14-dev clang-14 make gcc coreutils zlib1g-dev libelf-dev ca-certificates netbase && \


### PR DESCRIPTION
This is a suggestion. apt.llvm.org only keeps the latest build.

This uses the `sid` (`unstable`) channel from the Debian snapshot to get the LLVM 14 toolchain.
`bookworm` (`testing`) should also work depending on how stable or fast fixes are desired.

https://wiki.debian.org/DebianUnstable
https://wiki.debian.org/DebianTesting

It does get hard to tell which channel provides which package due to how they depend on each other, but unstable/testing should get the lowest priority if I understand correctly: https://manpages.debian.org/bullseye/apt/apt_preferences.5.en.html#APT's_Default_Priority_Assignments

Closes #449 