### PR TITLE
.eh_frame: Add unwinding table tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get install -yq libelf-dev zlib1g-dev llvm-11
           sudo ln -s /usr/lib/llvm-11/bin/* /usr/local/bin/
 
-      - name: Initialize and update libbpf submodule
+      - name: Initialize and update git submodules
         run: git submodule init && git submodule update
 
       - name: Build libbpf
@@ -86,7 +86,9 @@ jobs:
       - name: Test
         run: |
           make test ENABLE_RACE=yes
-          # make test/profiler (Needs to be fixed, somehow fails because of generics)
+
+      - name: Test unwind tables
+        run: make test-dwarf-unwind-tables
 
       - name: Format
         run: make format-check

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "github.com/libbpf/libbpf"]
 	path = 3rdparty/libbpf
 	url = https://github.com/libbpf/libbpf.git
+[submodule "github.com/parca-dev/testdata"]
+	path = testdata
+	url = https://github.com/parca-dev/testdata

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,12 @@ $(OUT_BIN_EH_FRAME): go/deps
 	find dist -exec touch -t 202101010000.00 {} +
 	$(GO) build $(SANITIZERS) -tags osusergo -mod=readonly -trimpath -v -o $@ ./cmd/eh-frame
 
+write-dwarf-unwind-tables: build
+	make -C testdata validate EH_FRAME_BIN=../dist/eh-frame
+
+test-dwarf-unwind-tables: write-dwarf-unwind-tables
+	git diff --exit-code
+
 .PHONY: go/deps
 go/deps:
 	$(GO) mod tidy

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -16,8 +16,24 @@ package unwind
 
 import (
 	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
 )
 
-// TODO(javierhonduco): Add test.
 func TestBuildUnwindTable(t *testing.T) {
+	logger := log.NewNopLogger()
+	ptb := NewUnwindTableBuilder(logger)
+
+	fdes, err := ptb.readFDEs("../../../testdata/out/basic-cpp", 0)
+	require.NoError(t, err)
+
+	unwindTable := buildTable(fdes)
+	require.Equal(t, 38, len(unwindTable))
+
+	require.Equal(t, uint64(0x401020), unwindTable[0].Loc)
+	require.Equal(t, uint64(0x40118e), unwindTable[len(unwindTable)-1].Loc)
+
+	require.Equal(t, Instruction{Op: OpCFAOffset, Offset: -8}, unwindTable[0].RA)
+	require.Equal(t, Instruction{Op: OpRegister, Reg: 0x7, Offset: 8}, unwindTable[0].CFA)
 }


### PR DESCRIPTION
This PR adds a new submodule under `testdata/`, which contains [the executables and their expected unwind tables](https://github.com/parca-dev/testdata/tree/main/tables).

## Test plan

**Run Go tests**

```
$ make tests
```

**Unwind tables snapshot tests**

```
$ make test-dwarf-unwind-tables
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>