### PR TITLE
debuginfo: Add more logging

### DIFF
--- a/pkg/debuginfo/debuginfo.go
+++ b/pkg/debuginfo/debuginfo.go
@@ -130,13 +130,13 @@ func (di *DebugInfo) EnsureUploaded(ctx context.Context, objFiles []*objectfile.
 		}()
 
 		if err := di.Extract(ctx, buf, src); err != nil {
-			level.Debug(di.logger).Log("msg", "failed to extract debug information", "err", err)
+			level.Debug(di.logger).Log("msg", "failed to extract debug information", "err", err, "buildID", buildID, "path", src)
 			continue
 		}
 
 		buf.SeekStart()
 		if err := validate(buf); err != nil {
-			level.Debug(logger).Log("msg", "failed to validate debug information", "err", err)
+			level.Debug(logger).Log("msg", "failed to validate debug information", "err", err, "buildID", buildID, "path", src)
 			continue
 		}
 


### PR DESCRIPTION
As this method is executed concurrently, it's helpful during debugging to have the buildID as well as the path logged in case of error.

This was very helpful while starting to debug https://github.com/parca-dev/parca-agent/issues/543