### PR TITLE
@nocommit WIP pkg/metadata, pkg/buildid perf improvements

### DIFF
--- a/internal/pprof/elfexec/elfexec.go
+++ b/internal/pprof/elfexec/elfexec.go
@@ -118,12 +118,7 @@ func parseNotes(reader io.Reader, alignment int, order binary.ByteOrder) ([]elfN
 //
 // If no build-ID was found but the binary was read without error, it returns
 // (nil, nil).
-func GetBuildID(binary io.ReaderAt) ([]byte, error) {
-	f, err := elf.NewFile(binary)
-	if err != nil {
-		return nil, err
-	}
-
+func GetBuildID(f *elf.File) ([]byte, error) {
 	findBuildID := func(notes []elfNote) ([]byte, error) {
 		var buildID []byte
 		for _, note := range notes {

--- a/pkg/buildid/buildid_test.go
+++ b/pkg/buildid/buildid_test.go
@@ -15,7 +15,9 @@
 package buildid
 
 import (
+	"debug/elf"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,7 +64,7 @@ func TestBuildID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildID(tt.args.path)
+			got, err := BuildIDPath(tt.args.path)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -100,7 +102,13 @@ func Test_fastGNUBuildID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := fastGNUBuildID(tt.args.path)
+			elf, err := elf.Open(tt.args.path)
+			if err != nil {
+				panic(fmt.Sprintf("failed to open elf: %v", err))
+			}
+			defer elf.Close()
+
+			got, err := fastGNUBuildID(elf)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -145,7 +153,13 @@ func Test_elfBuildID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := elfBuildID(tt.args.path)
+			elf, err := elf.Open(tt.args.path)
+			if err != nil {
+				panic(fmt.Sprintf("failed to open elf: %v", err))
+			}
+			defer elf.Close()
+
+			got, err := elfBuildID(elf)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -176,7 +190,13 @@ func Test_fastGoBuildID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := fastGoBuildID(tt.args.path)
+			elf, err := elf.Open(tt.args.path)
+			if err != nil {
+				panic(fmt.Sprintf("failed to open elf: %v", err))
+			}
+			defer elf.Close()
+
+			got, err := fastGoBuildID(elf)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/objectfile/object_file.go
+++ b/pkg/objectfile/object_file.go
@@ -71,7 +71,7 @@ func open(filePath string, start, limit, offset uint64, relocationSymbol string)
 	defer f.Close()
 
 	buildID := ""
-	if id, err := buildid.BuildID(filePath); err == nil {
+	if id, err := buildid.BuildID(f); err == nil {
 		buildID = id
 	}
 


### PR DESCRIPTION
WIP:

TL;DR: 40% of the Parca Agent CPU time is spent reading all the elf symbols for each binary to see whether they are stripped or not!

<img width="2033" alt="image" src="https://user-images.githubusercontent.com/959128/194358477-e847afc7-62b9-43de-b376-1ad7c9fb2663.png">

(8% in memory allocations, 22% reading data)


The changes will be split in two next week:
- caching
- and (maybe) passing elf handles rather than paths

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>