### PR TITLE
pkg/perf: Clarify the not found error is about perf-maps

### DIFF
--- a/pkg/perf/perf.go
+++ b/pkg/perf/perf.go
@@ -50,7 +50,7 @@ type Map struct {
 type realfs struct{}
 
 var (
-	ErrNotFound      = errors.New("not found")
+	ErrNotFound      = errors.New("perf-map not found")
 	ErrNoSymbolFound = errors.New("no symbol found")
 )
 


### PR DESCRIPTION
I tried to understand what a log line was trying to tell me and I kept thinking that the Parca Agent was failing to find symbols for something, when it was really just not finding a perf-map for that process, which is perfectly fine since most processes don't have jitted symbols.