### PR TITLE
chore(renovate): fix gh actions _VERSION regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -87,7 +87,7 @@
       "description": "Update _VERSION variables in GitHub workflows",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s*[A-Z_]+?_VERSION: ('|\")?(?<currentValue>.+?)('|\")?"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s*[A-Z_]+?_VERSION: ('|\")?(?<currentValue>.+?)('|\")?\\s"
       ]
     },
     {


### PR DESCRIPTION
It does not currently match until the end of line, match only `1` for Go `1.18.3` for example