### PR TITLE
build: fix silent container build failure and lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ insert_final_newline = true
 [*.go]
 indent_style = tab
 
-[*.rs]
+[*.{rs,sh}]
 indent_style = space
 indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,66 @@
-ARG GOLANG_BASE
-ARG DEBIAN_BASE
-
-FROM ${GOLANG_BASE} as build
+FROM docker.io/golang:1.18.1-bullseye@sha256:3b1a72af045ad0fff9fe8e00736baae76d70ff51325ac5bb814fe4754044b972 AS build
 
 # tag=1.24.3
 ARG RUSTUP_VERSION=ce5817a94ac372804babe32626ba7fd2d5e1b6ac
 
 # For more information about the snapshots, see: https://snapshot.debian.org/
-RUN echo "\
+RUN printf '\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-updates main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-backports main\n\
 deb http://snapshot.debian.org/archive/debian-security/20220420T025302Z bullseye-security main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z sid main\n\
-" > /etc/apt/sources.list
+' > /etc/apt/sources.list
 
-# NOTICE: -o Acquire::Check-Valid-Until="false" added as a mitigation, see https://github.com/parca-dev/parca-agent/issues/10 for further details.
+# NOTICE: -o Acquire::Check-Valid-Until="false" added as a mitigation,
+# see https://github.com/parca-dev/parca-agent/issues/10 for further details.
+# hadolint ignore=DL3008
 RUN apt-get -o Acquire::Check-Valid-Until="false" update -y && \
-      apt-get install --no-install-recommends -yq llvm-14-dev libclang-14-dev clang-14 make gcc coreutils zlib1g-dev libelf-dev ca-certificates netbase && \
-      ln -s /usr/bin/clang-14 /usr/bin/clang && \
-      ln -s /usr/bin/llc-14 /usr/bin/llc
+    apt-get install --no-install-recommends -yq \
+        llvm-14-dev \
+        libclang-14-dev \
+        clang-14 \
+        make \
+        gcc \
+        coreutils \
+        zlib1g-dev \
+        libelf-dev \
+        ca-certificates \
+        netbase && \
+    ln -s /usr/bin/clang-14 /usr/bin/clang && \
+    ln -s /usr/bin/llc-14 /usr/bin/llc
 
 WORKDIR /parca-agent
 
 # Install Rust
 COPY rust-toolchain.toml /parca-agent
+# SHELL is not supported for OCI image format
+# https://github.com/containers/buildah/blob/v1.26.1/config.go#L366-L377
+# hadolint ignore=DL4006
 RUN curl --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/rust-lang/rustup/${RUSTUP_VERSION}/rustup-init.sh" \
     | sh -s -- --default-toolchain none -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup show
 
-ARG ARCH
+ARG TARGETARCH=amd64
+ENV ARCH="${TARGETARCH}"
 ENV GOOS=linux
-ENV ARCH=$ARCH
-ENV GOARCH=$ARCH
+ENV GOARCH="${TARGETARCH}"
 
 COPY go.mod go.sum /parca-agent/
 RUN go mod download -modcacherw
 
-COPY Makefile /parca-agent/
+COPY Makefile /parca-agent
 COPY bpf /parca-agent/bpf
 RUN make -C bpf setup
+# hadolint ignore=DL3059
 RUN make bpf
 
 COPY . /parca-agent
 RUN git submodule init && git submodule update
 RUN make build
 
-FROM ${DEBIAN_BASE} as all
+FROM docker.io/debian:bullseye-slim@sha256:06a93cbdd49a265795ef7b24fe374fee670148a7973190fb798e43b3cf7c5d0f AS all
 
 COPY --from=build /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,26 +1,42 @@
-FROM golang:1.18.3-bullseye as build
+FROM docker.io/golang:1.18.1-bullseye@sha256:3b1a72af045ad0fff9fe8e00736baae76d70ff51325ac5bb814fe4754044b972 AS build
 
 # tag=1.24.3
 ARG RUSTUP_VERSION=ce5817a94ac372804babe32626ba7fd2d5e1b6ac
 
-RUN echo "\
+# For more information about the snapshots, see: https://snapshot.debian.org/
+RUN printf '\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-updates main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z bullseye-backports main\n\
 deb http://snapshot.debian.org/archive/debian-security/20220420T025302Z bullseye-security main\n\
 deb http://snapshot.debian.org/archive/debian/20220420T025302Z sid main\n\
-" > /etc/apt/sources.list
+' > /etc/apt/sources.list
 
+# NOTICE: -o Acquire::Check-Valid-Until="false" added as a mitigation,
+# see https://github.com/parca-dev/parca-agent/issues/10 for further details.
+# hadolint ignore=DL3008
 RUN apt-get -o Acquire::Check-Valid-Until="false" update -y && \
-     apt-get install --no-install-recommends -yq llvm-14-dev libclang-14-dev clang-14 make gcc coreutils zlib1g-dev libelf-dev ca-certificates netbase && \
-     ln -s /usr/bin/clang-14 /usr/bin/clang && \
-     ln -s /usr/bin/llc-14 /usr/bin/llc
-
+    apt-get install --no-install-recommends -yq \
+        llvm-14-dev \
+        libclang-14-dev \
+        clang-14 \
+        make \
+        gcc \
+        coreutils \
+        zlib1g-dev \
+        libelf-dev \
+        ca-certificates \
+        netbase && \
+    ln -s /usr/bin/clang-14 /usr/bin/clang && \
+    ln -s /usr/bin/llc-14 /usr/bin/llc
 
 WORKDIR /parca-agent
 
 # Install Rust
-COPY rust-toolchain.toml /parca-agent/
+COPY rust-toolchain.toml /parca-agent
+# SHELL is not supported for OCI image format
+# https://github.com/containers/buildah/blob/v1.26.1/config.go#L366-L377
+# hadolint ignore=DL4006
 RUN curl --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/rust-lang/rustup/${RUSTUP_VERSION}/rustup-init.sh" \
     | sh -s -- --default-toolchain none -y
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -30,18 +46,20 @@ RUN rustup show
 COPY go.mod go.sum /parca-agent/
 RUN go mod download -modcacherw
 
-COPY Makefile ./
-COPY 3rdparty ./3rdparty
-COPY bpf ./bpf
+COPY Makefile /parca-agent
+COPY 3rdparty /parca-agent/3rdparty
+COPY bpf /parca-agent/bpf
 RUN make -C bpf setup
+# hadolint ignore=DL3059
 RUN make bpf
 
+# hadolint ignore=DL3059
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 COPY . /parca-agent
 RUN make build
 
-FROM debian:bullseye-slim as all
+FROM docker.io/debian:bullseye-slim@sha256:06a93cbdd49a265795ef7b24fe374fee670148a7973190fb798e43b3cf7c5d0f AS all
 
 COPY --from=build /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/make-containers.sh
+++ b/make-containers.sh
@@ -1,33 +1,14 @@
 #!/usr/bin/env bash
-set +euxo pipefail
+set -euo pipefail
 
-MANIFEST="$1"
+MANIFEST="${1?Image name must be provided}"
 ARCHS=('arm64' 'amd64')
 
-# podman manifest inspect docker.io/golang:1.18.1-bullseye
-# SHA order is respectively arm64, amd64
-DOCKER_GOLANG_SHAS=(
-    'docker.io/golang@sha256:301d39546808488f001760626a904b6aa4bb6e8f94a79bdd43776d990ad6c28e'
-    'docker.io/golang@sha256:ee752bc53c628ff789bacefb714cff721701042ffa9eb736f7b2ed4e9f2bdab6'
-)
-
-# podman manifest inspect docker.io/debian:bullseye-slim
-# SHA order is respectively arm64, amd64
-DOCKER_DEBIAN_SHAS=(
-    'docker.io/debian@sha256:fc7792ebc6819bf63f967a6039f2f35346e7fa8f3650f8dd58f596c3da1a9882'
-    'docker.io/debian@sha256:fa4209bc498f3cf557c7d448f295d300aed44e7fd296fdd480a8ff5785cca305'
-)
-
-for i in "${!ARCHS[@]}"; do
-    ARCH=${ARCHS[$i]}
-    DOCKER_GOLANG_SHA=${DOCKER_GOLANG_SHAS[$i]}
-    DOCKER_DEBIAN_SHA=${DOCKER_DEBIAN_SHAS[$i]}
-    echo "Building manifest for $MANIFEST with arch \"$ARCH\""
+for arch in "${ARCHS[@]}"; do
+    printf 'Building manifest for %s with arch %s\n' "${MANIFEST}" "${arch}"
     podman build \
-        --build-arg GOLANG_BASE=$DOCKER_GOLANG_SHA \
-        --build-arg DEBIAN_BASE=$DOCKER_DEBIAN_SHA \
-        --build-arg ARCH=$ARCH \
-        --arch $ARCH \
+        --build-arg TARGETARCH="${arch}" \
+        --arch "${arch}" \
         --timestamp 0 \
-        --manifest $MANIFEST .; \
+        --manifest "${MANIFEST}" .
 done


### PR DESCRIPTION
* Fix `set +euxo pipefail` --> `set -eux pipefail`
* Pin manifest list digest of base images directly in `Dockerfile` (you can use `regctl manifest digest --require-list IMAGE_NAME` to find it), instead of passing individual arch digest via args, this should make updates simpler, and Dependabot may be able to do PRs, if not, I highly recommend [Renovate](https://github.com/apps/renovate) which [can do a lot more](https://docs.renovatebot.com/docker/#digest-pinning)
* Use [Buildkit's `TARGETARCH` ARG](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope) instead of `ARCH`, it standardize things a little and makes things easier if you happen to build with `docker-buildx`
* Lint with `shellcheck` and `hadolint`
* Sync `Dockerfile` and `Dockerfile.dev` as much as possible, to ensure nothing was missed, it also helps with the cache if you build one after the other

Closes #462 