### PR TITLE
Check that the user running the Agent is root

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -122,7 +122,15 @@ func main() {
 	}
 }
 
+func isRoot() bool {
+	return os.Geteuid() == 0
+}
+
 func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
+	if !isRoot() {
+		return errors.New("superuser (root) is required to run Parca Agent")
+	}
+
 	isContainer, err := kconfig.IsInContainer()
 	if err != nil {
 		level.Warn(logger).Log("msg", "failed to check if running in container", "err", err)


### PR DESCRIPTION
Some profilers that also require root, such as rbperf, check for the superuser to ensure that they can load BPF programs, among other things.

```
[javierhonduco@fedora rbperf]$ ./rbperf record -p $RUBY_PID cpu
Error: rbperf requires root to load and run BPF programs
```

Parca Agent doesn't run any checks and the output can be confusing to newcomers, so let's fix this :)

## Current behaviour
```
$ ./parca-agent
[...]
level=info name=parca-agent ts=2022-08-17T10:05:14.304168124Z caller=main.go:203 msg="local profile storage is enabled" dir=./tmp/profiles
name=parca-agent ts=2022-08-17T10:05:14.304188383Z caller=main.go:210 msg=starting... node=test store=
level=warn name=parca-agent ts=2022-08-17T10:05:14.304938858Z caller=discovery_manager.go:221 msg="unable to start provider" provider=systemd/0 error="context canceled"
level=error name=parca-agent ts=2022-08-17T10:05:14.304955172Z caller=main.go:121 err="new bpf module: error setting rlimit: operation not permitted"
```

## With this commit

```
$ ./parca-agent
[...]
level=error name=parca-agent ts=2022-08-17T10:12:11.179985242Z caller=main.go:121 err="superuser (root) is required to run Parca Agent"
```