### PR TITLE
Ksym cache: Use a bounded cache

### DIFF
--- a/pkg/ksym/ksym_test.go
+++ b/pkg/ksym/ksym_test.go
@@ -168,11 +168,6 @@ ffffffff8f6d15c4 a not_in_order
 		addr2 + 1: "xfrm_km_lock",
 	}, syms)
 
-	require.Equal(t, map[uint64]string{
-		addr1 + 1: "tcp_sock_id",
-		addr2 + 1: "xfrm_km_lock",
-	}, c.fastCache)
-
 	syms, err = c.Resolve(map[uint64]struct{}{
 		addr1 + 1: {},
 		addr2 + 1: {},
@@ -184,12 +179,6 @@ ffffffff8f6d15c4 a not_in_order
 		addr2 + 1: "xfrm_km_lock",
 		addr3 + 1: "udpv6_prot_lock",
 	}, syms)
-
-	require.Equal(t, map[uint64]string{
-		addr1 + 1: "tcp_sock_id",
-		addr2 + 1: "xfrm_km_lock",
-		addr3 + 1: "udpv6_prot_lock",
-	}, c.fastCache)
 
 	// Test exact matches.
 	syms, err = c.Resolve(map[uint64]struct{}{


### PR DESCRIPTION
Rather than an unlimited one, which has the potential of creating too much memory pressure.

When the cache is full, finding an element is cheaper than it used to thanks to https://github.com/parca-dev/parca-agent/pull/708, as:
- We don't have to read the file nor parse it every single time
- And most importantly, we swapped the linear search with a binary search

