### PR TITLE
chore(renovate): disable git-submodules updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,22 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>parca-dev/.github"],
   "reviewers": ["team:agent-maintainers"],
-  "git-submodules": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "description": "Use custom versioning for libbpfgo",
       "matchPackageNames": ["github.com/aquasecurity/libbpfgo"],
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<build>.+))?$"
-    },
-    {
-      "description": "Group libbpfgo and libbpf",
-      "matchPackageNames": [
-        "github.com/aquasecurity/libbpfgo",
-        "github.com/libbpf/libbpf"
-      ],
-      "groupName": "libbpf"
     }
   ]
 }


### PR DESCRIPTION
The `git-submodules` manager follow the `HEAD` of the repository instead of the tags, some comments in the feature request seemed to indicate it could be working, which prompted me to test it.

https://docs.renovatebot.com/modules/manager/git-submodules/#open-feature-requests