### PR TITLE
pkg/profiler/cpu: Lower log level when failing to symbolize

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -244,7 +244,7 @@ func (p *CPU) Run(ctx context.Context) error {
 		for _, prof := range profiles {
 			err = p.symbolizer.Symbolize(prof)
 			if err != nil {
-				level.Error(p.logger).Log("msg", "failed to symbolize profile", "err", err)
+				level.Debug(p.logger).Log("msg", "failed to symbolize profile", "err", err)
 			}
 
 			// ConvertToPprof can combine multiple profiles into a single profile,


### PR DESCRIPTION
This error is not preventing us from shipping data to a storage, so seeing this error in logs is more confusing to users than helpful. When debugging it might be useful though so lowering it to debug level.