### PR TITLE
.eh_frame: Unwind table generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ GOLANG_CROSS_VERSION := v1.19.1
 OUT_DIR ?= dist
 GO_SRC := $(shell find . -type f -name '*.go')
 OUT_BIN := $(OUT_DIR)/parca-agent
+OUT_BIN_EH_FRAME := $(OUT_DIR)/eh-frame
 OUT_DOCKER ?= ghcr.io/parca-dev/parca-agent
 DOCKER_BUILDER ?= parca-dev/cross-builder
 
@@ -98,7 +99,7 @@ $(OUT_DIR):
 	mkdir -p $@
 
 .PHONY: build
-build: $(OUT_BPF) $(OUT_BIN)
+build: $(OUT_BPF) $(OUT_BIN) $(OUT_BIN_EH_FRAME)
 
 GO_ENV := CGO_ENABLED=1 GOOS=linux GOARCH=$(ARCH) CC="$(CMD_CC)"
 CGO_ENV := CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)"
@@ -116,6 +117,10 @@ endif
 .PHONY: build-dyn
 build-dyn: $(OUT_BPF) libbpf
 	$(GO_ENV) CGO_CFLAGS="$(CGO_CFLAGS_DYN)" CGO_LDFLAGS="$(CGO_LDFLAGS_DYN)" $(GO) build $(SANITIZERS) $(GO_BUILD_FLAGS) -o $(OUT_DIR)/parca-agent-dyn ./cmd/parca-agent
+
+$(OUT_BIN_EH_FRAME): go/deps
+	find dist -exec touch -t 202101010000.00 {} +
+	$(GO) build $(SANITIZERS) -trimpath -v -o $(OUT_BIN_EH_FRAME) ./cmd/eh-frame
 
 .PHONY: go/deps
 go/deps:

--- a/cmd/eh-frame/main.go
+++ b/cmd/eh-frame/main.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/parca-dev/parca-agent/pkg/logger"
+	"github.com/parca-dev/parca-agent/pkg/stack/unwind"
+)
+
+type flags struct {
+	Executable string `kong:"help='The executable to print the .eh_unwind tables for.'"`
+}
+
+// This tool exists for debugging .eh_frame unwinding and its intended for Parca Agent's
+// developers.
+func main() {
+	logger := logger.NewLogger("debug", logger.LogFormatLogfmt, "eh-frame")
+
+	flags := flags{}
+	kong.Parse(&flags)
+
+	executablePath := flags.Executable
+
+	if executablePath == "" {
+		// nolint
+		fmt.Fprintln(os.Stderr, "The executable argument is required")
+		os.Exit(1)
+	}
+
+	ptb := unwind.NewUnwindTableBuilder(logger)
+	err := ptb.PrintTable(os.Stdout, executablePath)
+	if err != nil {
+		// nolint
+		fmt.Println("failed with:", err)
+	}
+}

--- a/internal/dwarf/frame/entries.go
+++ b/internal/dwarf/frame/entries.go
@@ -55,11 +55,6 @@ func (fde *FrameDescriptionEntry) Translate(delta uint64) {
 	fde.begin += delta
 }
 
-// EstablishFrame set up frame for the given PC.
-func (fde *FrameDescriptionEntry) EstablishFrame(pc uint64) *FrameContext {
-	return executeDwarfProgramUntilPC(fde, pc)
-}
-
 type FrameDescriptionEntries []*FrameDescriptionEntry
 
 func newFrameIndex() FrameDescriptionEntries {

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -322,6 +322,7 @@ func advanceloc(ctx *Context) {
 			Regs:          make(map[uint64]DWRule),
 			RetAddrReg:    frame.cie.ReturnAddressRegister,
 			initialRegs:   make(map[uint64]DWRule),
+			CFA:           frame.CFA,
 			prevRegs:      make(map[uint64]DWRule),
 			codeAlignment: frame.cie.CodeAlignmentFactor,
 			dataAlignment: frame.cie.DataAlignmentFactor,
@@ -335,6 +336,17 @@ func advanceloc(ctx *Context) {
 
 	delta := b & low_6_offset
 	frame.loc += uint64(delta) * frame.codeAlignment
+
+	// Copy registers from the current frame to the new one.
+	for k, v := range frame.Regs {
+		frame.Regs[k] = v
+	}
+	for k, v := range frame.initialRegs {
+		frame.initialRegs[k] = v
+	}
+	for k, v := range frame.prevRegs {
+		frame.prevRegs[k] = v
+	}
 }
 
 func advanceloc1(ctx *Context) {

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -90,6 +90,49 @@ const (
 	DW_CFA_GNU_negative_offset_extended = 0x2f
 )
 
+func CFAString(b byte) string {
+	m := map[byte]string{
+		DW_CFA_nop:                          "DW_CFA_nop",
+		DW_CFA_set_loc:                      "DW_CFA_set_loc",
+		DW_CFA_advance_loc1:                 "DW_CFA_advance_loc1",
+		DW_CFA_advance_loc2:                 "DW_CFA_advance_loc2",
+		DW_CFA_advance_loc4:                 "DW_CFA_advance_loc4",
+		DW_CFA_offset_extended:              "DW_CFA_offset_extended",
+		DW_CFA_restore_extended:             "DW_CFA_restore_extended",
+		DW_CFA_undefined:                    "DW_CFA_undefined",
+		DW_CFA_same_value:                   "DW_CFA_same_value",
+		DW_CFA_register:                     "DW_CFA_register",
+		DW_CFA_remember_state:               "DW_CFA_remember_state",
+		DW_CFA_restore_state:                "DW_CFA_restore_state",
+		DW_CFA_def_cfa:                      "DW_CFA_def_cfa",
+		DW_CFA_def_cfa_register:             "DW_CFA_def_cfa_register",
+		DW_CFA_def_cfa_offset:               "DW_CFA_def_cfa_offset",
+		DW_CFA_def_cfa_expression:           "DW_CFA_def_cfa_expression",
+		DW_CFA_expression:                   "DW_CFA_expression",
+		DW_CFA_offset_extended_sf:           "DW_CFA_offset_extended_sf",
+		DW_CFA_def_cfa_sf:                   "DW_CFA_def_cfa_sf",
+		DW_CFA_def_cfa_offset_sf:            "DW_CFA_def_cfa_offset_sf",
+		DW_CFA_val_offset:                   "DW_CFA_val_offset",
+		DW_CFA_val_offset_sf:                "DW_CFA_val_offset_sf",
+		DW_CFA_val_expression:               "DW_CFA_val_expression",
+		DW_CFA_lo_user:                      "DW_CFA_lo_user",
+		DW_CFA_hi_user:                      "DW_CFA_hi_user",
+		DW_CFA_advance_loc:                  "DW_CFA_advance_loc",
+		DW_CFA_offset:                       "DW_CFA_offset",
+		DW_CFA_restore:                      "DW_CFA_restoree",
+		DW_CFA_MIPS_advance_loc8:            "DW_CFA_MIPS_advance_loc8",
+		DW_CFA_GNU_window_save:              "DW_CFA_GNU_window_save",
+		DW_CFA_GNU_args_size:                "DW_CFA_GNU_args_size",
+		DW_CFA_GNU_negative_offset_extended: "DW_CFA_GNU_negative_offset_extended",
+	}
+
+	str, ok := m[b]
+	if !ok {
+		return "<unknown CFA value>"
+	}
+	return str
+}
+
 // Rule rule defined for register values.
 type Rule byte
 

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -204,7 +204,7 @@ func executeCIEInstructions(cie *CommonInformationEntry) *Context {
 		instructions: frames,
 		buf:          bytes.NewBuffer(initialInstructions),
 	}
-	// frame.executeDwarfProgram()
+	frame.executeDwarfProgram()
 	return frame
 }
 
@@ -215,8 +215,6 @@ func executeDwarfProgramUntilPC(fde *FrameDescriptionEntry, pc uint64) *Context 
 	ctx.order = fde.order
 	frame.loc = fde.Begin()
 	frame.address = pc
-	// ctx.ExecuteUntilPC(fde.Instructions)
-
 	return ctx
 }
 

--- a/internal/dwarf/util/buf.go
+++ b/internal/dwarf/util/buf.go
@@ -1,0 +1,117 @@
+// Copyright 2009 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Buffered reading and decoding of DWARF data streams.
+
+//lint:file-ignore ST1021 imported file
+//nolint:nonamedreturns
+package util
+
+import (
+	"debug/dwarf"
+	"fmt"
+)
+
+// Data buffer being decoded.
+type buf struct {
+	dwarf  *dwarf.Data
+	format dataFormat
+	name   string
+	off    dwarf.Offset
+	data   []byte
+	Err    error
+}
+
+// Data format, other than byte order.  This affects the handling of
+// certain field formats.
+type dataFormat interface {
+	// DWARF version number.  Zero means unknown.
+	version() int
+
+	// 64-bit DWARF format?
+	dwarf64() (dwarf64, isKnown bool)
+
+	// Size of an address, in bytes.  Zero means unknown.
+	addrsize() int
+}
+
+// Some parts of DWARF have no data format, e.g., abbrevs.
+type UnknownFormat struct{}
+
+func (u UnknownFormat) version() int {
+	return 0
+}
+
+func (u UnknownFormat) dwarf64() (bool, bool) {
+	return false, false
+}
+
+func (u UnknownFormat) addrsize() int {
+	return 0
+}
+
+func MakeBuf(d *dwarf.Data, format dataFormat, name string, off dwarf.Offset, data []byte) buf {
+	return buf{d, format, name, off, data, nil}
+}
+
+func (b *buf) Uint8() uint8 {
+	if len(b.data) < 1 {
+		b.error("underflow")
+		return 0
+	}
+	val := b.data[0]
+	b.data = b.data[1:]
+	b.off++
+	return val
+}
+
+// Read a varint, which is 7 bits per byte, little endian.
+// the 0x80 bit means read another byte.
+func (b *buf) Varint() (c uint64, bits uint) {
+	for i := 0; i < len(b.data); i++ {
+		byt := b.data[i]
+		c |= uint64(byt&0x7F) << bits
+		bits += 7
+		if byt&0x80 == 0 {
+			b.off += dwarf.Offset(i + 1)
+			b.data = b.data[i+1:]
+			return c, bits
+		}
+	}
+	return 0, 0
+}
+
+// Unsigned int is just a varint.
+func (b *buf) Uint() uint64 {
+	x, _ := b.Varint()
+	return x
+}
+
+// Signed int is a sign-extended varint.
+func (b *buf) Int() int64 {
+	ux, bits := b.Varint()
+	x := int64(ux)
+	if x&(1<<(bits-1)) != 0 {
+		x |= -1 << bits
+	}
+	return x
+}
+
+// AssertEmpty checks that everything has been read from b.
+func (b *buf) AssertEmpty() {
+	if len(b.data) == 0 {
+		return
+	}
+	if len(b.data) > 5 {
+		b.error(fmt.Sprintf("unexpected extra data: %x...", b.data[0:5]))
+	}
+	b.error(fmt.Sprintf("unexpected extra data: %x", b.data))
+}
+
+func (b *buf) error(s string) {
+	if b.Err == nil {
+		b.data = nil
+		b.Err = dwarf.DecodeError{Name: b.name, Offset: b.off, Err: s}
+	}
+}

--- a/internal/dwarf/util/util.go
+++ b/internal/dwarf/util/util.go
@@ -1,0 +1,270 @@
+// nolint:stylecheck,nonamedreturns
+package util
+
+import (
+	"bytes"
+	"debug/dwarf"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// ByteReaderWithLen is a io.ByteReader with a Len method. This interface is
+// satisified by both bytes.Buffer and bytes.Reader.
+type ByteReaderWithLen interface {
+	io.ByteReader
+	io.Reader
+	Len() int
+}
+
+// The Little Endian Base 128 format is defined in the DWARF v4 standard,
+// section 7.6, page 161 and following.
+
+// DecodeULEB128 decodes an unsigned Little Endian Base 128
+// represented number.
+func DecodeULEB128(buf ByteReaderWithLen) (uint64, uint32) {
+	var (
+		result uint64
+		shift  uint64
+		length uint32
+	)
+
+	if buf.Len() == 0 {
+		return 0, 0
+	}
+
+	for {
+		b, err := buf.ReadByte()
+		if err != nil {
+			panic("Could not parse ULEB128 value")
+		}
+		length++
+
+		result |= uint64((uint(b) & 0x7f) << shift)
+
+		// If high order bit is 1.
+		if b&0x80 == 0 {
+			break
+		}
+
+		shift += 7
+	}
+
+	return result, length
+}
+
+// DecodeSLEB128 decodes a signed Little Endian Base 128
+// represented number.
+func DecodeSLEB128(buf ByteReaderWithLen) (int64, uint32) {
+	var (
+		b      byte
+		err    error
+		result int64
+		shift  uint64
+		length uint32
+	)
+
+	if buf.Len() == 0 {
+		return 0, 0
+	}
+
+	for {
+		b, err = buf.ReadByte()
+		if err != nil {
+			panic("Could not parse SLEB128 value")
+		}
+		length++
+
+		result |= (int64(b) & 0x7f) << shift
+		shift += 7
+		if b&0x80 == 0 {
+			break
+		}
+	}
+
+	if (shift < 8*uint64(length)) && (b&0x40 > 0) {
+		result |= -(1 << shift)
+	}
+
+	return result, length
+}
+
+// EncodeULEB128 encodes x to the unsigned Little Endian Base 128 format
+// into out.
+func EncodeULEB128(out io.ByteWriter, x uint64) {
+	for {
+		b := byte(x & 0x7f)
+		x >>= 7
+		if x != 0 {
+			b |= 0x80
+		}
+		_ = out.WriteByte(b)
+		if x == 0 {
+			break
+		}
+	}
+}
+
+// EncodeSLEB128 encodes x to the signed Little Endian Base 128 format
+// into out.
+func EncodeSLEB128(out io.ByteWriter, x int64) {
+	for {
+		b := byte(x & 0x7f)
+		x >>= 7
+
+		signb := b & 0x40
+
+		last := false
+		if (x == 0 && signb == 0) || (x == -1 && signb != 0) {
+			last = true
+		} else {
+			b |= 0x80
+		}
+		_ = out.WriteByte(b)
+
+		if last {
+			break
+		}
+	}
+}
+
+// ParseString reads a null-terminated string from data.
+func ParseString(data *bytes.Buffer) (string, error) {
+	str, err := data.ReadString(0x0)
+	if err != nil {
+		return "", err
+	}
+
+	return str[:len(str)-1], nil
+}
+
+// ReadUintRaw reads an integer of ptrSize bytes, with the specified byte order, from reader.
+func ReadUintRaw(reader io.Reader, order binary.ByteOrder, ptrSize int) (uint64, error) {
+	switch ptrSize {
+	case 2:
+		var n uint16
+		if err := binary.Read(reader, order, &n); err != nil {
+			return 0, err
+		}
+		return uint64(n), nil
+	case 4:
+		var n uint32
+		if err := binary.Read(reader, order, &n); err != nil {
+			return 0, err
+		}
+		return uint64(n), nil
+	case 8:
+		var n uint64
+		if err := binary.Read(reader, order, &n); err != nil {
+			return 0, err
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("pointer size %d not supported", ptrSize)
+}
+
+// WriteUint writes an integer of ptrSize bytes to writer, in the specified byte order.
+func WriteUint(writer io.Writer, order binary.ByteOrder, ptrSize int, data uint64) error {
+	switch ptrSize {
+	case 4:
+		return binary.Write(writer, order, uint32(data))
+	case 8:
+		return binary.Write(writer, order, data)
+	}
+	return fmt.Errorf("pointer size %d not supported", ptrSize)
+}
+
+// ReadDwarfLengthVersion reads a DWARF length field followed by a version field.
+func ReadDwarfLengthVersion(data []byte) (length uint64, dwarf64 bool, version uint8, byteOrder binary.ByteOrder) {
+	if len(data) < 4 {
+		return 0, false, 0, binary.LittleEndian
+	}
+
+	lengthfield := binary.LittleEndian.Uint32(data)
+	voff := 4
+	if lengthfield == ^uint32(0) {
+		dwarf64 = true
+		voff = 12
+	}
+
+	if voff+1 >= len(data) {
+		return 0, false, 0, binary.LittleEndian
+	}
+
+	byteOrder = binary.LittleEndian
+	x, y := data[voff], data[voff+1]
+	switch {
+	default:
+		fallthrough
+	case x == 0 && y == 0:
+		version = 0
+		byteOrder = binary.LittleEndian
+	case x == 0:
+		version = y
+		byteOrder = binary.BigEndian
+	case y == 0:
+		version = x
+		byteOrder = binary.LittleEndian
+	}
+
+	if dwarf64 {
+		length = byteOrder.Uint64(data[4:])
+	} else {
+		length = uint64(byteOrder.Uint32(data))
+	}
+
+	return length, dwarf64, version, byteOrder
+}
+
+const (
+	_DW_UT_compile = 0x1 + iota
+	_DW_UT_type
+	_DW_UT_partial
+	_DW_UT_skeleton
+	_DW_UT_split_compile
+	_DW_UT_split_type
+)
+
+// ReadUnitVersions reads the DWARF version of each unit in a debug_info section and returns them as a map.
+func ReadUnitVersions(data []byte) map[dwarf.Offset]uint8 {
+	r := make(map[dwarf.Offset]uint8)
+	off := dwarf.Offset(0)
+	for len(data) > 0 {
+		length, dwarf64, version, _ := ReadDwarfLengthVersion(data)
+
+		data = data[4:]
+		off += 4
+		secoffsz := 4
+		if dwarf64 {
+			off += 8
+			secoffsz = 8
+			data = data[8:]
+		}
+
+		var headerSize int
+
+		switch version {
+		case 2, 3, 4:
+			headerSize = 3 + secoffsz
+		default: // 5 and later?
+			unitType := data[2]
+
+			switch unitType {
+			case _DW_UT_compile, _DW_UT_partial:
+				headerSize = 5 + secoffsz
+
+			case _DW_UT_skeleton, _DW_UT_split_compile:
+				headerSize = 4 + secoffsz + 8
+
+			case _DW_UT_type, _DW_UT_split_type:
+				headerSize = 4 + secoffsz + 8 + secoffsz
+			}
+		}
+
+		r[off+dwarf.Offset(headerSize)] = version
+
+		data = data[length:] // skip contents
+		off += dwarf.Offset(length)
+	}
+	return r
+}

--- a/internal/dwarf/util/util_test.go
+++ b/internal/dwarf/util/util_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDecodeULEB128(t *testing.T) {
+	leb128 := bytes.NewBuffer([]byte{0xE5, 0x8E, 0x26})
+
+	n, c := DecodeULEB128(leb128)
+	if n != 624485 {
+		t.Fatal("Number was not decoded properly, got: ", n, c)
+	}
+
+	if c != 3 {
+		t.Fatal("Count not returned correctly")
+	}
+}
+
+func TestDecodeSLEB128(t *testing.T) {
+	sleb128 := bytes.NewBuffer([]byte{0x9b, 0xf1, 0x59})
+
+	n, c := DecodeSLEB128(sleb128)
+	if n != -624485 {
+		t.Fatal("Number was not decoded properly, got: ", n, c)
+	}
+}
+
+func TestEncodeULEB128(t *testing.T) {
+	tc := []uint64{0x00, 0x7f, 0x80, 0x8f, 0xffff, 0xfffffff7}
+	for i := range tc {
+		var buf bytes.Buffer
+		EncodeULEB128(&buf, tc[i])
+		enc := append([]byte{}, buf.Bytes()...)
+		buf.Write([]byte{0x1, 0x2, 0x3})
+		out, c := DecodeULEB128(&buf)
+		t.Logf("input %x output %x encoded %x", tc[i], out, enc)
+		if c != uint32(len(enc)) {
+			t.Errorf("wrong encode")
+		}
+		if out != tc[i] {
+			t.Errorf("wrong encode")
+		}
+	}
+}
+
+func TestEncodeSLEB128(t *testing.T) {
+	tc := []int64{2, -2, 127, -127, 128, -128, 129, -129}
+	for i := range tc {
+		var buf bytes.Buffer
+		EncodeSLEB128(&buf, tc[i])
+		enc := append([]byte{}, buf.Bytes()...)
+		buf.Write([]byte{0x1, 0x2, 0x3})
+		out, c := DecodeSLEB128(&buf)
+		t.Logf("input %x output %x encoded %x", tc[i], out, enc)
+		if c != uint32(len(enc)) {
+			t.Errorf("wrong encode")
+		}
+		if out != tc[i] {
+			t.Errorf("wrong encode")
+		}
+	}
+}
+
+func TestParseString(t *testing.T) {
+	bstr := bytes.NewBuffer([]byte{'h', 'i', 0x0, 0xFF, 0xCC})
+
+	if str, _ := ParseString(bstr); str != "hi" {
+		t.Fatalf("String was not parsed correctly %#v", str)
+	}
+}

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -79,8 +79,17 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string) error {
 		tableRows := buildTableRows(fde)
 		fmt.Fprintf(writer, "\t(found %d rows)\n", len(tableRows))
 		for _, tableRow := range tableRows {
-			reg := registerToString(tableRow.CFA.Reg)
-			fmt.Fprintf(writer, "\t Loc: %x CFA: $%s=%d\n", tableRow.Loc, reg, tableRow.CFA.Offset)
+			CFAReg := registerToString(tableRow.CFA.Reg)
+
+			fmt.Fprintf(writer, "\tLoc: %x CFA: $%s=%-4d", tableRow.Loc, CFAReg, tableRow.CFA.Offset)
+
+			if tableRow.RBP.Op == OpUnimplemented || tableRow.RBP.Offset == 0 {
+				fmt.Fprintf(writer, "\tRBP: u")
+			} else {
+				fmt.Fprintf(writer, "\tRBP: c%-4d", tableRow.RBP.Offset)
+			}
+
+			fmt.Fprintf(writer, "\n")
 		}
 	}
 

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -1,0 +1,192 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//nolint:stylecheck,deadcode,unused
+package unwind
+
+import (
+	"debug/elf"
+	"fmt"
+
+	"github.com/go-delve/delve/pkg/dwarf/regnum"
+	"github.com/go-kit/log"
+
+	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
+)
+
+// UnwindTableBuilder helps to build UnwindTable for a given PID.
+//
+// javierhonduco(note): Caching on PID alone will result in hard to debug issues as
+// PIDs are reused. Right now we will parse the CIEs and FDEs over and over. Caching
+// will be added later on.
+
+type UnwindTableBuilder struct {
+	logger log.Logger
+}
+
+func NewUnwindTableBuilder(logger log.Logger) *UnwindTableBuilder {
+	return &UnwindTableBuilder{logger: logger}
+}
+
+type UnwindTable []UnwindTableRow
+
+func (t UnwindTable) Len() int           { return len(t) }
+func (t UnwindTable) Less(i, j int) bool { return t[i].Loc < t[j].Loc }
+func (t UnwindTable) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+
+func (ptb *UnwindTableBuilder) UnwindTableForPid(pid int) (UnwindTable, error) {
+	return UnwindTable{}, nil
+}
+
+func (ptb *UnwindTableBuilder) readFDEs(path string, start uint64) (frame.FrameDescriptionEntries, error) {
+	obj, err := elf.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open elf: %w", err)
+	}
+	defer obj.Close()
+
+	sec := obj.Section(".eh_frame")
+	if sec == nil {
+		return nil, fmt.Errorf("failed to find .eh_frame section")
+	}
+
+	// TODO(kakkoyun): Consider using the debug_frame section as a fallback.
+	// TODO(kakkoyun): Needs to support DWARF64 as well.
+	ehFrame, err := sec.Data()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read .eh_frame section: %w", err)
+	}
+
+	// TODO(kakkoyun): Byte order of a DWARF section can be different.
+	fdes, err := frame.Parse(ehFrame, obj.ByteOrder, start, pointerSize(obj.Machine), sec.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse frame data: %w", err)
+	}
+
+	return fdes, nil
+}
+
+func buildTable(fdes frame.FrameDescriptionEntries) UnwindTable {
+	table := make(UnwindTable, 0, len(fdes))
+	for _, fde := range fdes {
+		table = append(table, buildTableRows(fde)...)
+	}
+	return table
+}
+
+// UnwindTableRow represents a single row in the plan table.
+// x86_64: rip (instruction pointer register), rsp (stack pointer register), rbp (base pointer/frame pointer register)
+// aarch64: lr, sp, fp
+type UnwindTableRow struct {
+	// The address of the machine instruction.
+	// Each row covers a range of machine instruction, from its address (Loc) to that of the row below.
+	Loc uint64
+	// CFA offset to find the return address.
+	RA Instruction
+	// CFA (could be an offset from $rsp or $rbp in x86_64) or an expression.
+	CFA Instruction
+	// RBP value.
+	RBP Instruction
+}
+
+// TODO(kakkoyun): Maybe use CFA and RA for the field names.
+// Op represents an operation to identify the unwind calculation that needs to be done,
+// - to calculate address of the given register.
+type Op uint8
+
+const (
+	// This type of register is not supported.
+	OpUnimplemented Op = iota
+	// Undefined register. The value will be defined at some later IP in the same DIE.
+	OpUndefined
+	// Value stored at some offset from "CFA".
+	OpCFAOffset
+	// Value of a machine register plus offset.
+	OpRegister
+)
+
+// Instruction represents an instruction to unwind the address of a register.
+type Instruction struct {
+	Op     Op
+	Reg    uint64
+	Offset int64
+}
+
+func buildTableRows(fde *frame.FrameDescriptionEntry) []UnwindTableRow {
+	rows := make([]UnwindTableRow, 0)
+
+	frameContext := frame.ExecuteDwarfProgram(fde)
+
+	instructionContexts := frameContext.InstructionContexts()
+
+	for _, instructionContext := range instructionContexts {
+		// fmt.Println("ret addr:", instructionContext.RetAddrReg)
+
+		row := UnwindTableRow{
+			Loc: instructionContext.Loc(),
+		}
+
+		// Deal with return address register ($rax)
+		{
+			rule, found := instructionContext.Regs[instructionContext.RetAddrReg]
+			if found {
+				// nolint:exhaustive
+				switch rule.Rule {
+				case frame.RuleOffset:
+					row.RA = Instruction{Op: OpCFAOffset, Offset: rule.Offset}
+				case frame.RuleUndefined:
+					row.RA = Instruction{Op: OpUndefined}
+				default:
+					row.RA = Instruction{Op: OpUnimplemented}
+				}
+			} else {
+				row.RA = Instruction{Op: OpUnimplemented}
+			}
+		}
+
+		// Deal with $rbp
+		{
+			rule, found := instructionContext.Regs[regnum.AMD64_Rbp]
+			if found {
+				// nolint:exhaustive
+				switch rule.Rule {
+				case frame.RuleOffset:
+					row.RBP = Instruction{Op: OpCFAOffset, Offset: rule.Offset}
+				case frame.RuleUndefined:
+					row.RBP = Instruction{Op: OpUndefined}
+				default:
+					row.RBP = Instruction{Op: OpUnimplemented}
+				}
+			} else {
+				row.RBP = Instruction{Op: OpUnimplemented}
+			}
+		}
+
+		row.CFA = Instruction{Op: OpRegister, Reg: instructionContext.CFA.Reg, Offset: instructionContext.CFA.Offset}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func pointerSize(arch elf.Machine) int {
+	//nolint:exhaustive
+	switch arch {
+	case elf.EM_386:
+		return 4
+	case elf.EM_AARCH64, elf.EM_X86_64:
+		return 8
+	default:
+		return 0
+	}
+}

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"testing"
+)
+
+// TODO(javierhonduco): Add test.
+func TestBuildUnwindTable(t *testing.T) {
+}


### PR DESCRIPTION
This PR builds on https://github.com/parca-dev/parca-agent/pull/863, which added the initial DWARF parsing code and continues by adding almost all the remaining changes:

- Various utilities to decode DWARF's `sleb` and `uleb` numbers;
- The unwind table generation;
- A program to print the whole table, which we've been using to run snapshot tests and ensure that changes didn't affect correctness in unintended ways;
- Correctness fixes to the table generation:
  - Ensuring we copy all the registers from previous rows within a function, this fixes issues we saw with `$rbp`;
  - Creating new code locations for every `advancelocation` family of opcodes;
  - Fixing the remember and restore state, as the CFA wasn't stored

The original commits for this feature in the WIP branch:
- @kakkoyun https://github.com/parca-dev/parca-agent/pull/744/commits/eb9cef10d3ec322f01b89ce2a83f800788bf3107, https://github.com/parca-dev/parca-agent/pull/744/commits/9ec988ccbb24e192bc032f9343c09b91ba10f62c
- @v-thakkar https://github.com/parca-dev/parca-agent/pull/744/commits/133e27ad4e7c000427a5a878a53e22b58aed9bda, https://github.com/parca-dev/parca-agent/pull/744/commits/5c2fc3e2c97e373507f49cd20c4b3733306a256b
- myself: https://github.com/parca-dev/parca-agent/pull/744/commits/8f2cf609a5aa1c2b08dc366a4c3c6934ed673292, https://github.com/parca-dev/parca-agent/pull/744/commits/06cf43b51b0d6fe9e0735e067900ff0187aa44c0, https://github.com/parca-dev/parca-agent/pull/744/commits/3a7b6ded333e3f5a8b8cd415f451504254c3809a, https://github.com/parca-dev/parca-agent/pull/744/commits/013bd065f542979dad7efa4bc56eb1f31514b702, https://github.com/parca-dev/parca-agent/pull/744/commits/28ab687175506a505d478ef8fd5695dc155a9a17, https://github.com/parca-dev/parca-agent/pull/744/commits/6b3f51b6cbd119c14690e1065edf63ecd5bc7eb3, https://github.com/parca-dev/parca-agent/pull/744/commits/d2d518c8d5c903704471ab6c729ed7f2f7688a9b, https://github.com/parca-dev/parca-agent/pull/744/commits/8125312dd566ee769a9a36da506d72672e1c7d3f, https://github.com/parca-dev/parca-agent/pull/744/commits/dc8557a457c7e12d2259eb32282922fb853414c5

### Left out features
DWARF expression opcodes are not handled in the printer. That and the test binaries will be added in another PR

### Test Plan
Rebuilt the unwind tables for libc, libpython, libruby, and other binaries and there were no changes compared to the results from https://github.com/parca-dev/parca-agent/pull/744/commits/72b1f756432c9f5207d731c7f6c01ae3692ada60

