### PR TITLE
libbpf: Upgrade to libbpf v1.0.1

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -65,7 +65,7 @@ $(OUT_BPF): $(BPF_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(BPF_HEADERS) | $(OUT_DI
 		-D__BPF_TRACING__ \
 		-D__KERNEL__ \
 		-D__TARGET_ARCH_$(LINUX_ARCH) \
-		-I $(LIBBPF_HEADERS)/bpf \
+		-I $(LIBBPF_HEADERS) \
 		-I $(BPF_HEADERS) \
 		-Wno-address-of-packed-member \
 		-Wno-compare-distinct-pointer-types \

--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -11,10 +11,10 @@
 // TODO(kakkoyun): Split into multiple files.
 #include "../common.h"
 
-#include <bpf_core_read.h> // TODO(kakkoyun): Validate if this is needed.
-#include <bpf_endian.h>
-#include <bpf_helpers.h>
-#include <bpf_tracing.h> // TODO(kakkoyun): Validate if this is needed.
+#include <bpf/bpf_core_read.h> // TODO(kakkoyun): Validate if this is needed.
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h> // TODO(kakkoyun): Validate if this is needed.
 
 // NOTICE: Please check out
 // https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md for the

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/alecthomas/kong v0.6.1
-	github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0
+	github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible h1:9gWa46nstkJ9miBReJcN8Gq34cBFbzSpQZVVT9N09TM=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0 h1:NQEf484vQOshZwZOLTE7kzo62TvYrM906gUjlVg4D2k=
-github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
+github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0 h1:WHKqRRCVhEI5CG/2gqKhTZ494QeriVe/cuQrpkHzTAk=
+github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
Upgrade to libbpfgo@v0.4.0-libbpf-1.0.1

## Test Plan

**e2e test with Parca and Parca Agent running side by side**

<img width="1642" alt="image" src="https://user-images.githubusercontent.com/959128/195541222-31f25058-24f8-4d77-af15-cb2b6c2bae39.png">

**Ensure that there are no warnings**

```
[javierhonduco@fedora parca-agent]$ sudo dist/parca-agent --log-level=debug --node=info |& grep -e libbpf


```


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>