### PR TITLE
debuginfo: Increase exists cache size

### DIFF
--- a/pkg/debuginfo/debuginfo.go
+++ b/pkg/debuginfo/debuginfo.go
@@ -52,8 +52,8 @@ func New(logger log.Logger, client Client) *DebugInfo {
 		logger: logger,
 		client: client,
 		existsCache: cache.New(
-			cache.WithMaximumSize(128),                // Arbitrary cache size.
-			cache.WithExpireAfterWrite(2*time.Minute), // Arbitrary period.
+			cache.WithMaximumSize(512),                 // Arbitrary cache size.
+			cache.WithExpireAfterWrite(15*time.Minute), // Arbitrary period.
 		),
 		debugInfoSrcCache: cache.New(cache.WithMaximumSize(128)), // Arbitrary cache size.
 		// Up to this amount of debug files in flight at once. This number is very large
@@ -128,7 +128,6 @@ func (di *DebugInfo) EnsureUploaded(ctx context.Context, objFiles []*objectfile.
 		// If we found a debuginfo file, either in file or on the system, we upload it to the server.
 		if err := di.Upload(ctx, SourceInfo{BuildID: buildID, Path: src}, buf); err != nil {
 			if errors.Is(err, debuginfo.ErrDebugInfoAlreadyExists) {
-				// If already exists, we should mark as exists in cache!
 				di.existsCache.Put(buildID, struct{}{})
 				level.Debug(logger).Log("msg", "debug information has already been uploaded or exists in server")
 				continue


### PR DESCRIPTION
and increase the cache expiration time

Spotted this while running the Agent for several minutes. The rationale for this change is that:
- The increase in memory usage won't be very large: from 2,048 bytes to 6,144 bytes (+ the overhead of the cache data structures)

(Also removed an outdated comment).

Let me know what you think and if I missed anything

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>
