### PR TITLE
build: Ensure we clean dist/ on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ clean: mostlyclean
 	if [ -r "$$FILE" ] ; then \
 		$(CMD_DOCKER) rmi "$$(< $$FILE)" ; \
 	fi
+	rm -rf $(OUT_DIR)
 	$(MAKE) -C $(LIBBPF_SRC) clean
 	$(MAKE) -C $(BPF_ROOT) clean
 


### PR DESCRIPTION
Please do let me know if there's a better approach. This fixes `make clean` not cleaning out dist/ which among other things contains the built libbpf archive.

Not sure how Make actually works but I guess that when libbpf got bumped and we updated the git submodule, running `make build` doesn't regenerate the libbpf archive because it's already in the filesystem and it doesn't know what the source is, so can't tell if it needs to re-build?

Either way, while this doesn't address the root problem, it unblocks https://github.com/parca-dev/parca-agent/issues/545