### PR TITLE
perf: split perf-map and proc status not found errors

### DIFF
--- a/pkg/perf/perf.go
+++ b/pkg/perf/perf.go
@@ -50,8 +50,9 @@ type Map struct {
 type realfs struct{}
 
 var (
-	ErrNotFound      = errors.New("perf-map not found")
-	ErrNoSymbolFound = errors.New("no symbol found")
+	ErrPerfMapNotFound    = errors.New("perf-map not found")
+	ErrProcStatusNotFound = errors.New("process status not found")
+	ErrNoSymbolFound      = errors.New("no symbol found")
 )
 
 func (f *realfs) Open(name string) (fs.File, error) {
@@ -129,7 +130,7 @@ func (p *cache) MapForPID(pid int) (*Map, error) {
 		nsPids, err := findNSPIDs(p.fs, pid)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return nil, ErrNotFound
+				return nil, ErrProcStatusNotFound
 			}
 			return nil, err
 		}
@@ -142,7 +143,7 @@ func (p *cache) MapForPID(pid int) (*Map, error) {
 	h, err := hash.File(p.fs, perfFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, ErrNotFound
+			return nil, ErrPerfMapNotFound
 		}
 		return nil, err
 	}

--- a/pkg/symbol/symbol.go
+++ b/pkg/symbol/symbol.go
@@ -65,7 +65,7 @@ func (s *Symbolizer) Symbolize(prof *profiler.Profile) error {
 	userJITedFunctions, err := s.resolveJITedFunctions(pid, prof.UserLocations)
 	if err != nil {
 		// We expect only a minority of processes to have a JIT and produce the perf map.
-		if !errors.Is(err, perf.ErrNotFound) {
+		if !errors.Is(err, perf.ErrPerfMapNotFound) {
 			level.Debug(s.logger).Log("msg", "failed to obtain perf map for pid", "pid", pid, "err", err)
 			return nil
 		}
@@ -90,7 +90,7 @@ func (s *Symbolizer) resolveJITedFunctions(pid profiler.PID, locations []*profil
 		if !ok {
 			sym, err := perfMap.Lookup(loc.Address)
 			if err != nil {
-				if !errors.Is(err, perf.ErrNotFound) {
+				if !errors.Is(err, perf.ErrPerfMapNotFound) {
 					continue
 				}
 				level.Debug(s.logger).Log("msg", "failed to lookup JIT symbol", "address", loc.Address, "err", err)

--- a/pkg/symbol/symbol.go
+++ b/pkg/symbol/symbol.go
@@ -65,7 +65,7 @@ func (s *Symbolizer) Symbolize(prof *profiler.Profile) error {
 	userJITedFunctions, err := s.resolveJITedFunctions(pid, prof.UserLocations)
 	if err != nil {
 		// We expect only a minority of processes to have a JIT and produce the perf map.
-		if !errors.Is(err, perf.ErrPerfMapNotFound) {
+		if errors.Is(err, perf.ErrPerfMapNotFound) {
 			level.Debug(s.logger).Log("msg", "failed to obtain perf map for pid", "pid", pid, "err", err)
 			return nil
 		}
@@ -90,9 +90,6 @@ func (s *Symbolizer) resolveJITedFunctions(pid profiler.PID, locations []*profil
 		if !ok {
 			sym, err := perfMap.Lookup(loc.Address)
 			if err != nil {
-				if !errors.Is(err, perf.ErrPerfMapNotFound) {
-					continue
-				}
 				level.Debug(s.logger).Log("msg", "failed to lookup JIT symbol", "address", loc.Address, "err", err)
 				continue
 			}


### PR DESCRIPTION
As I was debugging https://github.com/parca-dev/parca-agent/issues/750 I realized
that we are returning the same error when checking if the map file is present
but also the proc status file which might be confusing during troubleshooting.