### PR TITLE
pkg/metadata: Cache compiler metadata output

### DIFF
--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -17,14 +17,29 @@ package metadata
 import (
 	"debug/elf"
 	"fmt"
+	"sync"
 
+	burrow "github.com/goburrow/cache"
 	"github.com/keybase/go-ps"
 	"github.com/prometheus/common/model"
 	"github.com/xyproto/ainur"
+
+	"github.com/parca-dev/parca-agent/pkg/buildid"
 )
+
+var (
+	c            burrow.Cache
+	onceCompiler sync.Once
+)
+
+func initialiseCache() {
+	c = burrow.New(burrow.WithMaximumSize(128))
+}
 
 // Compiler provides metadata for determined compiler.
 func Compiler() *Provider {
+	onceCompiler.Do(initialiseCache)
+
 	return &Provider{"compiler", func(pid int) (model.LabelSet, error) {
 		process, err := ps.FindProcess(pid)
 		if err != nil {
@@ -38,17 +53,34 @@ func Compiler() *Provider {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get path for process %d: %w", pid, err)
 		}
-		file, err := elf.Open(path)
+		elf, err := elf.Open(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open ELF file for process %d: %w", pid, err)
 		}
-		defer file.Close()
+		defer elf.Close()
 
-		return model.LabelSet{
+		buildID, err := buildid.BuildID(path)
+		if err != nil {
+			return nil, fmt.Errorf("buildID failed")
+		}
+
+		value, ok := c.GetIfPresent(buildID)
+		if ok {
+			cachedLabels, ok := value.(model.LabelSet)
+			if !ok {
+				panic("The buildID cache contained the wrong type. This should never happen")
+			}
+			return cachedLabels, nil
+		}
+
+		labels := model.LabelSet{
 			"executable": model.LabelValue(process.Executable()),
-			"compiler":   model.LabelValue(ainur.Compiler(file)),
-			"stripped":   model.LabelValue(fmt.Sprintf("%t", ainur.Stripped(file))),
-			"static":     model.LabelValue(fmt.Sprintf("%t", ainur.Static(file))),
-		}, nil
+			"compiler":   model.LabelValue(ainur.Compiler(elf)),
+			"stripped":   model.LabelValue(fmt.Sprintf("%t", ainur.Stripped(elf))),
+			"static":     model.LabelValue(fmt.Sprintf("%t", ainur.Static(elf))),
+		}
+
+		c.Put(buildID, labels)
+		return labels, nil
 	}}
 }


### PR DESCRIPTION
**TL;DR:** >40% of the Parca Agent CPU cycles are spent reading all the elf symbols for each binary to see whether they are stripped or not. Some extra cycles come from added pressure on the garbage collector


The compiler metadata, specifically, the stripped check, consumes a large amount of CPU as it parses and traverses the whole symbol table for each process running on the system.

This first commit caches the compiler metadata using the BuildID as the caching key.

I noticed that while checking CPU profiles in our demo environment:

![image](https://user-images.githubusercontent.com/959128/195559566-82d0a48e-19e2-41e0-9d5b-b847d932c8ce.png)


## Test Plan

I Ran Parca and Parca Agent side by side, and everything looked good, the compiler metadata uses way fewer cycles

![image](https://user-images.githubusercontent.com/959128/195562128-f1a94a8e-4965-4cd8-a29f-5a5b3f8d8ce7.png)

## Future work

The `string => elf.File` refactor in https://github.com/parca-dev/parca-agent/pull/876 was mostly to improve the API, performance-wise the impact of that is not very big. Will tackle this in another PR!


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>