### PR TITLE
deploy: Remove kubernetes arch label restriction

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -301,7 +301,6 @@ function(params) {
             serviceAccountName: pa.serviceAccount.metadata.name,
             nodeSelector: {
               'kubernetes.io/os': 'linux',
-              'kubernetes.io/arch': 'amd64',
             },
             tolerations: [
               {


### PR DESCRIPTION
Parca Agent now supports multiple architectures, so a nodeSelector to restrict it to amd64 nodes is no longer needed.