### PR TITLE
fix(discovery): ensure systemd units which have disappeared are accounted for

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -230,7 +230,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		}
 		m = discovery.NewManager(logger, reg,
 			discovery.WithProcessLabelCache(cache.New(
-				cache.WithExpireAfterAccess(flags.RemoteStoreBatchWriteInterval*2),
+				cache.WithExpireAfterWrite(flags.ProfilingDuration*2),
 			)),
 		)
 		if err := m.ApplyConfig(ctx, map[string]discovery.Configs{"all": configs}); err != nil {


### PR DESCRIPTION
This adds empty `TargetGroup`s (with only `Source` set) to notify the discovery manager when systemd units have exited. Kubernetes has a delete channel which allow do that nicely, but systemd would just leave them dangling until now. It may be possible to use DBus signals instead when doing #760

It also corrects the PID labels cache configuration (I had initially not seen it was configured with an option, and thought it was not configured at all):

* Expire after write as some keys may never be accessed
* Set expiration in relation to profiling duration as the cache is accessed in the profile loop, not during remote batch write

Fixes #806