### PR TITLE
build: Add race detector flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,9 +133,6 @@ jobs:
         run: make build
 
       - name: Test
-        run: make test
-
-      - name: Test with race detector
         run: make test ENABLE_RACE=yes
 
       - name: Format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Test with race detector
+        run: make test ENABLE_RACE=yes
+
       - name: Format
         run: |
           make format

--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,12 @@ $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 endif
 
 test/profiler: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
-	sudo $(go_env) go test -v $(shell go list ./... | grep "pkg/profiler") $(SANITIZERS)
+	sudo $(go_env) go test $(SANITIZERS) -v $(shell go list ./... | grep "pkg/profiler")
 
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf test/profiler
-	$(go_env) go test -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler" | grep -v "e2e")
+	$(go_env) go test $(SANITIZERS) -v $(shell go list ./... | grep -v "internal/pprof" | grep -v "pkg/profiler" | grep -v "e2e")
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,16 @@ ARCH_UNAME := $(shell uname -m)
 
 # sanitizer config:
 ENABLE_ASAN := no
+ENABLE_RACE := no
 
 ifeq ($(ENABLE_ASAN), yes)
-	SANITIZER ?= -asan
+	SANITIZERS += -asan
 endif
+
+ifeq ($(ENABLE_RACE), yes)
+	SANITIZERS += -race
+endif
+
 
 ifeq ($(ARCH_UNAME), x86_64)
 	ARCH ?= amd64
@@ -79,7 +85,7 @@ go_env := GOOS=linux GOARCH=$(ARCH:x86_64=amd64) CC=$(CMD_CLANG) CGO_CFLAGS="-I 
 ifndef DOCKER
 $(OUT_BIN): libbpf $(filter-out *_test.go,$(GO_SRC)) go/deps | $(OUT_DIR)
 	find dist -exec touch -t 202101010000.00 {} +
-	$(go_env) go build $(SANITIZER) -tags osusergo,netgo --ldflags="-extldflags=-static" -trimpath -v -o $(OUT_BIN) ./cmd/parca-agent
+	$(go_env) go build $(SANITIZERS) -tags osusergo,netgo --ldflags="-extldflags=-static" -trimpath -v -o $(OUT_BIN) ./cmd/parca-agent
 else
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@ VERSION=$(VERSION))
@@ -87,12 +93,12 @@ endif
 
 .PHONY: build-dyn
 build-dyn:
-	$(go_env) go build $(SANITIZER) -tags osusergo,netgo -trimpath -v -o $(OUT_BIN) ./cmd/parca-agent
+	$(go_env) go build $(SANITIZERS) -tags osusergo,netgo -trimpath -v -o $(OUT_BIN) ./cmd/parca-agent
 
 ifndef DOCKER
 $(OUT_BIN_DEBUG_INFO): go/deps
 	find dist -exec touch -t 202101010000.00 {} +
-	CGO_ENABLED=0 go build $(SANITIZER) -trimpath -v -o $(OUT_BIN_DEBUG_INFO) ./cmd/debug-info
+	CGO_ENABLED=0 go build $(SANITIZERS) -trimpath -v -o $(OUT_BIN_DEBUG_INFO) ./cmd/debug-info
 else
 $(OUT_BIN_DEBUG_INFO): $(DOCKER_BUILDER) go/deps | $(OUT_DIR)
 	$(call docker_builder_make,$@ VERSION=$(VERSION))
@@ -135,7 +141,7 @@ $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 endif
 
 test/profiler: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) bpf
-	sudo $(go_env) go test -v $(shell go list ./... | grep "pkg/profiler") $(SANITIZER)
+	sudo $(go_env) go test -v $(shell go list ./... | grep "pkg/profiler") $(SANITIZERS)
 
 .PHONY: test
 ifndef DOCKER


### PR DESCRIPTION
Let's add [Golang's race detector](https://go.dev/doc/articles/race_detector) to our Makefile. I have been running it in my test environment, and it showed zero errors, even under a lot of pressure (lots of concurrent debug info uploads, etc).

With the `GORACE="log_path=/tmp/race"` env variable we can pick a path where to write its output, rather than stdout / stderr.


Right now we should run this locally, but once https://github.com/parca-dev/parca-agent/issues/463 lands, this will be run in CI, too! 🎉 

Fixes: https://github.com/parca-dev/parca-agent/issues/445
## Test plan

**Build without sanitisers works**:

```
[javierhonduco@computer parca-agent]$ make build-dyn 
GOOS=linux GOARCH=amd64 CC=clang CGO_CFLAGS="-I /home/javierhonduco/code/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/javierhonduco/code/parca-agent/dist/libbpf/libbpf.a" go build  -tags osusergo,netgo -trimpath -v -o dist/parca-agent ./cmd/parca-agent
```

**Build with ASAN works**:

```
[javierhonduco@computer parca-agent]$ make build-dyn ENABLE_ASAN=yes
GOOS=linux GOARCH=amd64 CC=clang CGO_CFLAGS="-I /home/javierhonduco/code/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/javierhonduco/code/parca-agent/dist/libbpf/libbpf.a" go build -asan -tags osusergo,netgo -trimpath -v -o dist/parca-agent ./cmd/parca-agent
```

**Build with race detector works**:

```
[javierhonduco@computer parca-agent]$ make build-dyn ENABLE_RACE=yes
GOOS=linux GOARCH=amd64 CC=clang CGO_CFLAGS="-I /home/javierhonduco/code/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/javierhonduco/code/parca-agent/dist/libbpf/libbpf.a" go build -race -tags osusergo,netgo -trimpath -v -o dist/parca-agent ./cmd/parca-agent
```

_note_ ASAN + race isn't supported yet. I don't think we should check for this in the Makefile as it will increase its complexity and this is something that might change in the future:

```
[javierhonduco@computer parca-agent]$ make build-dyn ENABLE_ASAN=yes ENABLE_RACE=yes
GOOS=linux GOARCH=amd64 CC=clang CGO_CFLAGS="-I /home/javierhonduco/code/parca-agent/dist/libbpf/usr/include" CGO_LDFLAGS="/home/javierhonduco/code/parca-agent/dist/libbpf/libbpf.a" go build -asan -race -tags osusergo,netgo -trimpath -v -o dist/parca-agent ./cmd/parca-agent
go: may not use -race and -asan simultaneously
```

(`make test ENABLE_RACE=yes` and `make test ENABLE_ASAN=yes` also worked without issues)

