### PR TITLE
pkg/ksym: Add benchmarks for the kernel symbolizer

### DIFF
--- a/pkg/ksym/ksym_test.go
+++ b/pkg/ksym/ksym_test.go
@@ -242,3 +242,33 @@ ffffffff8f6d15c4 a not_in_order
 		addr2 + 1: "xfrm_km_lock",
 	}, syms)
 }
+
+var errLoadKsyms error
+
+func BenchmarkLoadKernelSymbols(b *testing.B) {
+	b.ReportAllocs()
+
+	c := NewKsymCache(
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+	)
+
+	for n := 0; n < b.N; n++ {
+		errLoadKsyms = c.loadKsyms()
+	}
+}
+
+var kallsymsResult uint64
+
+func BenchmarkHashProcKallSyms(b *testing.B) {
+	b.ReportAllocs()
+
+	c := NewKsymCache(
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+	)
+
+	for n := 0; n < b.N; n++ {
+		kallsymsResult, _ = c.kallsymsHash()
+	}
+}


### PR DESCRIPTION
Checking Parca's CPU profiles it was clear that the `kallsymsHash()` function consumes a non-trivial amount of CPU time, around ~8% of the Agent's CPU cycles, while `loadKsyms()` barely appears in them.

This makes sense, as the kernel symbols won't change often, so most of the time, the hash won't change and we won't re-read the kernel symbols and rebuild its table.

I wanted to understand the benefit of doing the hash and in case it's not the same, re-loading the kernel symbols, so wrote some simple benchmarks to understand the CPU and memory usage.

```
[javierhonduco@fedora testdata]$ go test -v github.com/parca-dev/parca-agent/pkg/ksym  -bench=.
=== RUN   TestEnsureKsymSizeDoesNotGrow
--- PASS: TestEnsureKsymSizeDoesNotGrow (0.00s)
=== RUN   TestKsym
--- PASS: TestKsym (0.00s)
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/ksym
cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
BenchmarkStringParsing
BenchmarkStringParsing-12                1739517               631.0 ns/op
BenchmarkUnsafeString
BenchmarkUnsafeString-12                106434932               11.09 ns/op
BenchmarkLoadKernelSymbols
BenchmarkLoadKernelSymbols-12                 14          83897211 ns/op        14631925 B/op      86669 allocs/op
BenchmarkHashProcKallSyms
BenchmarkHashProcKallSyms-12                  18          63232964 ns/op          100204 B/op          7 allocs/op
PASS
ok      github.com/parca-dev/parca-agent/pkg/ksym       6.293s
```

As it can be seen here, while they are both roughtly fast, the Hashing path perfoms ~12.000x fewer memory allocations, which is a pretty big win.

Given that we already spend >35% of our CPU cycles in garbage collector, putting less pressure on it seems great!

Pushing the benchmarks in case something changes in the future and also in case somebody is also curious about the tradeoffs we are making and how hashing is useful here.


<img width="958" alt="image" src="https://user-images.githubusercontent.com/959128/196911442-7960f510-a80c-485b-92d9-cd0a4f3bd717.png">

<img width="713" alt="image" src="https://user-images.githubusercontent.com/959128/196911556-dc822eb9-5091-4eb5-9df2-94abe5d474cf.png">

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>