### PR TITLE
debuginfo: Remove temporary local file state

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Flags:
       --systemd-units=SYSTEMD-UNITS,...
                                   [deprecated, use --cgroups instead] systemd
                                   units to profile on this node.
-      --temp-dir="/tmp"           Temporary directory path to use for processing
-                                  object files.
+      --temp-dir=""               (Deprecated) Temporary directory path to use
+                                  for processing object files.
       --socket-path=STRING        The filesystem path to the container runtimes
                                   socket. Leave this empty to use the defaults.
       --profiling-duration=10s    The agent profiling duration to use. Leave

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -80,8 +80,9 @@ type flags struct {
 	PodLabelSelector   string            `kong:"help='Label selector to control which Kubernetes Pods to select.'"`
 	Cgroups            []string          `kong:"help='Cgroups to profile on this node.'"`
 	// SystemdUnits is deprecated and will be eventually removed, please use the Cgroups flag instead.
-	SystemdUnits      []string      `kong:"help='[deprecated, use --cgroups instead] systemd units to profile on this node.'"`
-	TempDir           string        `kong:"help='Temporary directory path to use for processing object files.',default='/tmp'"`
+	SystemdUnits []string `kong:"help='[deprecated, use --cgroups instead] systemd units to profile on this node.'"`
+	// TempDir is deprecated and will be eventually removed.
+	TempDir           string        `kong:"help='(Deprecated) Temporary directory path to use for processing object files.',default=''"`
 	SocketPath        string        `kong:"help='The filesystem path to the container runtimes socket. Leave this empty to use the defaults.'"`
 	ProfilingDuration time.Duration `kong:"help='The agent profiling duration to use. Leave this empty to use the defaults.',default='10s'"`
 	CgroupPath        string        `kong:"help='The cgroupfs path.'"`
@@ -134,6 +135,10 @@ func main() {
 		"config", fmt.Sprint(flags),
 		"arch", goArch,
 	)
+
+	if flags.TempDir != "" {
+		level.Warn(logger).Log("msg", "--temp-dir is deprecated and will be removed in a future release.")
+	}
 
 	mux := http.NewServeMux()
 	reg := prometheus.NewRegistry()
@@ -196,7 +201,6 @@ func main() {
 		flags.ProfilingDuration,
 		externalLabels(flags.ExternalLabel, flags.Node),
 		flags.SamplingRatio,
-		flags.TempDir,
 	)
 
 	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433
+	github.com/rzajac/flexbuf v0.14.0
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	google.golang.org/grpc v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -1155,6 +1155,10 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/rzajac/flexbuf v0.14.0 h1:CHf+puRkM90RuBlVnfVRzW2Y1xAjbg8soWMFVOxids4=
+github.com/rzajac/flexbuf v0.14.0/go.mod h1:RNcYQQ1lPnO/vLh/pTwazVfHYyRk9jxoQvO/5YK9O8Y=
+github.com/rzajac/testkit v0.7.0 h1:3Sfoz4QFgIdEpvhzAz8xb5VzzQKhtUTeCQ81UHpy71k=
+github.com/rzajac/testkit v0.7.0/go.mod h1:Ye3Z+ZxhqIMSIr9W19b9fLNCKBOYvbN+5Ncw3J50F1k=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -1217,6 +1221,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.6.2-0.20201103103935-92707c0b2d50/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=

--- a/pkg/debuginfo/extract.go
+++ b/pkg/debuginfo/extract.go
@@ -15,16 +15,12 @@
 package debuginfo
 
 import (
-	"bytes"
 	"context"
 	"debug/elf"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strings"
-	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -36,75 +32,56 @@ import (
 // Extractor extracts debug information from a binary.
 type Extractor struct {
 	logger log.Logger
-	client Client
-	pool   sync.Pool
 
-	tmpDir string
+	client Client
 }
 
 // NewExtractor creates a new Extractor.
-func NewExtractor(logger log.Logger, client Client, tmpDir string) *Extractor {
+func NewExtractor(logger log.Logger, client Client) *Extractor {
 	return &Extractor{
 		logger: log.With(logger, "component", "extractor"),
+
 		client: client,
-		tmpDir: tmpDir,
-		pool: sync.Pool{
-			New: func() interface{} {
-				return bytes.NewBuffer(nil)
-			},
-		},
 	}
 }
 
 // ExtractAll extracts debug information from the given executables.
-// It consumes a map of build id to executable path and returns a map of build id to extracted debug information path.
-func (e *Extractor) ExtractAll(ctx context.Context, objFilePaths map[string]string) (map[string]string, error) {
-	files := map[string]string{}
+// It consumes a map of file sources to extract and a destination io.Writer.
+func (e *Extractor) ExtractAll(ctx context.Context, srcDsts map[string]io.WriteSeeker) error {
 	var result *multierror.Error
-	for buildID, filePath := range objFilePaths {
-		debugInfoFile, err := e.Extract(ctx, buildID, filePath)
-		if err != nil {
+	for src, dst := range srcDsts {
+		if err := e.Extract(ctx, dst, src); err != nil {
 			level.Warn(e.logger).Log(
-				"msg", "failed to extract debug information",
-				"buildid", buildID, "file", filePath, "err", err,
+				"msg", "failed to extract debug information", "file", src, "err", err,
 			)
 			result = multierror.Append(result, err)
-			files[buildID] = ""
 		}
-		files[buildID] = debugInfoFile
 	}
 
-	if result != nil && len(result.Errors) == len(objFilePaths) {
-		return nil, result.ErrorOrNil()
+	if result != nil && len(result.Errors) > 0 {
+		return result.ErrorOrNil()
 	}
-	return files, nil
+	return nil
 }
 
 // Extract extracts debug information from the given executable.
 // Cleaning up the temporary directory and the interim file is the caller's responsibility.
-func (e *Extractor) Extract(ctx context.Context, buildID, filePath string) (string, error) {
+func (e *Extractor) Extract(ctx context.Context, dst io.WriteSeeker, src string) error {
 	select {
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return ctx.Err()
 	default:
 	}
 
-	elfFile, err := open(filePath)
+	elfFile, err := open(src)
 	if err != nil {
-		return "", fmt.Errorf("failed to open given field: %w", err)
+		return fmt.Errorf("failed to open given field: %w", err)
 	}
 	defer elfFile.Close()
 
-	outPath := path.Join(e.tmpDir, fmt.Sprintf("%s.debuginfo", buildID))
-	outFile, err := os.Create(outPath)
+	w, err := elfwriter.New(dst, &elfFile.FileHeader)
 	if err != nil {
-		return "", fmt.Errorf("failed to open output file: %w", err)
-	}
-	// Writer will close the file.
-
-	w, err := elfwriter.New(outFile, &elfFile.FileHeader)
-	if err != nil {
-		return "", fmt.Errorf("failed to initialize writer: %w", err)
+		return fmt.Errorf("failed to initialize writer: %w", err)
 	}
 
 	for _, p := range elfFile.Progs {
@@ -124,31 +101,10 @@ func (e *Extractor) Extract(ctx context.Context, buildID, filePath string) (stri
 	}
 
 	if err := w.Write(); err != nil {
-		return "", fmt.Errorf("failed to write ELF file: %w", err)
+		return fmt.Errorf("failed to write ELF file: %w", err)
 	}
 
-	if err := w.Close(); err != nil {
-		return "", fmt.Errorf("failed to close ELF writer: %w", err)
-	}
-
-	if err := validate(outPath); err != nil {
-		return "", fmt.Errorf("failed to validate created ELF file: %w", err)
-	}
 	level.Debug(e.logger).Log("msg", "debug information successfully extracted")
-
-	return outPath, nil
-}
-
-func validate(filePath string) error {
-	elfFile, err := open(filePath)
-	if err != nil {
-		return err
-	}
-	defer elfFile.Close()
-
-	if len(elfFile.Sections) == 0 {
-		return errors.New("ELF does not have any sections")
-	}
 	return nil
 }
 

--- a/pkg/elfwriter/elfwriter.go
+++ b/pkg/elfwriter/elfwriter.go
@@ -47,16 +47,9 @@ var specialSectionLinks = map[string]string{
 	".symtab": ".strtab",
 }
 
-// WriteCloserSeeker is the union of io.Writer, io.Closer and io.Seeker.
-type WriteCloserSeeker interface {
-	io.Writer
-	io.Seeker
-	io.Closer
-}
-
 // Writer writes ELF files.
 type Writer struct {
-	w    WriteCloserSeeker
+	w    io.WriteSeeker
 	fhdr *elf.FileHeader
 
 	// Program headers to write in the output writer.
@@ -92,7 +85,7 @@ type Note struct {
 }
 
 // New creates a new Writer.
-func New(w WriteCloserSeeker, fhdr *elf.FileHeader, opts ...Option) (*Writer, error) {
+func New(w io.WriteSeeker, fhdr *elf.FileHeader, opts ...Option) (*Writer, error) {
 	if fhdr.ByteOrder == nil {
 		return nil, errors.New("byte order has to be specified")
 	}
@@ -670,15 +663,6 @@ func (w *Writer) writeSections() {
 		}
 		writeSectionHeader(w.shStrIdx[sec.Name], sec)
 	}
-}
-
-// Close closes the WriteCloseSeeker.
-func (w *Writer) Close() error {
-	var err error
-	if w.w != nil {
-		err = w.w.Close()
-	}
-	return err
 }
 
 // here returns the current seek offset from the start of the file.

--- a/pkg/elfwriter/elfwriter_test.go
+++ b/pkg/elfwriter/elfwriter_test.go
@@ -157,7 +157,6 @@ func TestWriter_Write(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.NoError(t, w.Close())
 
 			outElf, err := elf.Open(output.Name())
 			require.NoError(t, err)

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -228,7 +228,6 @@ func NewCgroupProfiler(
 	debugInfoClient debuginfo.Client,
 	target model.LabelSet,
 	profilingDuration time.Duration,
-	tmp string,
 ) *CgroupProfiler {
 	return &CgroupProfiler{
 		logger:              log.With(logger, "labels", target.String()),
@@ -243,7 +242,6 @@ func NewCgroupProfiler(
 		debugInfo: debuginfo.New(
 			log.With(logger, "component", "debuginfo"),
 			debugInfoClient,
-			tmp,
 		),
 		profileBufferPool: sync.Pool{
 			New: func() interface{} {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -41,7 +41,6 @@ type Manager struct {
 	debugInfoClient   debuginfo.Client
 	profilingDuration time.Duration
 	samplingRatio     float64
-	tmp               string
 }
 
 func NewManager(
@@ -52,7 +51,6 @@ func NewManager(
 	profilingDuration time.Duration,
 	externalLabels model.LabelSet,
 	samplingRatio float64,
-	tmp string,
 ) *Manager {
 	return &Manager{
 		mtx:               &sync.RWMutex{},
@@ -65,7 +63,6 @@ func NewManager(
 		debugInfoClient:   debugInfoClient,
 		profilingDuration: profilingDuration,
 		samplingRatio:     samplingRatio,
-		tmp:               tmp,
 	}
 }
 
@@ -98,7 +95,7 @@ func (m *Manager) reconcileTargets(ctx context.Context, targetSets map[string][]
 				m.ksymCache, objectfile.NewCache(cacheSize),
 				m.writeClient, m.debugInfoClient,
 				m.profilingDuration, m.externalLabels,
-				m.samplingRatio, m.tmp,
+				m.samplingRatio,
 			)
 			m.profilerPools[name] = pp
 		}

--- a/pkg/target/profiler_pool.go
+++ b/pkg/target/profiler_pool.go
@@ -60,7 +60,6 @@ type ProfilerPool struct {
 	debugInfoClient   debuginfo.Client
 	profilingDuration time.Duration
 	samplingRatio     float64
-	tmp               string
 }
 
 func NewProfilerPool(
@@ -73,7 +72,6 @@ func NewProfilerPool(
 	profilingDuration time.Duration,
 	externalLabels model.LabelSet,
 	samplingRatio float64,
-	tmp string,
 ) *ProfilerPool {
 	return &ProfilerPool{
 		mtx:               &sync.RWMutex{},
@@ -88,7 +86,6 @@ func NewProfilerPool(
 		debugInfoClient:   debugInfoClient,
 		profilingDuration: profilingDuration,
 		samplingRatio:     samplingRatio,
-		tmp:               tmp,
 	}
 }
 
@@ -149,7 +146,6 @@ func (pp *ProfilerPool) Sync(ctx context.Context, tg []*Group) {
 				pp.debugInfoClient,
 				newTarget.labelSet,
 				pp.profilingDuration,
-				pp.tmp,
 			)
 
 			go func() {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

With the introduction of the new Go `elfwriter` package, we don't need to keep a temporary state in the local filesystem for interim files. We can directly write to a memory buffer and flush it to the gRPC connection. So this PR exactly does that.

cc @v-thakkar @javierhonduco 