### PR TITLE
feat: support relabeling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,3 +76,8 @@ linters-settings:
   cyclop:
     # The maximal code complexity to report.
     max-complexity: 15
+  tagliatelle:
+    case:
+      use-field-name: true
+      rules:
+        yaml: snake

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Flags:
       --node=STRING               The name of the node that the process is
                                   running on. If on Kubernetes, this must match
                                   the Kubernetes node name.
+      --config-path="parca-agent.yaml"
+                                  Path to config file.
       --profiling-duration=10s    The agent profiling duration to use. Leave
                                   this empty to use the defaults.
       --metadata-external-labels=KEY=VALUE;...

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -138,13 +138,14 @@ func main() {
 }
 
 func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
-	cfg := &config.Config{}
-	if _, err := os.Stat(flags.ConfigPath); !errors.Is(err, os.ErrNotExist) {
-		cfg, err = config.LoadFile(flags.ConfigPath)
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to read config", "path", flags.ConfigPath)
-			return err
-		}
+	var cfg *config.Config
+	var err error
+	cfg, err = config.LoadFile(flags.ConfigPath)
+	if errors.Is(err, os.ErrNotExist) {
+		cfg = &config.Config{}
+	} else if err != nil {
+		level.Error(logger).Log("msg", "failed to read config", "path", flags.ConfigPath)
+		return err
 	}
 
 	isContainer, err := kconfig.IsInContainer()

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
@@ -153,7 +154,6 @@ require (
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/goburrow/cache v0.1.4
 	github.com/google/pprof v0.0.0-20220829040838-70bd9ae97f40
+	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
@@ -99,7 +100,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/googleapis/go-type-adapters v1.0.0 // indirect
-	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/parca-agent.yaml
+++ b/parca-agent.yaml
@@ -1,0 +1,2 @@
+## See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+# relabel_configs: []

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,60 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/prometheus/prometheus/model/relabel"
+	"gopkg.in/yaml.v2"
+)
+
+// Config holds all the configuration information for Parca Agent.
+type Config struct {
+	RelabelConfigs []*relabel.Config `yaml:"relabel_configs,omitempty"`
+}
+
+func (c Config) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("<error creating config string: %s>", err)
+	}
+	return string(b)
+}
+
+// Load parses the YAML input s into a Config.
+func Load(s string) (*Config, error) {
+	cfg := &Config{}
+
+	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// LoadFile parses the given YAML file into a Config.
+func LoadFile(filename string) (*Config, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := Load(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("parsing YAML file %s: %w", filename, err)
+	}
+	return cfg, nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca-agent/pkg/config"
+)
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	_, err := config.Load(`relabel_configs:
+- source_labels: [systemd_unit]
+  regex: ^$
+  action: drop
+`)
+	require.Nil(t, err)
+}

--- a/pkg/profiler/noop.go
+++ b/pkg/profiler/noop.go
@@ -17,6 +17,9 @@ package profiler
 import (
 	"context"
 	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 // NoopProfiler does nothing. It serves as a skeleton of what other will have
@@ -32,6 +35,14 @@ func (p *NoopProfiler) Run(_ context.Context) error {
 }
 
 func (p *NoopProfiler) Stop() {
+}
+
+func (p *NoopProfiler) Labels(pid PID) model.LabelSet {
+	return model.LabelSet{}
+}
+
+func (p *NoopProfiler) Relabel(model.LabelSet) labels.Labels {
+	return labels.Labels{}
 }
 
 func (p *NoopProfiler) LastProfileStartedAt() time.Time {

--- a/pkg/template/statuspage.html
+++ b/pkg/template/statuspage.html
@@ -20,7 +20,7 @@ table {
 
 th, td {
   text-align: left;
-  padding: 16px;
+  padding: 4px 8px;
 }
 
 tr:nth-child(even) {
@@ -103,6 +103,7 @@ tr:hover {
                     <table style="width:100%">
                         <tr>
                             <th>PID</th>
+                            <th>Profiler</th>
                             <th>Labels</th>
                             <th>Profiling Status</th>
                             <th>Errors</th>
@@ -115,38 +116,44 @@ tr:hover {
                             <td>
                                 {{ .PID }}
                             </td>
+                            <td>
+                                {{ .Profiler }}
+                            </td>
                             <td style="line-height:160%;max-width:min-content;">
                                 {{- range $label := .Labels }}
+                                {{- if eq .Name "__name__" "pid" | not }}
                                 <span class='label'>{{ .Name }}:"{{ .Value }}"</span>
                                 {{- end }}
-                            </td>
-                            <td style="white-space:nowrap">
-                                {{- range $profiler, $status := .ProfilingStatus }}
-                                <span class="status {{ $status }}" title="{{ $status }}">●</span> {{ $profiler }}</br>
                                 {{- end }}
                             </td>
                             <td>
-                                {{- range $profiler, $error := .Errors }}
-                                {{ $profiler }}: {{ $error }}
-                                {{- end }}
+                                <span class="status {{ .ProfilingStatus }}" title="{{ .ProfilingStatus }}">●</span>
+                            </td>
+                            <td>
+                                {{ .Error }}
                             </td>
                             {{- if $root.ProfileLinksEnabled }}
                             <td>
-                                {{- range $name, $link := .Links }}
-                                <a title='May take up to {{ $root.ProfilingInterval }} to display' href='{{ $link }}'>Show next {{ $name }} profile</a></br>
-                                {{- end }}
+                                <a title='May take up to {{ $root.ProfilingInterval }} to display' href='{{ .Link }}'>Show next profile</a></br>
                             </td>
                             {{- end }}
                         </tr>
                         {{- else }}
                         <tr>
                             <td>
-                                No running processes (this should never happen)
+                                No running processes matching configuration
                             </td>
                         </tr>
                         {{- end }}
                     </table>
                 </details>
+        </div>
+        <div>
+            <h2>Configuration</h2>
+            <details>
+                <summary>Content</summary>
+                <pre><code>{{ .Config }}</code></pre>
+            </details>
         </div>
         <div>
             <h2>Prometheus Metrics</h2>

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -35,10 +35,11 @@ type ActiveProfiler struct {
 
 type Process struct {
 	PID             int
+	Profiler        string
 	Labels          labels.Labels
-	ProfilingStatus map[string]string
-	Errors          map[string]error
-	Links           map[string]string
+	ProfilingStatus string
+	Error           error
+	Link            string
 }
 
 type StatusPage struct {
@@ -46,4 +47,5 @@ type StatusPage struct {
 	ProfileLinksEnabled bool
 	ActiveProfilers     []ActiveProfiler
 	Processes           []Process
+	Config              string
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -32,13 +32,15 @@ func TestStatusPageTemplate(t *testing.T) {
 	err = StatusPageTemplate.Execute(res, &StatusPage{
 		ProfilingInterval:   time.Second * 10,
 		ProfileLinksEnabled: true,
+		Config:              "{}\n",
 		ActiveProfilers: []ActiveProfiler{{
 			Name:           "fake_profiler",
 			NextStartedAgo: time.Second * 3,
 			Error:          errors.New("test"),
 		}},
 		Processes: []Process{{
-			PID: 1,
+			PID:      1,
+			Profiler: "fake_profiler",
 			Labels: []labels.Label{
 				{
 					Name:  "name1",
@@ -48,15 +50,9 @@ func TestStatusPageTemplate(t *testing.T) {
 					Value: "value2",
 				},
 			},
-			ProfilingStatus: map[string]string{
-				"fake_profiler": "errors",
-			},
-			Errors: map[string]error{
-				"fake_profiler": errors.New("test"),
-			},
-			Links: map[string]string{
-				"fake_profiler": "/test123",
-			},
+			ProfilingStatus: "errors",
+			Error:           errors.New("test"),
+			Link:            "/test123",
 		}},
 	})
 	require.NoError(t, err)

--- a/pkg/template/testdata/statuspage.html
+++ b/pkg/template/testdata/statuspage.html
@@ -19,7 +19,7 @@ table {
 
 th, td {
   text-align: left;
-  padding: 16px;
+  padding: 4px 8px;
 }
 
 tr:nth-child(even) {
@@ -94,6 +94,7 @@ tr:hover {
                     <table style="width:100%">
                         <tr>
                             <th>PID</th>
+                            <th>Profiler</th>
                             <th>Labels</th>
                             <th>Profiling Status</th>
                             <th>Errors</th>
@@ -103,22 +104,33 @@ tr:hover {
                             <td>
                                 1
                             </td>
+                            <td>
+                                fake_profiler
+                            </td>
                             <td style="line-height:160%;max-width:min-content;">
                                 <span class='label'>name1:"value1"</span>
                                 <span class='label'>name2:"value2"</span>
                             </td>
-                            <td style="white-space:nowrap">
-                                <span class="status errors" title="errors">●</span> fake_profiler</br>
+                            <td>
+                                <span class="status errors" title="errors">●</span>
                             </td>
                             <td>
-                                fake_profiler: test
+                                test
                             </td>
                             <td>
-                                <a title='May take up to 10s to display' href='/test123'>Show next fake_profiler profile</a></br>
+                                <a title='May take up to 10s to display' href='/test123'>Show next profile</a></br>
                             </td>
                         </tr>
                     </table>
                 </details>
+        </div>
+        <div>
+            <h2>Configuration</h2>
+            <details>
+                <summary>Content</summary>
+                <pre><code>{}
+</code></pre>
+            </details>
         </div>
         <div>
             <h2>Prometheus Metrics</h2>


### PR DESCRIPTION
This adds supports for `relabel_configs: []` via an optional configuration file.

There are some awkward back-and-forths between `model.LabelSet` and `labels.Labels` types, I tried to minimize them as much as possible.

On the long-run, how and where labels/metadata are managed will need to be rethought.

I had to re-arrange the status page once again to ensure relabeling works with the full set of labels for each profile types.

Following this PR, I have in mind:

* add back k8s/cgroup/systemd flags for best-effort backward compatibility and keep them for 1 or 2 minor releases (#690), this only require appending a relabel config for each case
* update the agent documentation
* reload configuration on-change

Closes #7 and #690