### PR TITLE
Adjust snap package to use classic confinement

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -188,14 +188,7 @@ jobs:
 
       - name: Install snap & invoke Parca Agent
         run: |
-          # TODO(jnsgruk): Undo this once a new snapd is released
-          sudo snap refresh snapd --channel=latest/edge
-
-          sudo snap install --dangerous *_amd64.snap
-
-          # Connect sensitive interfaces; this is done automatically for "real" installs
-          sudo snap connect parca-agent:system-trace
-          sudo snap connect parca-agent:system-observe
+          sudo snap install --classic --dangerous *_amd64.snap
 
           sudo snap set parca-agent log-level=debug
           parca-agent --help

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -231,23 +231,23 @@ jobs:
         run: |
           sudo snap logs parca-agent -n=all
 
-  # release-edge:
-  #   name: Release Snap (latest/edge)
-  #   needs: test
-  #   if: ${{ github.event_name != 'pull_request' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3.0.0
-  #       with:
-  #         name: built-snaps
+  release-edge:
+    name: Release Snap (latest/edge)
+    needs: test
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # tag=v3.0.0
+        with:
+          name: built-snaps
 
-  #     - name: Install snapcraft
-  #       run: |
-  #         sudo snap install snapcraft --classic --channel=7.x/stable
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic --channel=7.x/stable
 
-  #     - name: Release to latest/edge
-  #       env:
-  #         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-  #       run: |
-  #         snapcraft upload *_amd64.snap --release edge
-  #         snapcraft upload *_arm64.snap --release edge
+      - name: Release to latest/edge
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          snapcraft upload *_amd64.snap --release edge
+          snapcraft upload *_arm64.snap --release edge

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ contact: https://parca.dev
 issues: https://github.com/parca-dev/parca-agent/issues
 source-code: https://github.com/parca-dev/parca-agent
 website: https://parca.dev
-confinement: strict
+confinement: classic
 grade: stable
 base: core22
 compression: lzo
@@ -46,18 +46,8 @@ parts:
 apps:
   parca-agent:
     command: parca-agent
-    plugs:
-      - network-bind
-      - network
-      - system-trace
-      - system-observe
   parca-agent-svc:
     command: parca-agent-wrapper
     daemon: simple
     install-mode: disable
     restart-condition: never
-    plugs:
-      - network-bind
-      - network
-      - system-trace
-      - system-observe


### PR DESCRIPTION
After some thought, I think the way `parca-agent` accesses the underlying system makes it a more compelling candidate for `classic` confinement, rather than `strict`.

:warning:  This PR shouldn't be merged until the store have enabled classic confinement for this snap - I'll post back when that's done and take care of that getting sorted. :warning: 