### PR TITLE
build(eh-frame): build with osusergo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ build-dyn: $(OUT_BPF) libbpf
 
 $(OUT_BIN_EH_FRAME): go/deps
 	find dist -exec touch -t 202101010000.00 {} +
-	$(GO) build $(SANITIZERS) -trimpath -v -o $(OUT_BIN_EH_FRAME) ./cmd/eh-frame
+	$(GO) build $(SANITIZERS) -tags osusergo -mod=readonly -trimpath -v -o $@ ./cmd/eh-frame
 
 .PHONY: go/deps
 go/deps:

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ pkgs.mkShell rec {
     minikube
     pkg-config
     zlib.static
-  ] ++ (lib.optional stdenv.isLinux [ glibc.static ]);
+  ] ++ (lib.optional stdenv.isLinux [ glibc.dev glibc.static ]);
 
   shellHook = ''
     export PATH="''${PROJECT_ROOT}/bin:''${PATH}"


### PR DESCRIPTION
This basically makes the binary static.

I was unable to build it on NixOS:

```
go build  -trimpath -v -o dist/eh-frame ./cmd/eh-frame
# github.com/parca-dev/parca-agent/cmd/eh-frame
os/user(.text): relocation target malloc not defined
os/user(.text): relocation target free not defined
os/user(.text): relocation target getgrgid_r not defined
os/user(.text): relocation target getgrnam_r not defined
os/user(.text): relocation target getpwnam_r not defined
os/user(.text): relocation target getpwuid_r not defined
os/user(.text): relocation target realloc not defined
os/user(.text): relocation target sysconf not defined
runtime/cgo(.text): relocation target stderr not defined
runtime/cgo(.text): relocation target fwrite not defined
runtime/cgo(.text): relocation target __vfprintf_chk not defined
runtime/cgo(.text): relocation target fputc not defined
runtime/cgo(.text): relocation target abort not defined
runtime/cgo(.text): relocation target pthread_mutex_lock not defined
runtime/cgo(.text): relocation target pthread_cond_wait not defined
runtime/cgo(.text): relocation target pthread_mutex_unlock not defined
runtime/cgo(.text): relocation target __stack_chk_fail not defined
runtime/cgo(.text): relocation target pthread_cond_broadcast not defined
runtime/cgo(.text): relocation target pthread_create not defined
runtime/cgo(.text): relocation target nanosleep not defined
runtime/cgo(.text): relocation target pthread_detach not defined
/nix/store/9xd7fiahj0h4b1adb4biybpxp4a5a738-go-1.18.6/share/go/pkg/tool/linux_amd64/link: too many errors
```

Otherwise, the only way I have found to build it dynamically linked is with `-ldflags="-linkmode=external"`. I added back `glibc.dev` to `shell.nix` to allow running `parca-agent` built with `make build-dyn`