### PR TITLE
profiler: Add cgroup name to the process metadata

### DIFF
--- a/pkg/metadata/utils.go
+++ b/pkg/metadata/utils.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func parseCgroupFileContents(data string) (string, error) {
+	lines := strings.Split(data, "\n")
+	line := ""
+	// No newline or just a trailing one
+	if len(lines) == 1 || len(lines) == 2 {
+		line = lines[0]
+	} else {
+		foundCPUController := false
+		for _, currentLine := range lines {
+			if strings.Contains(currentLine, "cpu") && !strings.Contains(currentLine, "cpuset") {
+				line = currentLine
+				foundCPUController = true
+				break
+			}
+		}
+
+		if !foundCPUController {
+			for _, currentLine := range lines {
+				if strings.Contains(currentLine, "systemd") {
+					line = currentLine
+					break
+				}
+			}
+		}
+	}
+
+	splittedCgroupPath := strings.Split(line, ":")
+	if len(splittedCgroupPath) < 2 {
+		return "", fmt.Errorf("cgroup data did not have the expected format, line: %s", line)
+	}
+	cgroupName := strings.TrimSpace(strings.Join(splittedCgroupPath[2:], ""))
+	return cgroupName, nil
+}
+
+func CgroupName(pid int) (string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+
+	name, err := parseCgroupFileContents(string(data))
+	if err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/pkg/metadata/utils_test.go
+++ b/pkg/metadata/utils_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThing(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "single cgroup path",
+			contents: "0::/system.slice/systemd-journald.service\n",
+			want:     "/system.slice/systemd-journald.service",
+			wantErr:  false,
+		},
+		{
+			name:     "single cgroup path without trailing newline",
+			contents: "0::/system.slice/systemd-journald.service",
+			want:     "/system.slice/systemd-journald.service",
+			wantErr:  false,
+		},
+		{
+			name:     "deeper cgroup path",
+			contents: "0::/user.slice/user-1000.slice/user@1000.service/init.scope\n",
+			want:     "/user.slice/user-1000.slice/user@1000.service/init.scope",
+			wantErr:  false,
+		},
+		{
+			name:     "root cgroup path",
+			contents: "0::/",
+			want:     "/",
+			wantErr:  false,
+		},
+		{
+			name: "extract cpu controller from multiple cgroup controllers",
+			contents: `11:hugetlb:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+10:pids:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+9:blkio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+8:net_cls,net_prio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+7:cpuset:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+6:devices:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+5:memory:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+4:perf_event:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+3:cpu,cpuacct:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-09af509f3db677a2275723fc71bff3d9b6d19e4d404c44822f2262f700adcd4b.scope
+2:freezer:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+`,
+			want:    "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-09af509f3db677a2275723fc71bff3d9b6d19e4d404c44822f2262f700adcd4b.scope",
+			wantErr: false,
+		},
+		{
+			name: "extract cpu controller from multiple cgroup controllers",
+			contents: `11:hugetlb:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+9:pids:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+8:blkio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+7:net_cls,net_prio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+6:cpuset:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+5:devices:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+4:memory:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+3:perf_event:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+2:freezer:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-a.scope
+1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-09af509f3db677a2275723fc71bff3d9b6d19e4d404c44822f2262f700adcd4b.scope
+`,
+			want:    "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1ff39434b35faeef64159d11e3f96024.slice/docker-09af509f3db677a2275723fc71bff3d9b6d19e4d404c44822f2262f700adcd4b.scope",
+			wantErr: false,
+		},
+		{
+			name:     "malformed path does not panic",
+			contents: "_",
+			wantErr:  true,
+		},
+		{
+			name:     "empty path does not panic",
+			contents: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCgroupFileContents(tt.contents)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/profiler/cpu.go
+++ b/pkg/profiler/cpu.go
@@ -48,6 +48,7 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/discovery"
 	"github.com/parca-dev/parca-agent/pkg/ksym"
 	"github.com/parca-dev/parca-agent/pkg/maps"
+	"github.com/parca-dev/parca-agent/pkg/metadata"
 	"github.com/parca-dev/parca-agent/pkg/objectfile"
 	"github.com/parca-dev/parca-agent/pkg/perf"
 )
@@ -431,6 +432,14 @@ func (p *CPUProfiler) addProcessMetadata(group profileGroupKey) []*profilestorep
 		extraMetadata = append(extraMetadata, &label)
 
 		level.Debug(p.logger).Log("msg", "Added metadata to profile", "pid", int(group), "key", key, "value", value)
+	}
+
+	// Add the cgroup name.
+	cgroupName, err := metadata.CgroupName(int(group))
+	if err == nil {
+		extraMetadata = append(extraMetadata, &profilestorepb.Label{Name: "cgroup_name", Value: cgroupName})
+	} else {
+		level.Debug(p.logger).Log("msg", "Could not read cgroup name", "pid", int(group), "err", err)
 	}
 
 	return extraMetadata


### PR DESCRIPTION
## Test plan

**Added tests**:

```
$ make test/profiler
--- PASS: TestGetValueAndDeleteBatchExactElements (0.00s)
=== RUN   TestThing
=== RUN   TestThing/single_cgroup_path
=== RUN   TestThing/single_cgroup_path_without_trailing_newline
=== RUN   TestThing/deeper_cgroup_path
=== RUN   TestThing/root_cgroup_path
=== RUN   TestThing/extract_cpu_controller_from_multiple_cgroup_controllers
=== RUN   TestThing/extract_cpu_controller_from_multiple_cgroup_controllers#01
=== RUN   TestThing/malformed_path_does_not_panic
=== RUN   TestThing/empty_path_does_not_panic
--- PASS: TestThing (0.00s)
    --- PASS: TestThing/single_cgroup_path (0.00s)
    --- PASS: TestThing/single_cgroup_path_without_trailing_newline (0.00s)
    --- PASS: TestThing/deeper_cgroup_path (0.00s)
    --- PASS: TestThing/root_cgroup_path (0.00s)
    --- PASS: TestThing/extract_cpu_controller_from_multiple_cgroup_controllers (0.00s)
    --- PASS: TestThing/extract_cpu_controller_from_multiple_cgroup_controllers#01 (0.00s)
    --- PASS: TestThing/malformed_path_does_not_panic (0.00s)
    --- PASS: TestThing/empty_path_does_not_panic (0.00s)
PASS
ok  	github.com/parca-dev/parca-agent/pkg/profiler	(cached)
```
**Bare metal**
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/959128/182389949-5b40e6d5-4121-434f-8841-1b0c1fe73c88.png">


**K8s**
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/959128/182389899-a6d0aa19-561f-4865-a2d1-a6b2267b1fa2.png">


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>