### PR TITLE
.eh_frame: CFA := (exp | regOffset)

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -302,6 +302,12 @@ static __always_inline int walk_user_stacktrace(bpf_user_pt_regs_t *regs,
 
     bpf_printk("\tcfa reg: $%s, offset: %d (pc: %llx)", found_cfa_reg == X86_64_REGISTER_RSP? "rsp" : "rbp", found_cfa_offset, found_pc);
 
+    // HACK(javierhonduco): dwarf expressions aren't supported. We set these values to the register and the offset
+    // to recognise them.
+    if (found_cfa_reg == 0xBEEF && found_cfa_offset == 0xBADFAD) {
+      bpf_printk("\t!!!! CFA is an expression, bailing out");
+      return 0;
+    }
 
     u64 previous_rsp = 0;
     if (found_cfa_reg == X86_64_REGISTER_RBP) { 

--- a/internal/dwarf/frame/testdata/generated_tables/libc-6.txt
+++ b/internal/dwarf/frame/testdata/generated_tables/libc-6.txt
@@ -2,7 +2,7 @@
 	(found 3 rows)
 	Loc: 28000 CFA: $rsp=16  	RBP: u
 	Loc: 28006 CFA: $rsp=24  	RBP: u
-	Loc: 28010 CFA: $rsp=24  	RBP: u
+	Loc: 28010 CFA: exp     	RBP: u
 => Function start: 28380, Function end: 286f0
 	(found 1 rows)
 	Loc: 28380 CFA: $rsp=8   	RBP: u
@@ -1991,7 +1991,7 @@
 	Loc: 3ea20 CFA: $rsp=8   	RBP: u
 => Function start: 3ea6f, Function end: 3ea79
 	(found 1 rows)
-	Loc: 3ea6f CFA: $rax=0   	RBP: u
+	Loc: 3ea6f CFA: exp     	RBP: u
 => Function start: 3ea80, Function end: 3ec58
 	(found 4 rows)
 	Loc: 3ea80 CFA: $rsp=8   	RBP: u

--- a/internal/dwarf/frame/testdata/generated_tables/parca-demo-cpp-no-fp-out.txt
+++ b/internal/dwarf/frame/testdata/generated_tables/parca-demo-cpp-no-fp-out.txt
@@ -9,7 +9,7 @@
 	(found 3 rows)
 	Loc: 401020 CFA: $rsp=16  	RBP: u
 	Loc: 401026 CFA: $rsp=24  	RBP: u
-	Loc: 401030 CFA: $rsp=24  	RBP: u
+	Loc: 401030 CFA: exp     	RBP: u
 => Function start: 401090, Function end: 4010c5
 	(found 3 rows)
 	Loc: 401090 CFA: $rsp=8   	RBP: u

--- a/internal/dwarf/frame/testdata/generated_tables/parca-demo-cpp-out.txt
+++ b/internal/dwarf/frame/testdata/generated_tables/parca-demo-cpp-out.txt
@@ -9,7 +9,7 @@
 	(found 3 rows)
 	Loc: 401020 CFA: $rsp=16  	RBP: u
 	Loc: 401026 CFA: $rsp=24  	RBP: u
-	Loc: 401030 CFA: $rsp=24  	RBP: u
+	Loc: 401030 CFA: exp     	RBP: u
 => Function start: 4010b0, Function end: 4010e8
 	(found 4 rows)
 	Loc: 4010b0 CFA: $rsp=8   	RBP: u


### PR DESCRIPTION
Right now we were skipping over expressions but we weren't setting the current CFAs that require a expression to be evaluated as such.

This PR doesn't tackle expression evaluation. It focuses on ensuring that CFAs are marked as either a combination of register and an offset, which we already support, or as an unsupported expression. In the latter case we will not walk the stack in BPF.

This also fixes the table printing as rows with expressions had the previous value, which is not correct.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>