### PR TITLE
chore(nix-shell): fix llvm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,9 @@ OUT_DOCKER ?= ghcr.io/parca-dev/parca-agent
 DOCKER_BUILDER ?= parca-dev/cross-builder
 
 LIBBPF_SRC := 3rdparty/libbpf/src
-LIBBPF_HEADERS := $(OUT_DIR)/libbpf/$(ARCH)/usr/include
-LIBBPF_OBJ := $(OUT_DIR)/libbpf/$(ARCH)/libbpf.a
+LIBBPF_DIR := $(OUT_DIR)/libbpf/$(ARCH)
+LIBBPF_HEADERS := $(LIBBPF_DIR)/usr/include
+LIBBPF_OBJ := $(LIBBPF_DIR)/libbpf.a
 
 VMLINUX := vmlinux.h
 BPF_ROOT := bpf
@@ -65,8 +66,8 @@ CGO_LDFLAGS_STATIC = -fuse-ld=ld $(abspath $(LIBBPF_OBJ))
 CGO_LDFLAGS ?= $(CGO_LDFLAGS_STATIC)
 
 CGO_EXTLDFLAGS =-extldflags=-static
-CGO_CFGLAGS_DYN =-I. -I/usr/include/
-CGO_LDFLAGS_DYN =-fuse-ld=ld -lelf -lz -lbpf
+CGO_CFLAGS_DYN = -I$(abspath $(LIBBPF_HEADERS))
+CGO_LDFLAGS_DYN = -L$(abspath $(LIBBPF_DIR)) -fuse-ld=ld -lelf -lz -lbpf
 
 # possible other CGO flags:
 # CGO_CPPFLAGS ?=

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -1,13 +1,15 @@
 # renovate: datasource=github-releases depName=aya-rs/bpf-linker
 BPF_LINKER_VERSION := v0.9.4
 
+LLVM_SYS_140_PREFIX ?= /usr/lib/llvm-14
+
 .PHONY: setup
 setup:
 	rustup show
 	# we need to do this as we're using an external LLVM. See: https://github.com/aya-rs/bpf-linker#using-external-llvm
 	# TODO(vadorovsky): Remove the LLVM_SYS_140_PREFIX variable once
 	# https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/22 is merged.
-	LLVM_SYS_140_PREFIX=/usr/lib/llvm-14 cargo install --git https://github.com/aya-rs/bpf-linker --tag $(BPF_LINKER_VERSION) --no-default-features --features system-llvm -- bpf-linker
+	LLVM_SYS_140_PREFIX=$(LLVM_SYS_140_PREFIX) cargo install --git https://github.com/aya-rs/bpf-linker --tag $(BPF_LINKER_VERSION) --no-default-features --features system-llvm -- bpf-linker
 
 .PHONY: build
 build:

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -9,7 +9,7 @@ setup:
 	# we need to do this as we're using an external LLVM. See: https://github.com/aya-rs/bpf-linker#using-external-llvm
 	# TODO(vadorovsky): Remove the LLVM_SYS_140_PREFIX variable once
 	# https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/22 is merged.
-	LLVM_SYS_140_PREFIX=$(LLVM_SYS_140_PREFIX) cargo install --git https://github.com/aya-rs/bpf-linker --tag $(BPF_LINKER_VERSION) --no-default-features --features system-llvm -- bpf-linker
+	LLVM_SYS_140_PREFIX=$(LLVM_SYS_140_PREFIX) cargo install --locked --git https://github.com/aya-rs/bpf-linker --tag $(BPF_LINKER_VERSION) --no-default-features --features system-llvm -- bpf-linker
 
 .PHONY: build
 build:

--- a/shell.nix
+++ b/shell.nix
@@ -4,12 +4,13 @@ pkgs.mkShell rec {
   name = "parca-agent";
 
   packages = with pkgs; [
-    clang
+    clang_14
     elfutils.dev
     gnumake
     go_1_18
     kubectl
-    llvm
+    libxml2.dev
+    llvmPackages_14.llvm
     minikube
     pkg-config
     rustup
@@ -26,5 +27,10 @@ pkgs.mkShell rec {
   GOBIN = "${PROJECT_ROOT}/bin";
   RUSTUP_HOME = "${PROJECT_ROOT}/tmp/rustup";
   RUST_BACKTRACE = 1;
+
+  # we need to do this as we're using an external LLVM. See: https://github.com/aya-rs/bpf-linker#using-external-llvm
+  # TODO(vadorovsky): Remove the LLVM_SYS_140_PREFIX variable once
+  # https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/22 is merged.
+  LLVM_SYS_140_PREFIX = "${pkgs.llvmPackages_14.llvm.dev}";
 }
 


### PR DESCRIPTION
Since `bpf-linker` is built with `--features system-llvm`, LLVM 14 needs to be setup properly in `nix-shell` as well. 

~Blocked by NixOS/nixpkgs#148117 (https://nixpk.gs/pr-tracker.html?pr=178007)~