### PR TITLE
pkg/metrics: Add license header

### DIFF
--- a/pkg/debuginfo/metrics.go
+++ b/pkg/debuginfo/metrics.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package debuginfo
 
 import (


### PR DESCRIPTION
As the license checks are failing locally

## Test Plan

Before this PR:
``` 
[javierhonduco@fedora parca-agent]$ make lint
./scripts/check-license.sh
license header checking failed:
./pkg/debuginfo/metrics.go
make: *** [Makefile:168: check-license] Error 255
```

After:

``` 
[javierhonduco@fedora parca-agent]$ make lint
./scripts/check-license.sh
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="clang" golangci-lint run
[...]
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>