### PR TITLE
chore(deps): use full tag for gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Initialize and update libbpf submodule
         run: git submodule init && git submodule update
 
-      - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # tag=v3
+      - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # tag=v3.0.4
         with:
           # In order:
           # * Module download cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "BPF_OUT=$(pwd)/dist" >> $GITHUB_ENV
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # tag=v3
+        uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # tag=v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           distribution: goreleaser
@@ -88,7 +88,7 @@ jobs:
           cp deploy/manifests/openshift/manifest.yaml deploy/openshift-manifest.yaml
 
       - name: Release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # tag=v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # tag=v0.1.14
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
Follow up on #491, that pinned a few actions I had missed in #485.

Without the tags used by releases, we would get obscure digest updates, instead of pretty release notes