### PR TITLE
.eh_frame: Bubble up DWARF expressions and value registers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ write-dwarf-unwind-tables: build
 	make -C testdata validate EH_FRAME_BIN=../dist/eh-frame
 
 test-dwarf-unwind-tables: write-dwarf-unwind-tables
-	git diff --exit-code
+	git diff --exit-code testdata/
 
 .PHONY: go/deps
 go/deps:

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -1,4 +1,4 @@
-//nolint:stylecheck,deadcode,unused
+//nolint:stylecheck
 package frame
 
 import (
@@ -7,6 +7,20 @@ import (
 	"fmt"
 
 	"github.com/parca-dev/parca-agent/internal/dwarf/util"
+)
+
+// Rule rule defined for register values.
+type Rule byte
+
+const (
+	RuleUndefined Rule = iota
+	RuleSameVal
+	RuleOffset
+	RuleValOffset
+	RuleRegister
+	RuleExpression
+	RuleValExpression
+	RuleCFA // Value is rule.Reg + rule.Offset
 )
 
 // DWRule wrapper of rule defined for register values.
@@ -161,22 +175,6 @@ func CFAString(b byte) string {
 	return str
 }
 
-// Rule rule defined for register values.
-type Rule byte
-
-const (
-	RuleUndefined Rule = iota
-	RuleSameVal
-	RuleOffset
-	RuleValOffset
-	RuleRegister
-	RuleExpression
-	RuleValExpression
-	RuleArchitectural
-	RuleCFA          // Value is rule.Reg + rule.Offset
-	RuleFramePointer // Value is stored at address rule.Reg + rule.Offset, but only if it's less than the current CFA, otherwise same value
-)
-
 const low_6_offset = 0x3f
 
 type instruction func(ctx *Context)
@@ -233,16 +231,6 @@ func executeCIEInstructions(cie *CommonInformationEntry) *Context {
 	}
 	frame.executeDwarfProgram()
 	return frame
-}
-
-// Unwind the stack to find the return address register.
-func executeDwarfProgramUntilPC(fde *FrameDescriptionEntry, pc uint64) *Context {
-	ctx := executeCIEInstructions(fde.CIE)
-	frame := ctx.currentInstruction()
-	ctx.order = fde.order
-	frame.loc = fde.Begin()
-	frame.address = pc
-	return ctx
 }
 
 // ExecuteDwarfProgram unwinds the stack to find the return address register.

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
 )
 
 func TestBuildUnwindTable(t *testing.T) {
@@ -34,6 +36,6 @@ func TestBuildUnwindTable(t *testing.T) {
 	require.Equal(t, uint64(0x401020), unwindTable[0].Loc)
 	require.Equal(t, uint64(0x40118e), unwindTable[len(unwindTable)-1].Loc)
 
-	require.Equal(t, Instruction{Op: OpCFAOffset, Offset: -8}, unwindTable[0].RA)
-	require.Equal(t, Instruction{Op: OpRegister, Reg: 0x7, Offset: 8}, unwindTable[0].CFA)
+	require.Equal(t, frame.DWRule{Rule: frame.RuleOffset, Offset: -8}, unwindTable[0].RA)
+	require.Equal(t, frame.DWRule{Rule: frame.RuleCFA, Reg: 0x7, Offset: 8}, unwindTable[0].CFA)
 }


### PR DESCRIPTION
And print them accordingly. This implementation mostly comes from this commit: https://github.com/parca-dev/parca-agent/pull/744/commits/e1ac8c62bc6a2715a170b095ae5e198f0e104a74, but also cleans up the code to make it less confusing and adds some assertions in the form of panics to ensure that things are working the way we expect. We might change this in the future once this code is more battle-tested.

The tables have been regenerated and tested in https://github.com/parca-dev/testdata/commit/483300c38df358af9aca8938b648953723c3f75c

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>