### PR TITLE
chore(deps): pin rust crates

### DIFF
--- a/bpf/xtask/Cargo.toml
+++ b/bpf/xtask/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = { version = "0.3.26", default-features = false }
-anyhow = "1.0.58"
+structopt = { version = "=0.3.26", default-features = false }
+anyhow = "=1.0.58"

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>parca-dev/.github"],
   "reviewers": ["team:agent-maintainers"],
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "description": "Use custom versioning for libbpfgo",


### PR DESCRIPTION
The default is equivalent to a caret: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements