### PR TITLE
dwarf/frame: Add missing instructions

### DIFF
--- a/internal/dwarf/frame/entries.go
+++ b/internal/dwarf/frame/entries.go
@@ -56,7 +56,7 @@ func (fde *DescriptionEntry) Translate(delta uint64) {
 }
 
 // EstablishFrame set up frame for the given PC.
-func (fde *DescriptionEntry) EstablishFrame(pc uint64) *FrameContext {
+func (fde *DescriptionEntry) EstablishFrame(pc uint64) *Context {
 	return executeDwarfProgramUntilPC(fde, pc)
 }
 

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -9,6 +9,9 @@ import (
 	"github.com/parca-dev/parca-agent/internal/dwarf/util"
 )
 
+// TODO(kakkoyun): Only export functions that are used outside of this package.
+// TODO(kakkoyun): Remove print statements.
+
 // DWRule wrapper of rule defined for register values.
 type DWRule struct {
 	Rule Rule
@@ -26,11 +29,11 @@ type DWRule struct {
 // DWARF opcodes.
 //
 // Notes:
-// - probs many of these fields should be (re)moved.
-// - in another step we would remove redundant entries, e.g.:
-// 		0000000000401121 rsp+16   c-16  c-8
-// 		0000000000401124 rbp+16   c-16  c-8
-// 	 by grouping them together.
+//   - probs many of these fields should be (re)moved.
+//   - in another step we would remove redundant entries, e.g.:
+//     0000000000401121 rsp+16   c-16  c-8
+//     0000000000401124 rbp+16   c-16  c-8
+//     by grouping them together.
 type InstructionContext struct {
 	loc     uint64
 	address uint64
@@ -44,14 +47,15 @@ type InstructionContext struct {
 	RetAddrReg    uint64
 	codeAlignment uint64
 	dataAlignment int64
+	ArgsSize      uint64
 }
 
 func (instructionContext *InstructionContext) Loc() uint64 {
 	return instructionContext.loc
 }
 
-// Represents a whole native function.
-type FrameContext struct {
+// Context represents a whole native function.
+type Context struct {
 	// An entry for each machine code instruction (not DWARF instructions)
 	instructions []InstructionContext
 	// The buffer where we store the .eh_frame entries to be parsed for this function.
@@ -59,50 +63,48 @@ type FrameContext struct {
 	order binary.ByteOrder
 }
 
-func (frameContext *FrameContext) getCurrentInstruction() *InstructionContext {
-	return &frameContext.instructions[len(frameContext.instructions)-1]
+func (ctx *Context) getCurrentInstruction() *InstructionContext {
+	return &ctx.instructions[len(ctx.instructions)-1]
 }
 
-func (frameContext *FrameContext) GetAllInstructionContexts() []InstructionContext {
-	return frameContext.instructions
+func (ctx *Context) GetAllInstructionContexts() []InstructionContext {
+	return ctx.instructions
 }
 
 // Instructions used to recreate the table from the .debug_frame data.
 const (
-	DW_CFA_nop                = 0x0        // No ops
-	DW_CFA_set_loc            = 0x01       // op1: address
-	DW_CFA_advance_loc1       = iota       // op1: 1-bytes delta
-	DW_CFA_advance_loc2                    // op1: 2-byte delta
-	DW_CFA_advance_loc4                    // op1: 4-byte delta
-	DW_CFA_offset_extended                 // op1: ULEB128 register, op2: ULEB128 offset
-	DW_CFA_restore_extended                // op1: ULEB128 register
-	DW_CFA_undefined                       // op1: ULEB128 register
-	DW_CFA_same_value                      // op1: ULEB128 register
-	DW_CFA_register                        // op1: ULEB128 register, op2: ULEB128 register
-	DW_CFA_remember_state                  // No ops
-	DW_CFA_restore_state                   // No ops
-	DW_CFA_def_cfa                         // op1: ULEB128 register, op2: ULEB128 offset
-	DW_CFA_def_cfa_register                // op1: ULEB128 register
-	DW_CFA_def_cfa_offset                  // op1: ULEB128 offset
-	DW_CFA_def_cfa_expression              // op1: BLOCK
-	DW_CFA_expression                      // op1: ULEB128 register, op2: BLOCK
-	DW_CFA_offset_extended_sf              // op1: ULEB128 register, op2: SLEB128 BLOCK
-	DW_CFA_def_cfa_sf                      // op1: ULEB128 register, op2: SLEB128 offset
-	DW_CFA_def_cfa_offset_sf               // op1: SLEB128 offset
-	DW_CFA_val_offset                      // op1: ULEB128, op2: ULEB128
-	DW_CFA_val_offset_sf                   // op1: ULEB128, op2: SLEB128
-	DW_CFA_val_expression                  // op1: ULEB128, op2: BLOCK
-	DW_CFA_lo_user            = 0x1c       // op1: BLOCK
-	DW_CFA_hi_user            = 0x3f       // op1: ULEB128 register, op2: BLOCK
-	DW_CFA_advance_loc        = (0x1 << 6) // High 2 bits: 0x1, low 6: delta
-	DW_CFA_offset             = (0x2 << 6) // High 2 bits: 0x2, low 6: register
-	DW_CFA_restore            = (0x3 << 6) // High 2 bits: 0x3, low 6: register
-	// TODO(kakkoyun): Find corresponding values in the spec.
-	// TODO(kakkoyun): Implement noop funcs that skips corresponding bytes.
-	DW_CFA_MIPS_advance_loc8            = 0x1d
-	DW_CFA_GNU_window_save              = 0x2d
-	DW_CFA_GNU_args_size                = 0x2e
-	DW_CFA_GNU_negative_offset_extended = 0x2f
+	DW_CFA_nop                          = 0x0        // No ops
+	DW_CFA_set_loc                      = 0x01       // op1: address
+	DW_CFA_advance_loc1                 = iota       // op1: 1-bytes delta
+	DW_CFA_advance_loc2                              // op1: 2-byte delta
+	DW_CFA_advance_loc4                              // op1: 4-byte delta
+	DW_CFA_offset_extended                           // op1: ULEB128 register, op2: ULEB128 offset
+	DW_CFA_restore_extended                          // op1: ULEB128 register
+	DW_CFA_undefined                                 // op1: ULEB128 register
+	DW_CFA_same_value                                // op1: ULEB128 register
+	DW_CFA_register                                  // op1: ULEB128 register, op2: ULEB128 register
+	DW_CFA_remember_state                            // No ops
+	DW_CFA_restore_state                             // No ops
+	DW_CFA_def_cfa                                   // op1: ULEB128 register, op2: ULEB128 offset
+	DW_CFA_def_cfa_register                          // op1: ULEB128 register
+	DW_CFA_def_cfa_offset                            // op1: ULEB128 offset
+	DW_CFA_def_cfa_expression                        // op1: BLOCK
+	DW_CFA_expression                                // op1: ULEB128 register, op2: BLOCK
+	DW_CFA_offset_extended_sf                        // op1: ULEB128 register, op2: SLEB128 BLOCK
+	DW_CFA_def_cfa_sf                                // op1: ULEB128 register, op2: SLEB128 offset
+	DW_CFA_def_cfa_offset_sf                         // op1: SLEB128 offset
+	DW_CFA_val_offset                                // op1: ULEB128, op2: ULEB128
+	DW_CFA_val_offset_sf                             // op1: ULEB128, op2: SLEB128
+	DW_CFA_val_expression                            // op1: ULEB128, op2: BLOCK
+	DW_CFA_lo_user                      = 0x1c       // op1: BLOCK
+	DW_CFA_hi_user                      = 0x3f       // op1: ULEB128 register, op2: BLOCK
+	DW_CFA_advance_loc                  = (0x1 << 6) // High 2 bits: 0x1, low 6: delta
+	DW_CFA_offset                       = (0x2 << 6) // High 2 bits: 0x2, low 6: register
+	DW_CFA_restore                      = (0x3 << 6) // High 2 bits: 0x3, low 6: register
+	DW_CFA_MIPS_advance_loc8            = 0x1d       // op1: 8-byte delta
+	DW_CFA_GNU_window_save              = 0x2d       // op1: ULEB128 size
+	DW_CFA_GNU_args_size                = 0x2e       // op1: ULEB128 size
+	DW_CFA_GNU_negative_offset_extended = 0x2f       // op1: ULEB128 register, op2: ULEB128 offset
 )
 
 func CFAString(b byte) string {
@@ -166,41 +168,44 @@ const (
 
 const low_6_offset = 0x3f
 
-type instruction func(frameContext *FrameContext)
+type instruction func(ctx *Context)
 
 // // Mapping from DWARF opcode to function.
 var fnlookup = map[byte]instruction{
-	DW_CFA_advance_loc:        advanceloc,
-	DW_CFA_offset:             offset,
-	DW_CFA_restore:            restore,
-	DW_CFA_set_loc:            setloc,
-	DW_CFA_advance_loc1:       advanceloc1,
-	DW_CFA_advance_loc2:       advanceloc2,
-	DW_CFA_advance_loc4:       advanceloc4,
-	DW_CFA_offset_extended:    offsetextended,
-	DW_CFA_restore_extended:   restoreextended,
-	DW_CFA_undefined:          undefined,
-	DW_CFA_same_value:         samevalue,
-	DW_CFA_register:           register,
-	DW_CFA_remember_state:     rememberstate,
-	DW_CFA_restore_state:      restorestate,
-	DW_CFA_def_cfa:            defcfa,
-	DW_CFA_def_cfa_register:   defcfaregister,
-	DW_CFA_def_cfa_offset:     defcfaoffset,
-	DW_CFA_def_cfa_expression: defcfaexpression,
-	DW_CFA_expression:         expression,
-	DW_CFA_offset_extended_sf: offsetextendedsf,
-	DW_CFA_def_cfa_sf:         defcfasf,
-	DW_CFA_def_cfa_offset_sf:  defcfaoffsetsf,
-	DW_CFA_val_offset:         valoffset,
-	DW_CFA_val_offset_sf:      valoffsetsf,
-	DW_CFA_val_expression:     valexpression,
-	DW_CFA_lo_user:            louser,
-	DW_CFA_hi_user:            hiuser,
-	DW_CFA_GNU_args_size:      gnuargsize,
+	DW_CFA_advance_loc:                  advanceloc,
+	DW_CFA_offset:                       offset,
+	DW_CFA_restore:                      restore,
+	DW_CFA_set_loc:                      setloc,
+	DW_CFA_advance_loc1:                 advanceloc1,
+	DW_CFA_advance_loc2:                 advanceloc2,
+	DW_CFA_advance_loc4:                 advanceloc4,
+	DW_CFA_offset_extended:              offsetextended,
+	DW_CFA_restore_extended:             restoreextended,
+	DW_CFA_undefined:                    undefined,
+	DW_CFA_same_value:                   samevalue,
+	DW_CFA_register:                     register,
+	DW_CFA_remember_state:               rememberstate,
+	DW_CFA_restore_state:                restorestate,
+	DW_CFA_def_cfa:                      defcfa,
+	DW_CFA_def_cfa_register:             defcfaregister,
+	DW_CFA_def_cfa_offset:               defcfaoffset,
+	DW_CFA_def_cfa_expression:           defcfaexpression,
+	DW_CFA_expression:                   expression,
+	DW_CFA_offset_extended_sf:           offsetextendedsf,
+	DW_CFA_def_cfa_sf:                   defcfasf,
+	DW_CFA_def_cfa_offset_sf:            defcfaoffsetsf,
+	DW_CFA_val_offset:                   valoffset,
+	DW_CFA_val_offset_sf:                valoffsetsf,
+	DW_CFA_val_expression:               valexpression,
+	DW_CFA_lo_user:                      louser,
+	DW_CFA_hi_user:                      hiuser,
+	DW_CFA_MIPS_advance_loc8:            advanceloc8,
+	DW_CFA_GNU_window_save:              gnuwindowsave,
+	DW_CFA_GNU_args_size:                gnuargsize,
+	DW_CFA_GNU_negative_offset_extended: gnunegetiveoffsetextended,
 }
 
-func executeCIEInstructions(cie *CommonInformationEntry) *FrameContext {
+func executeCIEInstructions(cie *CommonInformationEntry) *Context {
 	initialInstructions := make([]byte, len(cie.InitialInstructions))
 	copy(initialInstructions, cie.InitialInstructions)
 
@@ -215,7 +220,7 @@ func executeCIEInstructions(cie *CommonInformationEntry) *FrameContext {
 		dataAlignment: cie.DataAlignmentFactor,
 	})
 
-	frame := &FrameContext{
+	frame := &Context{
 		instructions: frames,
 		buf:          bytes.NewBuffer(initialInstructions),
 	}
@@ -227,69 +232,67 @@ func executeCIEInstructions(cie *CommonInformationEntry) *FrameContext {
 }
 
 // Unwind the stack to find the return address register.
-func executeDwarfProgramUntilPC(fde *DescriptionEntry, pc uint64) *FrameContext {
-	frameContext := executeCIEInstructions(fde.CIE)
-	frame := frameContext.getCurrentInstruction()
-	frameContext.order = fde.order
+func executeDwarfProgramUntilPC(fde *DescriptionEntry, pc uint64) *Context {
+	ctx := executeCIEInstructions(fde.CIE)
+	frame := ctx.getCurrentInstruction()
+	ctx.order = fde.order
 	frame.loc = fde.Begin()
 	frame.address = pc
 
-	return frameContext
+	return ctx
 }
 
 // ExecuteDwarfProgram unwinds the stack to find the return address register.
-func ExecuteDwarfProgram(fde *DescriptionEntry) *FrameContext {
-	frameContext := executeCIEInstructions(fde.CIE)
-	frameContext.order = fde.order
-	frame := frameContext.getCurrentInstruction()
+func ExecuteDwarfProgram(fde *DescriptionEntry) *Context {
+	ctx := executeCIEInstructions(fde.CIE)
+	ctx.order = fde.order
+	frame := ctx.getCurrentInstruction()
 	frame.loc = fde.Begin()
 	// frame.address = pc
-	frameContext.Execute(fde.Instructions)
-	return frameContext
+	ctx.Execute(fde.Instructions)
+	return ctx
 }
 
-func (frameContext *FrameContext) executeDwarfProgram() {
-	for frameContext.buf.Len() > 0 {
-		executeDwarfInstruction(frameContext)
+func (ctx *Context) executeDwarfProgram() {
+	for ctx.buf.Len() > 0 {
+		executeDwarfInstruction(ctx)
 	}
 }
 
 // ExecuteUntilPC execute dwarf instructions.
-func (frameContext *FrameContext) ExecuteUntilPC(instructions []byte) {
-	frameContext.buf.Truncate(0)
-	frameContext.buf.Write(instructions)
+func (ctx *Context) ExecuteUntilPC(instructions []byte) {
+	ctx.buf.Truncate(0)
+	ctx.buf.Write(instructions)
 
 	// We only need to execute the instructions until
 	// ctx.loc > ctx.address (which is the address we
 	// are currently at in the traced process).
-	frame := frameContext.getCurrentInstruction()
+	frame := ctx.getCurrentInstruction()
 	// TODO CHANGE
-	for frame.address >= frame.loc && frameContext.buf.Len() > 0 {
-		executeDwarfInstruction(frameContext)
+	for frame.address >= frame.loc && ctx.buf.Len() > 0 {
+		executeDwarfInstruction(ctx)
 	}
 }
 
 // Execute execute dwarf instructions.
-func (frameContext *FrameContext) Execute(instructions []byte) {
-	frameContext.buf.Truncate(0)
-	frameContext.buf.Write(instructions)
-
-	// TODO(kakkoyun): Cleanup.
+func (ctx *Context) Execute(instructions []byte) {
+	ctx.buf.Truncate(0)
+	ctx.buf.Write(instructions)
 
 	// We only need to execute the instructions until
 	// ctx.loc > ctx.address (which is the address we
 	// are currently at in the traced process).
 	// for frame.address >= frame.loc &&
 
-	for frameContext.buf.Len() > 0 {
-		/* ins :=  */ executeDwarfInstruction(frameContext)
+	for ctx.buf.Len() > 0 {
+		/* ins :=  */ executeDwarfInstruction(ctx)
 		// Just for debugging:
-		// fmt.Fprintf(os.Stderr, "----------- dwarf instruction: %s at index %d\n", CFAString(ins), len(frameContext.instructions))
+		// fmt.Fprintf(os.Stderr, "----------- dwarf instruction: %s at index %d\n", CFAString(ins), len(ctx.instructions))
 	}
 }
 
-func executeDwarfInstruction(frameContext *FrameContext) byte {
-	instruction, err := frameContext.buf.ReadByte()
+func executeDwarfInstruction(ctx *Context) byte {
+	instruction, err := ctx.buf.ReadByte()
 	if err != nil {
 		panic("Could not read from instruction buffer")
 	}
@@ -298,8 +301,8 @@ func executeDwarfInstruction(frameContext *FrameContext) byte {
 		return instruction
 	}
 
-	fn, instruction := lookupFunc(instruction, frameContext.buf)
-	fn(frameContext)
+	fn, instruction := lookupFunc(instruction, ctx.buf)
+	fn(ctx)
 
 	return instruction
 }
@@ -333,11 +336,7 @@ func lookupFunc(instruction byte, buf *bytes.Buffer) (instruction, byte) {
 
 	fn, ok := fnlookup[instruction]
 	if !ok {
-		// msg := fmt.Sprintf("Encountered an unexpected DWARF CFA opcode: %#v", instruction)
-		// fmt.Println(msg)
-		// return unknown
-
-		// TODO(kakkoyun): Why do we have to panic?
+		// This should never have happened as we implemented all the opcodes for DWARF spec (unless spec is updated).
 		panic(fmt.Sprintf("Encountered an unexpected DWARF CFA opcode: %#v", instruction))
 	}
 
@@ -345,12 +344,12 @@ func lookupFunc(instruction byte, buf *bytes.Buffer) (instruction, byte) {
 }
 
 // new inst!
-func advanceloc(frameContext *FrameContext) {
-	currentFrame := frameContext.getCurrentInstruction()
+func advanceloc(ctx *Context) {
+	currentFrame := ctx.getCurrentInstruction()
 
 	// HACK?(javierhonduco): reusing prev frame stuff.
 	// Have to look into what should be reset, if anything.
-	frameContext.instructions = append(frameContext.instructions,
+	ctx.instructions = append(ctx.instructions,
 		InstructionContext{
 			loc:           currentFrame.loc,
 			cie:           currentFrame.cie,
@@ -364,9 +363,9 @@ func advanceloc(frameContext *FrameContext) {
 		},
 	)
 
-	frame := frameContext.getCurrentInstruction()
+	frame := ctx.getCurrentInstruction()
 
-	b, err := frameContext.buf.ReadByte()
+	b, err := ctx.buf.ReadByte()
 	if err != nil {
 		panic("Could not read byte")
 	}
@@ -390,58 +389,65 @@ func advanceloc(frameContext *FrameContext) {
 	}
 }
 
-func advanceloc1(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
-	delta, err := frameContext.buf.ReadByte()
+func advanceloc1(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
+	delta, err := ctx.buf.ReadByte()
 	if err != nil {
 		panic("Could not read byte")
 	}
 
 	frame.loc += uint64(delta) * frame.codeAlignment
-
 }
 
-func advanceloc2(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func advanceloc2(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var delta uint16
-	_ = binary.Read(frameContext.buf, frameContext.order, &delta)
+	_ = binary.Read(ctx.buf, ctx.order, &delta)
 
 	frame.loc += uint64(delta) * frame.codeAlignment
-
 }
 
-func advanceloc4(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func advanceloc4(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var delta uint32
-	_ = binary.Read(frameContext.buf, frameContext.order, &delta)
+	_ = binary.Read(ctx.buf, ctx.order, &delta)
 
 	frame.loc += uint64(delta) * frame.codeAlignment
-
 }
 
-func offset(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+// MIPS-specific.
+func advanceloc8(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	b, err := frameContext.buf.ReadByte()
+	var delta uint64
+	_ = binary.Read(ctx.buf, ctx.order, &delta)
+
+	frame.loc += delta * frame.codeAlignment
+}
+
+func offset(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
+
+	b, err := ctx.buf.ReadByte()
 	if err != nil {
 		panic(err)
 	}
 
 	var (
 		reg       = b & low_6_offset
-		offset, _ = util.DecodeULEB128(frameContext.buf)
+		offset, _ = util.DecodeULEB128(ctx.buf)
 	)
 
 	// fmt.Println("register", reg, "set to dwrule ...")
 	frame.Regs[uint64(reg)] = DWRule{Offset: int64(offset) * frame.dataAlignment, Rule: RuleOffset}
 }
 
-func restore(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func restore(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	b, err := frameContext.buf.ReadByte()
+	b, err := ctx.buf.ReadByte()
 	if err != nil {
 		panic(err)
 	}
@@ -456,70 +462,70 @@ func restore(frameContext *FrameContext) {
 	}
 }
 
-func setloc(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func setloc(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var loc uint64
-	_ = binary.Read(frameContext.buf, frameContext.order, &loc)
+	_ = binary.Read(ctx.buf, ctx.order, &loc)
 
 	frame.loc = loc + frame.cie.staticBase
 
 }
 
-func offsetextended(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func offsetextended(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		reg, _    = util.DecodeULEB128(frameContext.buf)
-		offset, _ = util.DecodeULEB128(frameContext.buf)
+		reg, _    = util.DecodeULEB128(ctx.buf)
+		offset, _ = util.DecodeULEB128(ctx.buf)
 	)
 
 	// fmt.Println("register", reg, "set to offsete")
 	frame.Regs[reg] = DWRule{Offset: int64(offset) * frame.dataAlignment, Rule: RuleOffset}
 }
 
-func undefined(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func undefined(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg, _ := util.DecodeULEB128(frameContext.buf)
+	reg, _ := util.DecodeULEB128(ctx.buf)
 	// fmt.Println("register", reg, "set to undefined")
 	frame.Regs[reg] = DWRule{Rule: RuleUndefined}
 }
 
-func samevalue(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func samevalue(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg, _ := util.DecodeULEB128(frameContext.buf)
+	reg, _ := util.DecodeULEB128(ctx.buf)
 	// fmt.Println("register", reg, "set to sameval")
 	frame.Regs[reg] = DWRule{Rule: RuleSameVal}
 }
 
-func register(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func register(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg1, _ := util.DecodeULEB128(frameContext.buf)
-	reg2, _ := util.DecodeULEB128(frameContext.buf)
+	reg1, _ := util.DecodeULEB128(ctx.buf)
+	reg2, _ := util.DecodeULEB128(ctx.buf)
 	// fmt.Println("register", reg1, "set to ", reg2)
 	frame.Regs[reg1] = DWRule{Reg: reg2, Rule: RuleRegister}
 }
 
-func rememberstate(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func rememberstate(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	frame.prevRegs = frame.Regs
 }
 
-func restorestate(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func restorestate(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	// fmt.Println("registers restore")
 	frame.Regs = frame.prevRegs
 }
 
-func restoreextended(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func restoreextended(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg, _ := util.DecodeULEB128(frameContext.buf)
+	reg, _ := util.DecodeULEB128(ctx.buf)
 
 	oldrule, ok := frame.initialRegs[reg]
 	if ok {
@@ -531,135 +537,150 @@ func restoreextended(frameContext *FrameContext) {
 	}
 }
 
-func defcfa(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func defcfa(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg, _ := util.DecodeULEB128(frameContext.buf)
-	offset, _ := util.DecodeULEB128(frameContext.buf)
+	reg, _ := util.DecodeULEB128(ctx.buf)
+	offset, _ := util.DecodeULEB128(ctx.buf)
 
 	frame.CFA.Rule = RuleCFA
 	frame.CFA.Reg = reg
 	frame.CFA.Offset = int64(offset)
 }
 
-func defcfaregister(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func defcfaregister(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg, _ := util.DecodeULEB128(frameContext.buf)
+	reg, _ := util.DecodeULEB128(ctx.buf)
 	frame.CFA.Reg = reg
 }
 
-func defcfaoffset(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func defcfaoffset(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	offset, _ := util.DecodeULEB128(frameContext.buf)
+	offset, _ := util.DecodeULEB128(ctx.buf)
 	frame.CFA.Offset = int64(offset)
 }
 
-func defcfasf(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func defcfasf(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	reg, _ := util.DecodeULEB128(frameContext.buf)
-	offset, _ := util.DecodeSLEB128(frameContext.buf)
+	reg, _ := util.DecodeULEB128(ctx.buf)
+	offset, _ := util.DecodeSLEB128(ctx.buf)
 
 	frame.CFA.Rule = RuleCFA
 	frame.CFA.Reg = reg
 	frame.CFA.Offset = offset * frame.dataAlignment
 }
 
-func defcfaoffsetsf(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func defcfaoffsetsf(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
-	offset, _ := util.DecodeSLEB128(frameContext.buf)
+	offset, _ := util.DecodeSLEB128(ctx.buf)
 	offset *= frame.dataAlignment
 	frame.CFA.Offset = offset
 }
 
-func defcfaexpression(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func defcfaexpression(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		l, _ = util.DecodeULEB128(frameContext.buf)
-		expr = frameContext.buf.Next(int(l))
+		l, _ = util.DecodeULEB128(ctx.buf)
+		expr = ctx.buf.Next(int(l))
 	)
 
 	frame.CFA.Expression = expr
 	frame.CFA.Rule = RuleExpression
 }
 
-func expression(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func expression(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		reg, _ = util.DecodeULEB128(frameContext.buf)
-		l, _   = util.DecodeULEB128(frameContext.buf)
-		expr   = frameContext.buf.Next(int(l))
+		reg, _ = util.DecodeULEB128(ctx.buf)
+		l, _   = util.DecodeULEB128(ctx.buf)
+		expr   = ctx.buf.Next(int(l))
 	)
 
 	// fmt.Println("register", reg, "set to expression")
 	frame.Regs[reg] = DWRule{Rule: RuleExpression, Expression: expr}
 }
 
-func offsetextendedsf(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func offsetextendedsf(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		reg, _    = util.DecodeULEB128(frameContext.buf)
-		offset, _ = util.DecodeSLEB128(frameContext.buf)
+		reg, _    = util.DecodeULEB128(ctx.buf)
+		offset, _ = util.DecodeSLEB128(ctx.buf)
 	)
 
 	// fmt.Println("register", reg, "set to dwrule")
 	frame.Regs[reg] = DWRule{Offset: offset * frame.dataAlignment, Rule: RuleOffset}
 }
 
-func valoffset(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func valoffset(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		reg, _    = util.DecodeULEB128(frameContext.buf)
-		offset, _ = util.DecodeULEB128(frameContext.buf)
+		reg, _    = util.DecodeULEB128(ctx.buf)
+		offset, _ = util.DecodeULEB128(ctx.buf)
 	)
 
 	// fmt.Println("register", reg, "set to dwrule")
 	frame.Regs[reg] = DWRule{Offset: int64(offset), Rule: RuleValOffset}
 }
 
-func valoffsetsf(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func valoffsetsf(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		reg, _    = util.DecodeULEB128(frameContext.buf)
-		offset, _ = util.DecodeSLEB128(frameContext.buf)
+		reg, _    = util.DecodeULEB128(ctx.buf)
+		offset, _ = util.DecodeSLEB128(ctx.buf)
 	)
 
 	// fmt.Println("register", reg, "set to offset")
 	frame.Regs[reg] = DWRule{Offset: offset * frame.dataAlignment, Rule: RuleValOffset}
 }
 
-func valexpression(frameContext *FrameContext) {
-	frame := frameContext.getCurrentInstruction()
+func valexpression(ctx *Context) {
+	frame := ctx.getCurrentInstruction()
 
 	var (
-		reg, _ = util.DecodeULEB128(frameContext.buf)
-		l, _   = util.DecodeULEB128(frameContext.buf)
-		expr   = frameContext.buf.Next(int(l))
+		reg, _ = util.DecodeULEB128(ctx.buf)
+		l, _   = util.DecodeULEB128(ctx.buf)
+		expr   = ctx.buf.Next(int(l))
 	)
 
 	frame.Regs[reg] = DWRule{Rule: RuleValExpression, Expression: expr}
 }
 
-func louser(frameContext *FrameContext) {
-	frameContext.buf.Next(1)
+func louser(ctx *Context) {
+	ctx.buf.Next(1)
 }
 
-func hiuser(frameContext *FrameContext) {
-	frameContext.buf.Next(1)
+func hiuser(ctx *Context) {
+	ctx.buf.Next(1)
 }
 
-func gnuargsize(frameContext *FrameContext) {
+// SPARC-specific.
+func gnuwindowsave(ctx *Context) {
+	// Skip, do nothing. Architecture is not supported.
+	_, _ = util.DecodeSLEB128(ctx.buf)
+}
 
+func gnuargsize(ctx *Context) {
 	// The DW_CFA_GNU_args_size instruction takes an unsigned LEB128 operand representing an argument size.
-	// Just read and do nothing.
-	// TODO(kakkoyun): Implement this.
-	_, _ = util.DecodeSLEB128(frameContext.buf)
+	// This instruction specifies the total of the size of the arguments which have been pushed onto the stack.
+	frame := ctx.getCurrentInstruction()
+	size, _ := util.DecodeULEB128(ctx.buf)
+	frame.ArgsSize = size
+}
+
+// PowerPC-specific. Deprecated.
+func gnunegetiveoffsetextended(ctx *Context) {
+	// Skip, do nothing. Architecture is not supported.
+	var (
+		_, _ = util.DecodeULEB128(ctx.buf)
+		_, _ = util.DecodeSLEB128(ctx.buf)
+	)
 }

--- a/pkg/stack/unwind/plan_table_test.go
+++ b/pkg/stack/unwind/plan_table_test.go
@@ -15,9 +15,7 @@ package unwind
 
 import (
 	"testing"
-	"unsafe"
 
-	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
@@ -29,14 +27,11 @@ func TestBuildPlanTable(t *testing.T) {
 	ptb := NewPlanTableBuilder(logger, process.NewMappingFileCache(logger))
 
 	fdes, err := ptb.readFDEs("testdata/pie-dynamic", 0)
-	// fdes, err := ptb.readFDEs("testdata/cgo-static", 0)
 	require.NoError(t, err)
 
 	planTable := buildTable(fdes, 0)
-	t.Log("Plan Table Length:", len(planTable))
-	t.Logf("Size of %T struct: %s\n", planTable, humanize.Bytes(uint64(unsafe.Sizeof(planTable))+uint64(len(planTable))*uint64(unsafe.Sizeof(planTable[0]))))
-	require.Equal(t, len(fdes), len(planTable))
+	require.Equal(t, 291619, len(planTable))
 	require.Equal(t, uint64(0xfb6960), planTable[0].Loc)
-	require.Equal(t, Instruction{Op: OpUndefined}, planTable[0].RA)
+	require.Equal(t, Instruction{Op: OpCFAOffset, Offset: -8}, planTable[0].RA)
 	require.Equal(t, Instruction{Op: 3, Reg: 0x7, Offset: 8}, planTable[0].CFA)
 }


### PR DESCRIPTION
= Adds missing implementations for DWARF frame instructions.

```
DW_CFA_MIPS_advance_loc8		MIPS-specific. Implementation is provided regardless.
DW_CFA_GNU_window_save			SPARC-specific. Unsupported architecture. Read and skip.
DW_CFA_GNU_args_size			This instruction specifies the total of the size of the arguments which have been pushed onto the stack.
DW_CFA_GNU_negative_offset_extended	PowerPC-specific. Deprecated. Read and skip.
```

- Fixrd failing test
- Renames `FrameContext` to `Context` to avoid stutter. 