### PR TITLE
feat: add snap packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,5 +243,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           snapcraft upload dist/*_amd64.snap --release stable
-          # amd64 releases only at the moment
-          # snapcraft upload dist/*_arm64.snap --release stable
+          snapcraft upload dist/*_arm64.snap --release stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,3 +225,23 @@ jobs:
           COSIGN_EXPERIMENTAL: true
         run: |
           make sign-container
+
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
+        with:
+          name: parca-agent-dist-release
+          path: dist
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Release to latest/edge
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          snapcraft upload dist/*_amd64.snap --release stable
+          # amd64 releases only at the moment
+          # snapcraft upload dist/*_arm64.snap --release stable

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,288 @@
+name: Snap
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  # renovate: datasource=go depName=github.com/goreleaser/goreleaser
+  GORELEASER_VERSION: v1.10.3
+
+permissions:
+  contents: write
+
+jobs:
+  skip-check:
+    name: Skip check
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip-check.outputs.should_skip }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - id: skip-check
+        uses: fkirc/skip-duplicate-actions@9d116fa7e55f295019cfab7e3ab72b478bcf7fdd # tag=v4.0.0
+        with:
+          do_not_skip: '["schedule", "workflow_dispatch"]'
+          paths: |-
+            [
+              "**.go",
+              "**.rs",
+              ".dockerignore",
+              ".github/workflows/snap.yml",
+              ".go-version",
+              "3rdparty",
+              "Dockerfile*",
+              "Makefile",
+              "bpf/**/.cargo",
+              "bpf/**/Cargo.*",
+              "bpf/.cargo",
+              "bpf/Cargo.*",
+              "bpf/Makefile",
+              "go.mod",
+              "go.sum",
+              "rust-toolchain.toml"
+            ]
+          skip_after_successful_duplicate: false
+
+  dependencies:
+    name: Build and download dependencies
+    needs: skip-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # tag=v3.2.1
+        with:
+          go-version-file: .go-version
+
+      - name: Set up Rust
+        run: rustup show
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # tag=v1.4.0
+        with:
+          working-directory: ./bpf
+
+      - name: Install LLVM (Aya, BPF dependency)
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo -e "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main\n" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update -y
+          sudo apt-get install -yq llvm-14-dev libclang-14-dev
+
+      - name: Run eBPF toolchain setup
+        run: |
+          make -C bpf setup
+          cd bpf && cargo check
+
+      - name: Build BPF
+        run: make bpf
+
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0
+        with:
+          name: ebpf-object-file-release
+          path: pkg/profiler/cpu-profiler.bpf.o
+          if-no-files-found: error
+
+  binaries:
+    name: Goreleaser release
+    runs-on: ubuntu-latest
+    needs: dependencies
+    container:
+      image: docker.io/goreleaser/goreleaser-cross:v1.18.3
+      options: --privileged
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set Tag
+        run: |
+          echo "goreleaser_current_tag=`git describe --match 'v*' --tags`" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # tag=v3.2.1
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
+      - name: Initialize and update libbpf submodule
+        run: git submodule init && git submodule update
+
+      - name: Install libbpf dependencies
+        run: |
+          apt-get update -y
+          apt-get install -yq lld libelf-dev zlib1g-dev libelf-dev:arm64 zlib1g-dev:arm64
+
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
+        with:
+          name: ebpf-object-file-release
+          path: pkg/profiler/cpu-profiler.bpf.o
+
+      - name: Run Goreleaser
+        run: goreleaser release --rm-dist --debug --snapshot --skip-validate --skip-publish
+        env:
+          GORELEASER_CURRENT_TAG: "${{ env.goreleaser_current_tag }}"
+
+      - name: Archive generated artifacts
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0
+        with:
+          name: parca-agent-dist-release
+          if-no-files-found: error
+          path: |
+            goreleaser/dist
+            !goreleaser/dist/*.txt
+
+  snap:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    needs: binaries
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
+        with:
+          name: parca-agent-dist-release
+          path: dist
+
+      - name: Setup LXD (for Snapcraft)
+        uses: whywaita/setup-lxd@v1
+        with:
+          lxd_version: latest/stable
+
+      - name: Setup Snapcraft
+        run: |
+          sudo snap install snapcraft --channel 7.x/stable --classic
+
+      - name: Build snaps
+        run: |
+          # Copy the metadata.json is so snapcraft can parse it for version info
+          cp ./dist/metadata.json snap/local/metadata.json
+
+          # Build the amd64 snap
+          cp ./dist/parca-agent-amd64_linux_amd64_v1/parca-agent snap/local/parca-agent
+          snapcraft pack --verbose --build-for amd64
+
+          # Build the arm64 snap
+          cp ./dist/parca-agent-arm64_linux_arm64/parca-agent snap/local/parca-agent
+          snapcraft pack --verbose --build-for arm64
+
+      - name: Upload locally built snap artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-snaps
+          path: |
+            *.snap
+
+  test:
+    name: Test Snap
+    needs: snap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch built snap
+        uses: actions/download-artifact@v3
+        with:
+          name: built-snaps
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Install snap & invoke Parca Agent
+        run: |
+          sudo snap install --dangerous *_amd64.snap
+
+          # Connect sensitive interfaces; this is done automatically for "real" installs
+          sudo snap connect parca-agent:system-trace
+          sudo snap connect parca-agent:system-observe
+
+          sudo snap set parca-agent log-level=debug
+          parca-agent --help
+
+      - name: Start Parca Agent - default config
+        run: |
+          sudo snap start parca-agent
+
+          # Set some options to allow retries while Parca comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+
+      - name: Configure snap - node name
+        run: |
+          sudo snap set parca-agent node=foobar
+          sudo snap restart parca-agent
+
+          # Set some options to allow retries while Parca comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+
+      - name: Configure snap - kubernetes discovery
+        run: |
+          sudo snap set parca-agent kubernetes=true
+          sudo snap restart parca-agent
+
+          # Set some options to allow retries while Parca comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+
+      - name: Configure snap - http address
+        run: |
+          sudo snap set parca-agent http-address=":8081"
+          sudo snap restart parca-agent
+
+          # Set some options to allow retries while Parca comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:8081/
+          curl ${CURL_OPTS[@]} http://localhost:8081/metrics
+
+      # In case the above tests fail, dump the logs for inspection
+      - name: Dump snap service logs
+        if: failure()
+        run: |
+          sudo snap logs parca-agent -n=all
+
+  release-edge:
+    name: Release Snap (latest/edge)
+    needs: test
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
+        with:
+          name: built-snaps
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Release to latest/edge
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          snapcraft upload *_amd64.snap --release edge
+          snapcraft upload *_arm64.snap --release edge

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.bpf.o
 TODO.md
 minikube-*
+*.snap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Tag }}-next"
+  name_template: "{{ incpatch .Tag }}-{{ .ShortCommit }}"
 release:
   prerelease: auto
   # Defaults to empty.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,10 +28,10 @@ The process formally starts with the initial pre-release, but some preparations 
 
 > For a new major or minor release, work from the `main` branch. For a patch release, work in the branch of the minor release you want to patch (e.g. `release-0.3` if you're releasing `v0.3.2`).
 
-* We aim to keep the main branch in a working state as much as possible. In principle, it should be possible to cut a release from main at any time. In practice, things might not work out as nicely. A few days before the pre-release is scheduled, the releaser should check the state of main. Following their best judgement, the releaser should try to expedite bug fixes that are still in progress but should make it into the release. On the other hand, the releaser may hold back merging last-minute invasive and risky changes that are better suited for the next minor release.
-* The releaser cuts the first pre-release (using the suffix `-rc.0`) and creates a new branch called  `release-<major>.<minor>` starting at the commit tagged for the pre-release. In general, a pre-release is considered a release candidate (that's what `rc` stands for) and should therefore not contain any known bugs that are planned to be fixed in the final release.
-* With the pre-release, the releaser is responsible for running and monitoring a benchmark run of the pre-release for 1 day (https://demo.parca.dev should be used), after which, if successful, the pre-release is promoted to a stable release.
-* If regressions or critical bugs are detected, they need to get fixed before cutting a new pre-release (called `-rc.1`, `-rc.2`, etc.).
+- We aim to keep the main branch in a working state as much as possible. In principle, it should be possible to cut a release from main at any time. In practice, things might not work out as nicely. A few days before the pre-release is scheduled, the releaser should check the state of main. Following their best judgement, the releaser should try to expedite bug fixes that are still in progress but should make it into the release. On the other hand, the releaser may hold back merging last-minute invasive and risky changes that are better suited for the next minor release.
+- The releaser cuts the first pre-release (using the suffix `-rc.0`) and creates a new branch called `release-<major>.<minor>` starting at the commit tagged for the pre-release. In general, a pre-release is considered a release candidate (that's what `rc` stands for) and should therefore not contain any known bugs that are planned to be fixed in the final release.
+- With the pre-release, the releaser is responsible for running and monitoring a benchmark run of the pre-release for 1 day (https://demo.parca.dev should be used), after which, if successful, the pre-release is promoted to a stable release.
+- If regressions or critical bugs are detected, they need to get fixed before cutting a new pre-release (called `-rc.1`, `-rc.2`, etc.).
 
 ## Publish the new release
 
@@ -71,3 +71,21 @@ Go to https://github.com/parca-dev/parca-dev/releases and check the created rele
 For patch releases, submit a pull request to merge back the release branch into the `main` branch.
 
 Take a breath. You're done releasing.
+
+## Generating Snapcraft tokens
+
+The pipeline is configured to release Snap packages automatically to
+[snapcraft.io](https://snapcraft.io).
+
+The token for the store has a limited life. It can be regenerated like so (replace date
+placeholders!):
+
+```shell
+snapcraft export-login \
+  --snaps=parca-agent \
+  --acls package_access,package_push,package_update,package_release \
+  --expires "YYYY-MM-DD" \
+  /tmp/parca_agent_snap_token
+```
+
+The contents of `/tmp/parca_agent_snap_token` should then be added to a Github Secret called `SNAPCRAFT_STORE_CREDENTIALS`.

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,40 @@
+# Parca Agent Snap
+
+This directory contains files used to build the [Parca Agent](https://parca.dev) snap.
+
+## Parca Agent App
+
+The snap provides a base `parca-agent` app, which can be executed as per the upstream
+documentation.
+
+You can start Parca Agent manually like so:
+
+```bash
+# Install from the 'edge' channel
+$ sudo snap install parca-agent --channel edge
+
+# Start the agent with simple defaults for testing
+parca-agent --node="foobar" --store-address="localhost:7070" --insecure
+```
+
+## Parca Agent Service
+
+Additionally, the snap provides a service for Parca Agent with a limited set of configuration
+options. You can start the service like so:
+
+```bash
+$ snap start parca-agent
+```
+
+There are a small number of config options:
+
+| Name            | Valid Options                    | Default          | Description                                                             |
+| :-------------- | :------------------------------- | :--------------- | :---------------------------------------------------------------------- |
+| `node`          | Any string                       | `$(hostname)`    | Name node the process is running on.                                    |
+| `log-level`     | `error`, `warn`, `info`, `debug` | `info`           | Log level for Parca                                                     |
+| `http-address`  | Any string                       | `:7071`          | Address for HTTP server to bind to                                      |
+| `store-address` | Any string                       | `localhost:7071` | gRPC address to send profiles and symbols to.                           |
+| `insecure`      | `true`, `false`                  | `false`          | Send gRPC requests via plaintext instead of TLS.                        |
+| `kubernetes`    | `true`, `false`                  | `false`          | Discover containers running on this node and profile them automatically |
+
+Config options can be set with `sudo snap set parca-agent <option>=<value>`

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # On Fedora $SNAP is under /var and there is some magic to map it to /snap.
 # We need to handle that case and reset $SNAP

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# We need to handle that case and reset $SNAP
+SNAP="${SNAP//\/var\/lib\/snapd/}"
+
+# Discover containers running on this node to profile automatically.
+kubernetes="$(snapctl get kubernetes)"
+if [[ -z "$kubernetes" ]]; then
+    snapctl set kubernetes=false
+fi
+
+log_level="$(snapctl get log-level)"
+if [[ -z "$log_level" ]]; then
+    snapctl set log-level=info
+fi
+
+# Name node the process is running on. If on Kubernetes, this must match the Kubernetes node name.
+node="$(snapctl get node)"
+if [[ -z "$node" ]]; then
+    snapctl set node="$(hostname)"
+fi
+
+# Address to bind HTTP server to.
+http_address="$(snapctl get http-address)"
+if [[ -z "$http_address" ]]; then
+    snapctl set http-address=":7071"
+fi
+
+# gRPC address to send profiles and symbols to.
+store="$(snapctl get store-address)"
+if [[ -z "$store" ]]; then
+    snapctl set store-address="localhost:7070"
+fi
+
+# Send gRPC requests via plaintext instead of TLS
+insecure="$(snapctl get insecure)"
+if [[ -z "$insecure" ]]; then
+    snapctl set insecure=false
+fi

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Run the configure hook which sets defaults for any config options
+"${SNAP}/snap/hooks/configure"
+
+# Grab the config options
+kubernetes="$(snapctl get kubernetes)"
+log_level="$(snapctl get log-level)"
+node="$(snapctl get node)"
+http_address="$(snapctl get http-address)"
+store="$(snapctl get store)"
+insecure="$(snapctl get insecure)"
+
+# Start building an array of command line options
+opts=(
+    "--node=${node}"
+    "--log-level=${log_level}"
+    "--http-address=${http_address}"
+    "--kubernetes=${kubernetes}"
+    "--store-address=${store}"
+    "--insecure=${insecure}"
+)
+
+# Run parca-agent with the gathered arguments
+exec "${SNAP}/parca-agent" "${opts[@]}"

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Run the configure hook which sets defaults for any config options
 "${SNAP}/snap/hooks/configure"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,63 @@
+name: parca-agent
+adopt-info: local-parts
+summary: Parca Agent is an always-on sampling profiler that uses eBPF
+description: |
+  Parca Agent is an always-on sampling profiler that uses eBPF to capture raw
+  profiling data with very low overhead. It observes user-space and
+  kernel-space stacktraces 100 times per second and builds pprof formatted
+  profiles from the extracted data.
+
+  The collected data can be viewed locally via HTTP endpoints and then be
+  configured to be sent to a Parca server to be queried and analyzed over time.
+license: Apache-2.0
+contact: https://parca.dev
+issues: https://github.com/parca-dev/parca-agent/issues
+source-code: https://github.com/parca-dev/parca-agent
+website: https://parca.dev
+confinement: strict
+grade: stable
+base: core22
+compression: lzo
+architectures:
+  - build-for: arm64
+    build-on: amd64
+  - build-for: amd64
+    build-on: amd64
+
+parts:
+  local-parts:
+    plugin: dump
+    source: ./snap/local
+    source-type: local
+    build-packages:
+      - jq
+      - libjq1
+    override-build: |
+      # Set the version of Parca Agent snap based on goreleaser build
+      craftctl set version="$(cat metadata.json | jq -r '.version')"
+
+      # Copy the binary and wrapper into place
+      cp parca-agent $CRAFT_PART_INSTALL/
+      cp parca-agent-wrapper $CRAFT_PART_INSTALL/
+
+      chmod 0755 $CRAFT_PART_INSTALL/parca-agent
+      chmod 0755 $CRAFT_PART_INSTALL/parca-agent-wrapper
+
+apps:
+  parca-agent:
+    command: parca-agent
+    plugs:
+      - network-bind
+      - network
+      - system-trace
+      - system-observe
+  parca-agent-svc:
+    command: parca-agent-wrapper
+    daemon: simple
+    install-mode: disable
+    restart-condition: never
+    plugs:
+      - network-bind
+      - network
+      - system-trace
+      - system-observe


### PR DESCRIPTION
Adds snap packaging to the goreleaser config, along with some CI setup to test/publish the snap on merges to main, or when publishing a release.

Will need some credentials adding before merging for the publishing to work! :)

Similar to https://github.com/parca-dev/parca/pull/1488 but works slightly differently. Because the agent is built in a container, and snapcraft cannot be installed in a container (Snapcraft is only delivered as a snap) I've had to make it a separate build step.


Fixes #674 
