### PR TITLE
ci: use snapd from edge channel

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -204,6 +204,9 @@ jobs:
 
       - name: Install snap & invoke Parca Agent
         run: |
+          # TODO(jnsgruk): Undo this once a new snapd is released
+          sudo snap refresh snapd --channel=latest/edge
+
           sudo snap install --dangerous *_amd64.snap
 
           # Connect sensitive interfaces; this is done automatically for "real" installs
@@ -213,43 +216,43 @@ jobs:
           sudo snap set parca-agent log-level=debug
           parca-agent --help
 
-      # - name: Start Parca Agent - default config
-      #   run: |
-      #     sudo snap start parca-agent
+      - name: Start Parca Agent - default config
+        run: |
+          sudo snap start parca-agent
 
-      #     # Set some options to allow retries while Parca Agent comes back up
-      #     CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+          # Set some options to allow retries while Parca Agent comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
 
-      #     curl ${CURL_OPTS[@]} http://localhost:7071/
-      #     curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
 
-      # - name: Configure snap - node name
-      #   run: |
-      #     sudo snap set parca-agent node=foobar
-      #     sudo snap restart parca-agent
+      - name: Configure snap - node name
+        run: |
+          sudo snap set parca-agent node=foobar
+          sudo snap restart parca-agent
 
-      #     # Set some options to allow retries while Parca Agent comes back up
-      #     CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+          # Set some options to allow retries while Parca Agent comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
 
-      #     curl ${CURL_OPTS[@]} http://localhost:7071/
-      #     curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
 
-      # - name: Configure snap - http address
-      #   run: |
-      #     sudo snap set parca-agent http-address=":8081"
-      #     sudo snap restart parca-agent
+      - name: Configure snap - http address
+        run: |
+          sudo snap set parca-agent http-address=":8081"
+          sudo snap restart parca-agent
 
-      #     # Set some options to allow retries while Parca comes back up
-      #     CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+          # Set some options to allow retries while Parca comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
 
-      #     curl ${CURL_OPTS[@]} http://localhost:8081/
-      #     curl ${CURL_OPTS[@]} http://localhost:8081/metrics
+          curl ${CURL_OPTS[@]} http://localhost:8081/
+          curl ${CURL_OPTS[@]} http://localhost:8081/metrics
 
-      # # In case the above tests fail, dump the logs for inspection
-      # - name: Dump snap service logs
-      #   if: failure()
-      #   run: |
-      #     sudo snap logs parca-agent -n=all
+      # In case the above tests fail, dump the logs for inspection
+      - name: Dump snap service logs
+        if: failure()
+        run: |
+          sudo snap logs parca-agent -n=all
 
   # release-edge:
   #   name: Release Snap (latest/edge)


### PR DESCRIPTION
Now that this PR: https://github.com/snapcore/snapd/pull/12061 is landed, snapd should permit the agent to read the kernel config from `/boot/config*`.

Marking as "Draft" for now until `snapd` releases properly.