### PR TITLE
ci: fix golangci-lint version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,9 @@ jobs:
           cd bpf && cargo check
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+        run: |
+          curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/${{ env.GOLANGCI_LINT_VERSION }}/install.sh' \
+            | sh -s -- -b "$(go env GOPATH)/bin" '${{ env.GOLANGCI_LINT_VERSION }}'
 
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@${{ env.GOFUMPT_VERSION }}


### PR DESCRIPTION
Fixes:

```
/home/runner/work/_temp/420af443-00f1-4def-b386-9035d4dc1c24.sh: line 1: GOLANGCI_LINT_VERSION: command not found
golangci/golangci-lint info checking GitHub for latest tag
```