### PR TITLE
ci: improve linting of Rust code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ env:
   GOFUMPT_VERSION: v0.3.1
   # renovate: datasource=go depName=github.com/golangci/golangci-lint
   GOLANGCI_LINT_VERSION: v1.47.2
+  RUSTFLAGS: --deny warnings
+  RUSTDOCFLAGS: --deny warnings
 
 jobs:
   skip-check:
@@ -80,9 +82,10 @@ jobs:
           sudo apt-get install -yq llvm-14-dev libclang-14-dev
 
       - name: Run eBPF toolchain setup
-        run: |
-          make -C bpf setup
-          cd bpf && cargo check
+        run: make -C bpf setup
+
+      - name: Lint Rust
+        run: make -C bpf lint
 
       - name: Build BPF
         run: make bpf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,9 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Set up gofumpt
+        run: go install "mvdan.cc/gofumpt@${GOFUMPT_VERSION}"
+
       - name: Set up Rust
         # Yes, oddly `rustup show` installs the toolchain (:
         # https://github.com/rust-lang/rustup/issues/2686
@@ -83,9 +86,6 @@ jobs:
 
       - name: Run eBPF toolchain setup
         run: make -C bpf setup
-
-      - name: Lint Rust
-        run: make -C bpf lint
 
       - name: Build BPF
         run: make bpf
@@ -110,12 +110,10 @@ jobs:
           # make test/profiler (Needs to be fixed, somehow fails because of generics)
 
       - name: Format
-        run: |
-          make format
-          git diff --exit-code
+        run: make format-check
 
-      - name: Vet
-        run: make vet
+      - name: Lint Rust
+        run: make -C bpf lint
 
       - name: Lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # tag=v3.2.0

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,36 @@
+name: "Cargo Audit"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '28 16 * * 3'
+
+env:
+  # renovate: datasource=crate depName=cargo-audit versioning=cargo
+  CARGO_AUDIT_VERSION: =0.17.0
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - name: Set up Rust
+        run: rustup show
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # tag=v1.4.0
+        with:
+          working-directory: ./bpf
+
+      - name: Set up cargo-audit
+        run: cargo install --locked cargo-audit --version "${CARGO_AUDIT_VERSION}"
+
+      - name: Audit
+        run: cd bpf && cargo audit --deny warnings

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,6 +9,8 @@ on:
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
   GORELEASER_VERSION: v1.10.3
+  RUSTFLAGS: --deny warnings
+  RUSTDOCFLAGS: --deny warnings
 
 jobs:
   skip-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
   GORELEASER_VERSION: v1.10.3
+  RUSTFLAGS: --deny warnings
+  RUSTDOCFLAGS: --deny warnings
 
 jobs:
   dependencies:

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ go/fmt:
 
 .PHONY: go/fmt-check
 go/fmt-check:
-	@test -z $(shell gofumpt -d -extra $(shell $(GO) list -f '{{.Dir}}' -find ./... | grep -Ev "internal/pprof|internal/go") | tee /dev/stderr >/dev/null)
+	@test -z "$(shell gofumpt -d -extra $(shell $(GO) list -f '{{.Dir}}' -find ./... | grep -Ev "internal/pprof|internal/go") | tee /dev/stderr)"
 
 # clean:
 .PHONY: mostlyclean

--- a/bpf/Cargo.lock
+++ b/bpf/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
 name = "bitflags"

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -19,13 +19,18 @@ build:
 clean:
 	cargo clean
 
+.PHONY: format
+format:
+	cargo fmt
+
+.PHONY: format-check
+format-check:
+	cargo fmt --check
+
 .PHONY: lint
 lint:
 	cargo clippy
 	cargo doc
-	cargo fmt --check
 
-.PHONY: lint-fix
 lint-fix:
-	cargo fmt
 	cargo clippy --fix

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -19,10 +19,13 @@ build:
 clean:
 	cargo clean
 
-.PHONY: format
-format:
-	rustfmt cpu-profiler/**/*.rs
-
 .PHONY: lint
 lint:
 	cargo clippy
+	cargo doc
+	cargo fmt --check
+
+.PHONY: lint-fix
+lint-fix:
+	cargo fmt
+	cargo clippy --fix

--- a/bpf/cpu-profiler/src/main.rs
+++ b/bpf/cpu-profiler/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 #![feature(core_intrinsics)]
+#![warn(clippy::all)]
 
 #[no_mangle]
 #[link_section = "license"]

--- a/bpf/xtask/Cargo.toml
+++ b/bpf/xtask/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 structopt = { version = "=0.3.26", default-features = false }
-anyhow = "=1.0.60"
+anyhow = "=1.0.59"

--- a/bpf/xtask/src/main.rs
+++ b/bpf/xtask/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 mod build_ebpf;
 mod run;
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -198,7 +198,6 @@ func main() {
 					NextStartedAgo: time.Since(profiler.NextProfileStartedAt()),
 					Error:          profiler.LastError(),
 				})
-
 			}
 			err := template.StatusPageTemplate.Execute(w, statusPage)
 			if err != nil {

--- a/pkg/profiler/cpu.go
+++ b/pkg/profiler/cpu.go
@@ -421,8 +421,8 @@ func (p *CPUProfiler) Run(ctx context.Context) error {
 // Add process specific metadata to the profiles.
 func (p *CPUProfiler) addProcessMetadata(group profileGroupKey) []*profilestorepb.Label {
 	extraMetadata := []*profilestorepb.Label{
-		&profilestorepb.Label{Name: "profiler_name", Value: p.Name()},
-		&profilestorepb.Label{Name: "pid", Value: strconv.FormatUint(uint64(group), 10)},
+		{Name: "profiler_name", Value: p.Name()},
+		{Name: "pid", Value: strconv.FormatUint(uint64(group), 10)},
 	}
 
 	// Add service discovery metadata, such as the Kubernetes pod where the

--- a/pkg/profiler/noop.go
+++ b/pkg/profiler/noop.go
@@ -44,7 +44,6 @@ func NewNoopProfiler(
 	target model.LabelSet,
 	profilingDuration time.Duration,
 	allGroups func() map[string][]*target.Group,
-
 ) Profiler {
 	return &NoopProfiler{}
 }


### PR DESCRIPTION
This PR enables various lint strategies for Rust I have recently learned

* Deny all warnings
* Run `fmt`, `clippy`, and `doc` (even though there is no doc comments at the moment) in CI
* Use `cargo-audit`. Since CodeQL does not support Rust, [rustsec.org](https://rustsec.org) is the best alternative I have found (although it is not static analysis)
* Enable Clippy for RLS users (`#![warn(clippy::all)]`): [rust-lang/rls#configuration](https://github.com/rust-lang/rls#configuration)
* Downgrade `anyhow` to v1.0.59. Found out v1.0.60 has been yanked with `cargo-audit`
* Remove `go vet`. Redundant with `golangci-lint`
* Format with `gofumpt`. Not sure why `golangci-lint run --fix` does not work for that
* Optimize `go list` commands in `Makefile`