### PR TITLE
.eh_frame: unwind table map improvements

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -43,7 +43,7 @@ char LICENSE[] SEC("license") = "GPL";
 #define MAX_STACK_DEPTH 50 // Max depth of each stack trace to track. TODO(javierhonduco): just to debug. Set to a larger number.
 #define MAX_PID_MAP_SIZE 256 // Size of the `<PID, unwind_table>` mapping. Determines how many processes we can unwind.
 #define MAX_BINARY_SEARCH_DEPTH 20 // Binary search iterations. 2ˆ20 can bisect ~1_048_576 entries.
-#define MAX_UNWIND_TABLE_SIZE 100 * 1000 // Size of the unwind_table. 
+#define MAX_UNWIND_TABLE_SIZE 130 * 1000 // Size of the unwind_table.
 
 /*=========================== MACROS ==================================*/
 

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -397,12 +397,14 @@ func (p *CPU) ensureUnwindTables(pid int) error {
 			return fmt.Errorf("failed to open elf: %w", err)
 		}
 
-		syms, err := e.Symbols()
+		syms, symsErr := e.Symbols()
+		dynSyms, dynSymsErr := e.DynamicSymbols()
 
-		if err != nil {
+		if symsErr != nil && dynSymsErr != nil {
 			return fmt.Errorf("failed to read symbols: %w", err)
 
 		}
+		syms = append(syms, dynSyms...)
 		fmt.Println("symbol count", len(syms))
 
 		for _, sym := range syms {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -287,7 +287,7 @@ func (p *CPU) Run(ctx context.Context) error {
 	defer ticker.Stop()
 	// Update tables
 	pid := p.ehFramePid
-	if err := p.ensureUnwindTables(int(pid)); err != nil {
+	if err := p.ensureUnwindTables(int(pid), false); err != nil {
 		level.Error(p.logger).Log("msg", "failed to check or update unwind tables", "pid", pid, "err", err)
 		panic("fatal err")
 	}
@@ -378,7 +378,7 @@ func (p *CPU) report(lastError error) {
 	p.lastError = lastError
 }
 
-func (p *CPU) ensureUnwindTables(pid int) error {
+func (p *CPU) ensureUnwindTables(pid int, compact bool) error {
 	if _, ok := p.unwindTableCache.GetIfPresent(pid); !ok {
 		pt, err := p.unwindTableBuilder.PlanTableForPid(pid)
 		if err != nil {
@@ -417,6 +417,25 @@ func (p *CPU) ensureUnwindTables(pid int) error {
 			}
 		}
 
+		if compact {
+			compact := unwind.PlanTable{}
+			prevCFARegister := uint64(0)
+			prevCFAOffset := int64(0)
+			prevRBPRegisterOffset := int64(0)
+
+			for _, row := range pt {
+				newEntry := row.CFA.Reg != prevCFARegister || row.CFA.Offset != prevCFAOffset || row.RBP.Offset != prevRBPRegisterOffset
+				if newEntry {
+					compact = append(compact, row)
+					prevCFARegister = row.CFA.Reg
+					prevCFAOffset = row.CFA.Offset
+					prevRBPRegisterOffset = row.RBP.Offset
+				}
+			}
+			fmt.Println("Compacted the unwind table from", len(pt), "elements to", len(compact), "elements")
+
+			pt = compact
+		}
 		if err := p.bpfMaps.updateUnwindTables(pid, pt, mainLowPC, mainHighPC); err != nil {
 			return fmt.Errorf("failed to update unwind table: %w", err)
 		}

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -35,7 +35,7 @@ const (
 	stackTracesMapName = "stack_traces"
 	unwindTableMapName = "unwind_tables"
 
-	maxPlanTableSize = 100 * 1000 // // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in BPF program.
+	maxPlanTableSize = 130 * 1000 // // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in BPF program.
 )
 
 var (
@@ -120,7 +120,7 @@ func (m *bpfMaps) updateUnwindTables(pid int, pt unwind.PlanTable, mainLowPC uin
 
 	for i, row := range pt {
 		if i >= maxPlanTableSize {
-			panic("max plan table size reached")
+			panic(fmt.Sprintf("max plan table size reached. Table size %d, but max size is %d", len(pt), maxPlanTableSize))
 			break
 		}
 		// Ignore RIP right now, it's usually 8 bytes before the CFA.


### PR DESCRIPTION
- increase table size by 30k items
- read symbols from the dynamic string table, too
- add initial code to compact the unwind table by removing redundant rows (disabled by default, will add tests in the near future, but tested with `parca-demo-cpp-no-fp` and `parca-demo-cpp` and they both worked)