### PR TITLE
fix(statuspage): improve display of next profile

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -295,20 +295,21 @@ func main() {
 				return
 			}
 
-			// We profile every 10 seconds so leaving 1s wiggle room. If after
-			// 11s no profile has matched, then there is very likely no
+			// We profile every ProfilingDuration so leaving 1s wiggle room. If after
+			// ProfilingDuration+1s no profile has matched, then there is very likely no
 			// profiler running that matches the label-set.
-			ctx, cancel := context.WithTimeout(ctx, time.Second*11)
+			timeout := flags.ProfilingDuration + time.Second
+			ctx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
 			profile, err := profileListener.NextMatchingProfile(ctx, matchers)
 			if profile == nil || errors.Is(err, context.Canceled) {
-				http.Error(w,
-					"No profile taken in the last 11 seconds that matches the requested label-matchers query. "+
-						"Profiles are taken every 10 seconds so either the profiler matching the label-set has stopped profiling, "+
+				http.Error(w, fmt.Sprintf(
+					"No profile taken in the last %s that matches the requested label-matchers query. "+
+						"Profiles are taken every %s so either the profiler matching the label-set has stopped profiling, "+
 						"or the label-set was incorrect.",
-					http.StatusNotFound,
-				)
+					timeout, flags.ProfilingDuration,
+				), http.StatusNotFound)
 				return
 			}
 			if err != nil {
@@ -322,7 +323,12 @@ func main() {
 				q := url.Values{}
 				q.Add("query", query)
 
-				fmt.Fprintf(w, "<p><a href='/query?%s'>Download Pprof</a></p>\n", q.Encode())
+				fmt.Fprintf(
+					w,
+					"<p><a title='May take up %s to retrieve' href='/query?%s'>Download Next Pprof</a></p>\n",
+					flags.ProfilingDuration,
+					q.Encode(),
+				)
 				fmt.Fprint(w, "<code><pre>\n")
 				fmt.Fprint(w, profile.String())
 				fmt.Fprint(w, "\n</pre></code>")

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -241,11 +241,12 @@ func main() {
 					q.Add("query", labelSet.String())
 
 					statusPage.ActiveProfilers = append(statusPage.ActiveProfilers, template.ActiveProfiler{
-						Type:         profileType,
-						Labels:       labelSet,
-						LastTakenAgo: time.Since(profiler.LastSuccessfulProfileStartedAt()),
-						Error:        profiler.LastError(),
-						Link:         fmt.Sprintf("/query?%s", q.Encode()),
+						Type:           profileType,
+						Labels:         labelSet,
+						Interval:       flags.ProfilingDuration,
+						NextStartedAgo: time.Since(profiler.NextProfileStartedAt()),
+						Error:          profiler.LastError(),
+						Link:           fmt.Sprintf("/query?%s", q.Encode()),
 					})
 				}
 			}

--- a/pkg/agent/profile_listener.go
+++ b/pkg/agent/profile_listener.go
@@ -94,6 +94,7 @@ func (l *profileListener) NextMatchingProfile(ctx context.Context, matchers []*l
 	o := l.observe(func(r *profilestorepb.WriteRawRequest) {
 		var searchedSeries *profilestorepb.RawProfileSeries
 
+	seriesloop:
 		for _, series := range r.Series {
 			profileLabels := model.LabelSet{}
 
@@ -104,7 +105,7 @@ func (l *profileListener) NextMatchingProfile(ctx context.Context, matchers []*l
 			for _, matcher := range matchers {
 				labelValue := profileLabels[model.LabelName(matcher.Name)]
 				if !matcher.Matches(string(labelValue)) {
-					continue
+					continue seriesloop
 				}
 			}
 			searchedSeries = series

--- a/pkg/template/statuspage.html
+++ b/pkg/template/statuspage.html
@@ -55,37 +55,37 @@ tr:hover {
                 <tr>
                     <th>Profile Type</th>
                     <th>Labels</th>
-                    <th>Last Profile Taken</th>
+                    <th>Next Profile Started</th>
                     <th>Error</th>
-                    <th>Show Profile</th>
+                    <th>Show Next Profile</th>
                 </tr>
-                {{range $profiler := .ActiveProfilers}}
+                {{- range $profiler := .ActiveProfilers }}
                 <tr>
                     <td>
                         {{ .Type }}
                     </td>
                     <td>
-                        {{range $label := .Labels}}
+                        {{- range $label := .Labels }}
                         <span class='label'>{{.Name}}="{{.Value}}"</span>
-                        {{end}}
+                        {{- end }}
                     </td>
                     <td>
-                        {{ .LastTakenAgo }} ago
+                        {{ .NextStartedAgo }} ago
                     </td>
                     <td>
                         {{ .Error }}
                     </td>
                     <td>
-                        <a href='{{ .Link }}'>Show Profile</a>
+                        <a title='May take up to {{ .Interval }} to display' href='{{ .Link }}'>Show Next Profile</a>
                     </td>
                 </tr>
-                {{else}}
+                {{- else }}
                 <tr>
                     <td>
                         No active profilers
                     </td>
                 </tr>
-                {{end}}
+                {{- end }}
             </table>
         </div>
         <div>

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -28,11 +28,12 @@ var StatusPageTemplateBytes []byte
 var StatusPageTemplate = template.Must(template.New("statuspage").Parse(string(StatusPageTemplateBytes)))
 
 type ActiveProfiler struct {
-	Type         string
-	Labels       labels.Labels
-	LastTakenAgo time.Duration
-	Error        error
-	Link         string
+	Type           string
+	Labels         labels.Labels
+	Interval       time.Duration
+	NextStartedAgo time.Duration
+	Error          error
+	Link           string
 }
 
 type StatusPage struct {

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -39,9 +39,10 @@ func TestStatusPageTemplate(t *testing.T) {
 				Name:  "name2",
 				Value: "value2",
 			}},
-			LastTakenAgo: time.Second * 3,
-			Error:        errors.New("test"),
-			Link:         "/test123",
+			Interval:       time.Second * 10,
+			NextStartedAgo: time.Second * 3,
+			Error:          errors.New("test"),
+			Link:           "/test123",
 		}},
 	})
 	require.NoError(t, err)

--- a/pkg/template/testdata/statuspage.html
+++ b/pkg/template/testdata/statuspage.html
@@ -55,21 +55,17 @@ tr:hover {
                 <tr>
                     <th>Profile Type</th>
                     <th>Labels</th>
-                    <th>Last Profile Taken</th>
+                    <th>Next Profile Started</th>
                     <th>Error</th>
-                    <th>Show Profile</th>
+                    <th>Show Next Profile</th>
                 </tr>
-                
                 <tr>
                     <td>
                         test_profile_type
                     </td>
                     <td>
-                        
                         <span class='label'>name1="value1"</span>
-                        
                         <span class='label'>name2="value2"</span>
-                        
                     </td>
                     <td>
                         3s ago
@@ -78,10 +74,9 @@ tr:hover {
                         test
                     </td>
                     <td>
-                        <a href='/test123'>Show Profile</a>
+                        <a title='May take up to 10s to display' href='/test123'>Show Next Profile</a>
                     </td>
                 </tr>
-                
             </table>
         </div>
         <div>


### PR DESCRIPTION
* Use next profile start time instead of last. Last has become less relevant (goes up to 2x duration) and shows 52 years for the first duration
* Change `Show Profile` into `Show Next Profile`
* Add `title` to link (tooltip) informing it may take up to the profiling duration to display
* Trim white-spaces
* Change `Download Pprof` into `Download Next Pprof`, add tooltip as well
* Calculate query timeout based on `--profiling-duration` flag
* Fix `profileListener.NextMatchingProfile()` (it was always returning the first profile)

![image](https://user-images.githubusercontent.com/32458727/174363629-a49b1868-8b07-4928-a83b-a18ded6f331c.png)

Related to #146