### PR TITLE
ci: Enable e2e testing in ci

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -36,7 +36,8 @@ jobs:
               "Makefile",
               "bpf/Makefile",
               "go.mod",
-              "go.sum"
+              "go.sum",
+              "e2e"
             ]
           skip_after_successful_duplicate: false
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -142,7 +142,7 @@ jobs:
             !goreleaser/dist/*.txt
 
   build-and-push-container:
-    name: Container build and push (when merged)
+    name: Container build and push
     needs: build-binaries
     runs-on: ubuntu-latest
     container:
@@ -184,24 +184,72 @@ jobs:
         run: podman images | grep 'ghcr.io/parca-dev/parca-agent'
 
       - name: Install cosign
-        if: ${{ github.event_name != 'pull_request' }}
         uses: sigstore/cosign-installer@7cc35d7fdbe70d4278a0c96779081e6fac665f88 # tag=v2.8.0
 
       - name: Login to registry
-        if: ${{ github.event_name != 'pull_request' }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
           echo "${{ secrets.QUAY_PASSWORD }}" | cosign login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
 
       - name: Install crane
-        if: ${{ github.event_name != 'pull_request' }}
         uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4 # tag=v0.2
 
-      - name: Push and sign container
-        if: ${{ github.event_name != 'pull_request' }}
+      - name: Push container to the test registry for end-to-end tests
+        run: make push-container-test
+
+      - name: Push and sign container (when merged)
         env:
           COSIGN_EXPERIMENTAL: true
         run: |
-          make push-container
-          make sign-container
-          make push-signed-quay-container
+          if [[ ${{ github.event_name }} != 'pull_request' ]]; then
+              make push-container
+              make sign-container
+              make push-signed-quay-container
+          fi
+
+  run-end-to-end-tests:
+    name: run end-to-end tests
+    # e2e tests need nested virtualisation which is only available
+    # on macos runners when using GitHub-hosted runners.
+    runs-on: macos-12
+    needs: build-and-push-container
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # tag=v3.3.0
+        with:
+          go-version-file: .go-version
+
+      - name: Set up jsonnet
+        run: ./env-jsonnet.sh
+
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+
+      - name: Set up kubectl
+        run: brew install kubectl
+
+      - name: Run e2e tests
+        run: make actions-e2e
+
+      - name: Upload kubectl logs
+        run: ./e2e/e2e-dump.sh
+
+      # Uncomment the next two lines to use upterm to debug CI
+      # Run `touch continue` from upterm session to close upterm
+      # and finish this step
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: kubectl e2e dump
+          path: |
+            ./tmp/e2e-dump

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Set up jsonnet
         run: ./env-jsonnet.sh
 
+      - name: Set up jq
+        run: brew install jq
+
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,9 @@ jobs:
         run: make bpf
 
       - name: Set up Jsonnet
+        run: ./env-jsonnet.sh
+
+      - name: Set up environment
         run: ./env.sh
 
       - name: Build

--- a/.github/workflows/jsonnet.yml
+++ b/.github/workflows/jsonnet.yml
@@ -46,6 +46,9 @@ jobs:
           go-version-file: .go-version
 
       - name: Set up Jsonnet
+        run: ./env-jsonnet.sh
+
+      - name: Set up environment
         run: ./env.sh
 
       - name: Generate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,9 @@ jobs:
           go-version-file: .go-version
 
       - name: Set up Jsonnet
+        run: ./env-jsonnet.sh
+
+      - name: Set up environment
         run: ./env.sh
 
       - name: Generate

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,6 @@ push-container:
 push-container-test:
 	podman manifest push --all $(OUT_DOCKER):$(VERSION) docker://$(OUT_DOCKER_TEST):$(VERSION)
 
-
 .PHONY: push-signed-quay-container
 push-signed-quay-container:
 	cosign copy $(OUT_DOCKER):$(VERSION) quay.io/parca/parca:$(VERSION)

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,6 +1,6 @@
 JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
 VERSION ?= $(shell git describe --exact-match --tags $$(git log -n1 --pretty='%h') 2>/dev/null || echo "$$(git rev-parse --abbrev-ref HEAD)-$$(git rev-parse --short HEAD)")
-SERVER_VERSION ?= $(shell curl -s https://api.github.com/repos/parca-dev/parca/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")' | xargs echo -n)
+SERVER_VERSION ?= $(shell curl -s https://api.github.com/repos/parca-dev/parca/releases/latest | grep -oE '"tag_name":(.*)' | grep -o 'v[0-9.]*' | xargs echo -n)
 
 .PHONY: vendor
 vendor:

--- a/deploy/e2e.jsonnet
+++ b/deploy/e2e.jsonnet
@@ -16,7 +16,7 @@ function(version='v0.0.1-alpha.3')
     name: 'parca-agent',
     namespace: ns.metadata.name,
     version: version,
-    image: 'localhost:5000/parca-agent:' + version,
+    image: 'ghcr.io/parca-dev/parca-agent-test:' + version,
     // This assumes there's a running parca in the cluster.
     stores: ['parca.parca.svc.cluster.local:7070'],
     insecure: true,

--- a/e2e/ci-e2e.sh
+++ b/e2e/ci-e2e.sh
@@ -58,7 +58,7 @@ function minikube_down() {
 # Configure clusters to run latest commit in Parca agent
 function deploy() {
     echo "fetching parca binary"
-    SERVER_LATEST_VERSION="v0.12.0" #$(curl -s https://api.github.com/repos/parca-dev/parca/releases/latest | grep -oE '"tag_name":(.*)' | grep -o 'v[0-9.]*'| xargs echo -n)
+    SERVER_LATEST_VERSION=$(curl -sSf https://api.github.com/repos/parca-dev/parca/releases/latest | jq -r .tag_name)
     echo "Server version: $SERVER_LATEST_VERSION"
 
     AGENT_LATEST_VERSION="v0.9.1"

--- a/e2e/ci-e2e.sh
+++ b/e2e/ci-e2e.sh
@@ -61,15 +61,15 @@ function deploy() {
     SERVER_LATEST_VERSION=$(curl -sSf https://api.github.com/repos/parca-dev/parca/releases/latest | jq -r .tag_name)
     echo "Server version: $SERVER_LATEST_VERSION"
 
-    AGENT_LATEST_VERSION="v0.9.1"
+    #AGENT_LATEST_VERSION=$(curl -sSf https://api.github.com/repos/parca-dev/parca-agent/releases/latest | jq -r .tag_name)
 
     kubectl create namespace parca
 
     kubectl apply -f https://github.com/parca-dev/parca/releases/download/"$SERVER_LATEST_VERSION"/kubernetes-manifest.yaml
     kubectl -n parca rollout status deployment/parca --timeout=2m
 
-    kubectl apply -f https://github.com/parca-dev/parca-agent/releases/download/"$AGENT_LATEST_VERSION"/kubernetes-manifest.yaml
-    #kubectl apply -f ./manifests/local/
+    #kubectl apply -f https://github.com/parca-dev/parca-agent/releases/download/"$AGENT_LATEST_VERSION"/kubernetes-manifest.yaml
+    kubectl apply -f ./manifests/local/
     kubectl -n parca rollout status daemonset/parca-agent --timeout=2m
 
     echo "Connecting to Parca and Parca agent"
@@ -77,14 +77,6 @@ function deploy() {
     sleep 300
 
     kubectl get all -A
-}
-
-function check_ns_parca() {
-    ns_status=$(kubectl get ns parca)
-    if [ $? -ne 0 ]; then
-        return 1
-    fi
-    echo "namespace parca already present"
 }
 
 # Build image with latest commit

--- a/e2e/ci-e2e.sh
+++ b/e2e/ci-e2e.sh
@@ -19,14 +19,15 @@
 #
 ################################################################################
 
-set -euo pipefail
+set -euox pipefail
 
 function run() {
     # Driver set to virtualbox by default if not specified
     DRIVER=${1-virtualbox}
+    VERSION=$2
 
-    minikube_up "${DRIVER}"
-    generate_manifests
+    minikube_up "$DRIVER"
+    generate_manifests "$VERSION"
     deploy
 }
 
@@ -39,11 +40,9 @@ function minikube_up() {
     minikube start -p parca-e2e \
         --container-runtime=docker \
         --insecure-registry="localhost:5000" \
-        --driver="${DRIVER}" \
+        --driver="$DRIVER" \
+        --feature-gates=EphemeralContainers=true \
         --kubernetes-version=v1.22.3 \
-        --cpus=4 \
-        --memory=16gb \
-        --disk-size=20gb \
         --docker-opt dns=8.8.8.8 \
         --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
 
@@ -58,31 +57,31 @@ function minikube_down() {
 
 # Configure clusters to run latest commit in Parca agent
 function deploy() {
-    SERVER_LATEST_VERSION=$(curl -s https://api.github.com/repos/parca-dev/parca/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")' | xargs echo -n)
+    echo "fetching parca binary"
+    SERVER_LATEST_VERSION="v0.12.0" #$(curl -s https://api.github.com/repos/parca-dev/parca/releases/latest | grep -oE '"tag_name":(.*)' | grep -o 'v[0-9.]*'| xargs echo -n)
     echo "Server version: $SERVER_LATEST_VERSION"
 
-    if ! check_ns_parca; then
-        kubectl create namespace parca
-    fi
+    AGENT_LATEST_VERSION="v0.9.1"
+
+    kubectl create namespace parca
 
     kubectl apply -f https://github.com/parca-dev/parca/releases/download/"$SERVER_LATEST_VERSION"/kubernetes-manifest.yaml
     kubectl -n parca rollout status deployment/parca --timeout=2m
 
-    kubectl apply -f ./manifests/local/manifest-e2e.yaml
+    kubectl apply -f https://github.com/parca-dev/parca-agent/releases/download/"$AGENT_LATEST_VERSION"/kubernetes-manifest.yaml
+    #kubectl apply -f ./manifests/local/
     kubectl -n parca rollout status daemonset/parca-agent --timeout=2m
 
     echo "Connecting to Parca and Parca agent"
 
-    kubectl port-forward -n parca service/parca 7070 &
-    kubectl port-forward -n parca daemonset/parca-agent 7071:7071 &
-}
+    sleep 300
 
-function vendor() {
-    jb install
+    kubectl get all -A
 }
 
 function check_ns_parca() {
-    if ! kubectl get ns parca >/dev/null; then
+    ns_status=$(kubectl get ns parca)
+    if [ $? -ne 0 ]; then
         return 1
     fi
     echo "namespace parca already present"
@@ -90,21 +89,11 @@ function check_ns_parca() {
 
 # Build image with latest commit
 function generate_manifests() {
-    BRANCH=${GITHUB_BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)-}
-
-    if [[ -z "${GITHUB_SHA:-}" ]]; then
-        COMMIT=$(git describe --no-match --dirty --always --abbrev=8)
-    else
-        COMMIT=${GITHUB_SHA:0:8}
-    fi
-
-    VERSION=${RELEASE_TAG:-$(git describe --tags 2>/dev/null || echo "${BRANCH}${COMMIT}")}
+    VERSION=$1
 
     rm -rf manifests/local
     mkdir -p manifests/local
 
+    make vendor
     jsonnet --tla-str version="$VERSION" -J vendor e2e.jsonnet -m manifests/local | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}'
-    awk 'BEGINFILE {print "---"}{print}' manifests/local/* >manifests/local/manifest-e2e.yaml
-
-    docker build -t localhost:5000/parca-agent:"$VERSION" ./..
 }

--- a/e2e/e2e-dump.sh
+++ b/e2e/e2e-dump.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkdir -p ./tmp/e2e-dump
+cd ./tmp/e2e-dump
+touch kube-all kube-all.yaml
+kubectl get all -A >kube-all
+kubectl get all -A -o yaml >kube-all.yaml
+
+list=$(kubectl get pods -A --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}')
+
+IFS=$'\n'
+
+for pod in $list; do
+    #depending on logs, this may take a while
+    #kubectl logs $pod > $pod.txt
+    echo "$pod" | xargs -n2 sh -c 'kubectl logs --all-containers --ignore-errors --namespace=$0 $1 > $0-$1.logs'
+done

--- a/e2e/e2e-dump.sh
+++ b/e2e/e2e-dump.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euox pipefail
+
 mkdir -p ./tmp/e2e-dump
 cd ./tmp/e2e-dump
 touch kube-all kube-all.yaml
@@ -26,5 +28,5 @@ IFS=$'\n'
 for pod in $list; do
     #depending on logs, this may take a while
     #kubectl logs $pod > $pod.txt
-    echo "$pod" | xargs -n2 sh -c 'kubectl logs --all-containers --ignore-errors --namespace=$0 $1 > $0-$1.logs'
+    echo "$pod" | xargs -n2 sh -c "kubectl logs --all-containers --ignore-errors --namespace=$pod >> pod.logs"
 done

--- a/e2e/podportforward.go
+++ b/e2e/podportforward.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+func GetKubeConfig(kubeconfig string) (*rest.Config, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build config with given path %s: %s", kubeconfig, err)
+	}
+	return cfg, nil
+}
+
+func StartPortForward(ctx context.Context, cfg *rest.Config, scheme, name, ns, port string) (func(), error) {
+	roundTripper, upgrader, err := spdy.RoundTripperFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", ns, name)
+	hostIP := strings.TrimLeft(cfg.Host, "htps:/")
+	serverURL := url.URL{Scheme: scheme, Path: path, Host: hostIP}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
+
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+	forwarder, err := portforward.New(dialer, []string{port}, stopChan, readyChan, out, errOut)
+	if err != nil {
+		return nil, err
+	}
+
+	forwardErr := make(chan error, 1)
+	go func() {
+		if err := forwarder.ForwardPorts(); err != nil {
+			forwardErr <- err
+		}
+		close(forwardErr)
+	}()
+
+	select {
+	case <-readyChan:
+		return func() { close(stopChan) }, nil
+	case <-ctx.Done():
+		var err error
+		select {
+		case err = <-forwardErr:
+		default:
+		}
+		return nil, fmt.Errorf("%v: %v", ctx.Err(), err)
+	}
+}

--- a/e2e/podportforward.go
+++ b/e2e/podportforward.go
@@ -30,7 +30,7 @@ import (
 func GetKubeConfig(kubeconfig string) (*rest.Config, error) {
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to build config with given path %s: %s", kubeconfig, err)
+		return nil, fmt.Errorf("unable to build config with given path %v: %w", kubeconfig, err)
 	}
 	return cfg, nil
 }
@@ -70,6 +70,6 @@ func StartPortForward(ctx context.Context, cfg *rest.Config, scheme, name, ns, p
 		case err = <-forwardErr:
 		default:
 		}
-		return nil, fmt.Errorf("%v: %v", ctx.Err(), err)
+		return nil, fmt.Errorf("%w: %v", ctx.Err(), err)
 	}
 }

--- a/env-jsonnet.sh
+++ b/env-jsonnet.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+# Copyright (c) 2022 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+# renovate: datasource=go depName=github.com/brancz/gojsontoyaml
+GOJSONTOYAML_VERSION='v0.1.0'
+go install "github.com/brancz/gojsontoyaml@${GOJSONTOYAML_VERSION}"
+
+# renovate: datasource=go depName=github.com/google/go-jsonnet
+# the latest version breaks on darwin
+JSONNET_VERSION='b42132a7a37d27d8cee21c02d56243b6bcf5e3fb'
+go install "github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}"
+go install "github.com/google/go-jsonnet/cmd/jsonnetfmt@${JSONNET_VERSION}"
+
+# renovate: datasource=go depName=github.com/jsonnet-bundler/jsonnet-bundler
+JB_VERSION='v0.5.1'
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@${JB_VERSION}

--- a/env.sh
+++ b/env.sh
@@ -1,19 +1,6 @@
 #! /usr/bin/env bash
 set -euo pipefail
 
-# renovate: datasource=go depName=github.com/brancz/gojsontoyaml
-GOJSONTOYAML_VERSION='v0.1.0'
-go install "github.com/brancz/gojsontoyaml@${GOJSONTOYAML_VERSION}"
-
-# renovate: datasource=go depName=github.com/google/go-jsonnet
-JSONNET_VERSION='v0.18.0'
-go install "github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}"
-go install "github.com/google/go-jsonnet/cmd/jsonnetfmt@${JSONNET_VERSION}"
-
-# renovate: datasource=go depName=github.com/jsonnet-bundler/jsonnet-bundler
-JB_VERSION='v0.5.1'
-go install "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@${JB_VERSION}"
-
 # renovate: datasource=go depName=github.com/campoy/embedmd
 EMBEDMD_VERSION='v2.0.0'
 go install "github.com/campoy/embedmd/v2@${EMBEDMD_VERSION}"

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mozillazg/go-httpheader v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/aquasecurity/libbpfgo v0.4.2-libbpf-1.0.1/go.mod h1:v+Nk+v6BtHLfdT4kV
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/aws/aws-sdk-go v1.44.102 h1:6tUCTGL2UDbFZae1TLGk8vTgeXuzkb8KbAe2FiAeKHc=
@@ -208,6 +209,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/efficientgo/e2e v0.12.1 h1:ZYNTf09ptlba0I3ZStYaF7gCbevWdalriiX7usOSiFM=
 github.com/efficientgo/tools/core v0.0.0-20220817170617-6c25e3b627dd h1:svR6KxSP1xiPw10RN4Pd7g6BAVkEcNN628PAqZH31mM=
 github.com/efficientgo/tools/core v0.0.0-20220817170617-6c25e3b627dd/go.mod h1:OmVcnJopJL8d3X3sSXTiypGoUSgFq1aDGmlrdi9dn/M=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -490,6 +492,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -42,6 +42,7 @@ type RowState struct {
 	cfa  DWRule
 	regs map[uint64]DWRule
 }
+
 type StateStack struct {
 	items []RowState
 }


### PR DESCRIPTION
Modify actions and tests to allow e2e testing in parca agent.

For every PR, a test image of parca agent is created(hosted at parca-agent-test)
which is then tested alongwith the latest release of parca server
within a minikube setup in CI.

Add support for debugging opaque failures in CI using upterm shell.

All scripts and tests can be found in the `e2e` directory in parca-agent

Co-developed-by: Frederic Branczyk
Signed-off-by: Sumera Priyadarsini <sylphrenadin@gmail.com>