### PR TITLE
ci: disable publish to latest/stable in snap store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,22 +225,3 @@ jobs:
           COSIGN_EXPERIMENTAL: true
         run: |
           make sign-container
-
-  snap:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
-        with:
-          name: parca-agent-dist-release
-          path: dist
-
-      - name: Install snapcraft
-        run: |
-          sudo snap install snapcraft --classic --channel=7.x/stable
-
-      - name: Release to latest/edge
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        run: |
-          snapcraft upload dist/*_amd64.snap --release stable
-          snapcraft upload dist/*_arm64.snap --release stable

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -213,61 +213,61 @@ jobs:
           sudo snap set parca-agent log-level=debug
           parca-agent --help
 
-      - name: Start Parca Agent - default config
-        run: |
-          sudo snap start parca-agent
+      # - name: Start Parca Agent - default config
+      #   run: |
+      #     sudo snap start parca-agent
 
-          # Set some options to allow retries while Parca Agent comes back up
-          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+      #     # Set some options to allow retries while Parca Agent comes back up
+      #     CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
 
-          curl ${CURL_OPTS[@]} http://localhost:7071/
-          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+      #     curl ${CURL_OPTS[@]} http://localhost:7071/
+      #     curl ${CURL_OPTS[@]} http://localhost:7071/metrics
 
-      - name: Configure snap - node name
-        run: |
-          sudo snap set parca-agent node=foobar
-          sudo snap restart parca-agent
+      # - name: Configure snap - node name
+      #   run: |
+      #     sudo snap set parca-agent node=foobar
+      #     sudo snap restart parca-agent
 
-          # Set some options to allow retries while Parca Agent comes back up
-          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+      #     # Set some options to allow retries while Parca Agent comes back up
+      #     CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
 
-          curl ${CURL_OPTS[@]} http://localhost:7071/
-          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+      #     curl ${CURL_OPTS[@]} http://localhost:7071/
+      #     curl ${CURL_OPTS[@]} http://localhost:7071/metrics
 
-      - name: Configure snap - http address
-        run: |
-          sudo snap set parca-agent http-address=":8081"
-          sudo snap restart parca-agent
+      # - name: Configure snap - http address
+      #   run: |
+      #     sudo snap set parca-agent http-address=":8081"
+      #     sudo snap restart parca-agent
 
-          # Set some options to allow retries while Parca comes back up
-          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+      #     # Set some options to allow retries while Parca comes back up
+      #     CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
 
-          curl ${CURL_OPTS[@]} http://localhost:8081/
-          curl ${CURL_OPTS[@]} http://localhost:8081/metrics
+      #     curl ${CURL_OPTS[@]} http://localhost:8081/
+      #     curl ${CURL_OPTS[@]} http://localhost:8081/metrics
 
-      # In case the above tests fail, dump the logs for inspection
-      - name: Dump snap service logs
-        if: failure()
-        run: |
-          sudo snap logs parca-agent -n=all
+      # # In case the above tests fail, dump the logs for inspection
+      # - name: Dump snap service logs
+      #   if: failure()
+      #   run: |
+      #     sudo snap logs parca-agent -n=all
 
-  release-edge:
-    name: Release Snap (latest/edge)
-    needs: test
-    if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
-        with:
-          name: built-snaps
+  # release-edge:
+  #   name: Release Snap (latest/edge)
+  #   needs: test
+  #   if: ${{ github.event_name != 'pull_request' }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3
+  #       with:
+  #         name: built-snaps
 
-      - name: Install snapcraft
-        run: |
-          sudo snap install snapcraft --classic --channel=7.x/stable
+  #     - name: Install snapcraft
+  #       run: |
+  #         sudo snap install snapcraft --classic --channel=7.x/stable
 
-      - name: Release to latest/edge
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        run: |
-          snapcraft upload *_amd64.snap --release edge
-          snapcraft upload *_arm64.snap --release edge
+  #     - name: Release to latest/edge
+  #       env:
+  #         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+  #       run: |
+  #         snapcraft upload *_amd64.snap --release edge
+  #         snapcraft upload *_arm64.snap --release edge

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -202,14 +202,6 @@ jobs:
         with:
           name: built-snaps
 
-      - name: Install snapcraft
-        run: |
-          sudo snap install snapcraft --classic --channel=7.x/stable
-
-      - name: Enable eBPF
-      - run: |
-          sudo apt-get -y install linux-tools-common linux-headers-$(uname -r)
-
       - name: Install snap & invoke Parca Agent
         run: |
           sudo snap install --dangerous *_amd64.snap

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@
 *.bpf.o
 TODO.md
 minikube-*
+
+# Snap Packaging Artifacts
 *.snap
+snap/local/parca-agent
+snap/local/metadata.json


### PR DESCRIPTION
Related to #692

This PR

- Disables publishing to `latest/stable` in the Snap store until we can fix the confinement issue
- Adds some entries to `.gitignore` that are useful when debugging snaps locally
- Removes some unneeded steps from the snap tests