### PR TITLE
ci: fix image manifest push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ container: $(OUT_DIR)
 	podman build \
 		--platform linux/amd64,linux/arm64 \
 		--timestamp 0 \
-		--tag $(OUT_DOCKER):$(VERSION) .
+		--manifest $(OUT_DOCKER):$(VERSION) .
 
 .PHONY: container-dev
 container-dev:


### PR DESCRIPTION
I have not tested pushing, but ~I have a hunch~ Podman's `--tag` behave like the classic `docker build`, rather than changing to Docker Buildx's behavior with `--platform`, so platforms override one after the other and `--manifest` must be used instead

> When more than one platform is specified, the `--manifest` option should be used instead of the `--tag` option.

https://docs.podman.io/en/latest/markdown/podman-build.1.html#platform-os-arch-variant

Fixes #559 