### PR TITLE
Native stack walking with DWARF v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,9 @@ go/lint:
 go/lint-fix:
 	$(GO_ENV) golangci-lint run --fix
 
+.PHONY: bpf/lint
+bpf/lint:
+	$(MAKE) -C bpf lint
 
 .PHONY: bpf/lint-fix
 bpf/lint-fix:

--- a/Makefile
+++ b/Makefile
@@ -187,9 +187,6 @@ go/lint:
 go/lint-fix:
 	$(GO_ENV) golangci-lint run --fix
 
-.PHONY: bpf/lint
-bpf/lint:
-	$(MAKE) -C bpf lint
 
 .PHONY: bpf/lint-fix
 bpf/lint-fix:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Flags:
                                   Ordered list of local directories to
                                   search for debug info files. Defaults to
                                   /usr/lib/debug.
+      --experimental-dwarf-unwinding-pids=EXPERIMENTAL-DWARF-UNWINDING-PIDS,...
+                                  Unwind stack using .eh_frame information for
+                                  these processes.
 ```
 
 ### Cgroups

--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -1,47 +1,40 @@
 // +build ignore
 // ^^ this is a golang build tag meant to exclude this C file from compilation
 // by the CGO compiler
+//
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 The Parca Authors
+//
+// NOTICE: When modifying this code, check
+// https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md for the
+// features supported by which kernels.
 
-// TODO(kakkoyun): Remove unused macros and functions.
-
-#define KBUILD_MODNAME "parca-agent"
-
-#undef container_of
-
-// TODO(kakkoyun): Split into multiple files.
 #include "../common.h"
 
-#include <bpf/bpf_core_read.h> // TODO(kakkoyun): Validate if this is needed.
+#include <bpf/bpf_core_read.h>
 #include <bpf/bpf_endian.h>
 #include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h> // TODO(kakkoyun): Validate if this is needed.
+#include <bpf/bpf_tracing.h>
 
-// NOTICE: Please check out
-// https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md for the
-// features supported by Agent's minimum required kernel version.
+/*================================ CONSTANTS =================================*/
 
-// TODO(kakkoyun): Remove bpf_printk calls! /sys/kernel/tracing/trace_pipe
-// TODO(kakkoyun): Use bpftool to debug!
+#define MAX_STACK_DEPTH 127 // Max depth of each stack trace to track
 
-volatile const char bpf_metadata_name[] SEC(".rodata") =
-    "parca-agent (https://github.com/parca-dev/parca-agent)";
+#define MAX_STACK_ADDRESSES 1024 // Num of unique stack traces.
+#define MAX_ENTRIES                                                            \
+  10240 // Num entries for the `stack_counts` map. Unused atm.
+        // TODO(javierhonduco): use this later on.
+#define UNWIND_TABLES_MAX_STACK_DEPTH                                          \
+  100 // Max depth of each stack trace to track. TODO(javierhonduco): just to
+      // debug. Set to a larger number.
+#define MAX_PID_MAP_SIZE                                                       \
+  256 // Size of the `<PID, unwind_table>` mapping. Determines how many
+      // processes we can unwind.
+#define MAX_BINARY_SEARCH_DEPTH                                                \
+  20 // Binary search iterations. 2ˆ20 can bisect ~1_048_576 entries.
+#define MAX_UNWIND_TABLE_SIZE 130 * 1000 // Size of the unwind_table.
 
-unsigned int VERSION SEC("version") = 1;
-char LICENSE[] SEC("license") = "GPL";
-
-// TODO(kakkoyun): Is there a use case for this?
-#if defined(bpf_target_x86)
-#define PT_REGS_PARM6(ctx) ((ctx)->r9)
-#elif defined(bpf_target_arm64)
-#define PT_REGS_PARM6(x) (((PT_REGS_ARM64 *)(x))->regs[5])
-#endif
-
-// Max amount of different stack trace addresses to buffer in the Map
-#define MAX_STACK_ADDRESSES 1024
-// Max depth of each stack trace to track
-#define MAX_STACK_DEPTH 127
-
-/*================================ eBPF MAPS =================================*/
+/*============================== MACROS =====================================*/
 
 #define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries)            \
   struct {                                                                     \
@@ -58,23 +51,187 @@ typedef __u64 stack_trace_type[MAX_STACK_DEPTH];
 #define BPF_STACK_TRACE(_name, _max_entries)                                   \
   BPF_MAP(_name, BPF_MAP_TYPE_STACK_TRACE, u32, stack_trace_type, _max_entries);
 
-#define BPF_HASH(_name, _key_type, _value_type)                                \
-  BPF_MAP(_name, BPF_MAP_TYPE_HASH, _key_type, _value_type, 10240);
+#define BPF_HASH(_name, _key_type, _value_type, _max_entries)                  \
+  BPF_MAP(_name, BPF_MAP_TYPE_HASH, _key_type, _value_type, _max_entries);
 
+#define DEFINE_COUNTER(__func__name)                                           \
+  static void BUMP_##__func__name() {                                          \
+    u32 *c = bpf_map_lookup_elem(&percpu_stats, &__func__name);                \
+    if (c != NULL) {                                                           \
+      *c += 1;                                                                 \
+    }                                                                          \
+  }
 /*============================= INTERNAL STRUCTS ============================*/
+
+// The addresses of a native stack trace.
+typedef struct stack_trace_t {
+  u64 len;
+  u64 addresses[MAX_STACK_DEPTH];
+} stack_trace_t;
 
 typedef struct stack_count_key {
   u32 pid;
   int user_stack_id;
   int kernel_stack_id;
+  stack_trace_t unwind_table_frames;
 } stack_count_key_t;
 
+// A row in the stack unwinding table.
+// PERF(javierhonduco): in the future, split this struct from a buffer of
+// `stack_unwind_row`` to multiple buffers containing each field. That way we
+// would be able to not only have more entries, but we would increase
+// performance as more data will be able to fit in the CPU cache.
+//
+// This is particularly important for the program counter => map<pid, pcs> +
+// map<pid, other_data>. the second map can be split further if we decide to do
+// so.
+//
+// This is at the cost of code readability, so should only be done if
+// experiments confirm this theory.
+//
+// PERF(javierhonduco): Some of these types use a bigger type than we need, but
+// this makes prototyping easier as no padding should be added between fields.
+// Later on, we can make this more compact, which again, will allow us to pack
+// more items + make a better use of the CPU caches.
+typedef struct stack_unwind_row {
+  u64 pc;
+  u64 cfa_reg;
+  s64 cfa_offset;
+  s64 rbp_offset;
+} stack_unwind_row_t;
+
+// Unwinding table representation.
+typedef struct stack_unwind_table_t {
+  u64 table_len; // size of the table, as the max size is static.
+  stack_unwind_row_t rows[MAX_UNWIND_TABLE_SIZE];
+} stack_unwind_table_t;
+
+// Context for the binary search. We mutate it on every step and at the end
+// we read the resulting values.
+struct callback_ctx {
+  u64 pc;                      // the needle.
+  stack_unwind_table_t *table; // the haystack.
+  u32 found;
+  u32 left;  // current left index.
+  u32 right; // current right index.
+};
+
+// TODO(javierhonduco): Improve register list, this is just the two
+// registers we need for x86_64.
+enum registers {
+  X86_64_REGISTER_RBP = 6,
+  X86_64_REGISTER_RSP = 7,
+};
+
+// Statistics.
+//
+// We reached main.
+u32 UNWIND_SUCCESS = 1;
+// Partial stack was retrieved.
+u32 UNWIND_TRUNCATED = 2;
+// An (unhandled) dwarf expression was found.
+u32 UNWIND_UNSUPPORTED_EXPRESSION = 3;
+// Any other error, such as failed memory reads.
+// TODO(javierhonduco): split this error into subtypes.
+u32 UNWIND_CATCHALL_ERROR = 4;
+// Errors that should never happen.
+u32 UNWIND_SHOULD_NEVER_HAPPEN_ERROR = 5;
+// PC not in table (Kernel PC?).
+u32 UNWIND_PC_NOT_COVERED_ERROR = 6;
+// Keep track of total samples.
+u32 UNWIND_SAMPLES_COUNT = 7;
 /*================================ MAPS =====================================*/
 
-BPF_HASH(counts, stack_count_key_t, u64);
+BPF_HASH(stack_counts, stack_count_key_t, u64, MAX_ENTRIES);
+
 BPF_STACK_TRACE(stack_traces, MAX_STACK_ADDRESSES);
+BPF_HASH(unwind_tables, pid_t, stack_unwind_table_t, MAX_PID_MAP_SIZE);
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, 1);
+  __type(key, __u32);
+  __type(value, stack_count_key_t);
+} heap SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, 10);
+  __type(key, __u32);
+  __type(value, __u32);
+} percpu_stats SEC(".maps");
 
 /*=========================== HELPER FUNCTIONS ==============================*/
+
+DEFINE_COUNTER(UNWIND_SUCCESS);
+DEFINE_COUNTER(UNWIND_TRUNCATED);
+DEFINE_COUNTER(UNWIND_UNSUPPORTED_EXPRESSION);
+DEFINE_COUNTER(UNWIND_SHOULD_NEVER_HAPPEN_ERROR);
+DEFINE_COUNTER(UNWIND_CATCHALL_ERROR);
+DEFINE_COUNTER(UNWIND_PC_NOT_COVERED_ERROR);
+
+static void unwind_print_stats() {
+  u32 *success_counter = bpf_map_lookup_elem(&percpu_stats, &UNWIND_SUCCESS);
+  if (success_counter == NULL) {
+    return;
+  }
+
+  u32 *total_counter =
+      bpf_map_lookup_elem(&percpu_stats, &UNWIND_SAMPLES_COUNT);
+  if (total_counter == NULL) {
+    return;
+  }
+
+  u32 *truncated_counter =
+      bpf_map_lookup_elem(&percpu_stats, &UNWIND_TRUNCATED);
+  if (truncated_counter == NULL) {
+    return;
+  }
+
+  u32 *unsup_expression =
+      bpf_map_lookup_elem(&percpu_stats, &UNWIND_UNSUPPORTED_EXPRESSION);
+  if (unsup_expression == NULL) {
+    return;
+  }
+
+  u32 *not_covered_count =
+      bpf_map_lookup_elem(&percpu_stats, &UNWIND_PC_NOT_COVERED_ERROR);
+  if (not_covered_count == NULL) {
+    return;
+  }
+
+  u32 *catchall_count =
+      bpf_map_lookup_elem(&percpu_stats, &UNWIND_CATCHALL_ERROR);
+  if (catchall_count == NULL) {
+    return;
+  }
+
+  u32 *never =
+      bpf_map_lookup_elem(&percpu_stats, &UNWIND_SHOULD_NEVER_HAPPEN_ERROR);
+  if (never == NULL) {
+    return;
+  }
+
+  bpf_printk("[[ stats for cpu %d ]]", (int)bpf_get_smp_processor_id());
+  bpf_printk("success=%lu", *success_counter);
+  bpf_printk("unsup_expression=%lu", *unsup_expression);
+  bpf_printk("truncated=%lu", *truncated_counter);
+  bpf_printk("catchall=%lu", *catchall_count);
+  bpf_printk("never=%lu", *never);
+
+  bpf_printk("total_counter=%lu", *total_counter);
+  bpf_printk("(not_covered=%lu)", *not_covered_count);
+}
+
+static void bump_samples() {
+  u32 *c = bpf_map_lookup_elem(&percpu_stats, &UNWIND_SAMPLES_COUNT);
+  if (c != NULL) {
+    *c += 1;
+    if (*c % 50 == 0) {
+      unwind_print_stats();
+    }
+  }
+}
 
 static __always_inline void *
 bpf_map_lookup_or_try_init(void *map, const void *key, const void *init) {
@@ -95,7 +252,252 @@ bpf_map_lookup_or_try_init(void *map, const void *key, const void *init) {
 
 /*================================= HOOKS ==================================*/
 
-// This code gets a bit complex. Probably not suitable for casual hacking.
+// This function does 1 iteration of the binary search.
+// It's called via `bpf_loop` as the BPF verifier is unable
+// to verify a single function that does all the steps.
+//
+// (See comment around the call-site.)
+//
+// Experimentally, I have seen that ~7 iterations could
+// be completed with the approach I previously tried, but
+// unfortunately, that's just ~128 (2^7) entries, which
+// won't be enough for most tables.
+//
+// In my tests a very small binary already has 60k entries,
+// so it requires ~log2(60k) ~= 16 iterations to find an entry
+// in this case.
+static int find_offset_for_pc(__u32 index, void *data) {
+  struct callback_ctx *ctx = data;
+
+  // TODO(javierhonduco): ensure that this condition is right as we use
+  // unsigned values...
+  if (ctx->left >= ctx->right) {
+    bpf_printk("\t.done");
+    return 1;
+  }
+
+  u32 mid = (ctx->left + ctx->right) / 2;
+
+  // Appease the verifier.
+  if (mid < 0 || mid >= MAX_UNWIND_TABLE_SIZE) {
+    bpf_printk("\t.should never happen");
+    BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
+    return 1;
+  }
+
+  // Debug logs.
+  // bpf_printk("\t-> fetched PC %llx, target PC %llx (iteration %d/%d, mid: %d,
+  // left:%d, right:%d)", ctx->table->rows[mid].pc, ctx->pc, index,
+  // MAX_BINARY_SEARCH_DEPTH, mid, ctx->left, ctx->right);
+  if (ctx->table->rows[mid].pc <= ctx->pc) {
+    ctx->found = mid;
+    ctx->left = mid + 1;
+  } else {
+    ctx->right = mid;
+  }
+
+  // Debug logs.
+  // bpf_printk("\t<- fetched PC %llx, target PC %llx (iteration %d/%d, mid: --,
+  // left:%d, right:%d)", ctx->table->rows[mid].pc, ctx->pc, index,
+  // MAX_BINARY_SEARCH_DEPTH, ctx->left, ctx->right);
+
+  return 0;
+}
+
+// Print an unwinding table row for debugging.
+static __always_inline void show_row(stack_unwind_table_t *unwind_table,
+                                     int index) {
+  u64 pc = unwind_table->rows[index].pc;
+  int cfa_reg = unwind_table->rows[index].cfa_reg;
+  int cfa_offset = unwind_table->rows[index].cfa_offset;
+  int rbp_offset = unwind_table->rows[index].rbp_offset;
+
+  bpf_printk("~ %d entry. Loc: %llx, CFA reg: %d Offset: %d, $rbp %d", index,
+             pc, cfa_reg, cfa_offset, rbp_offset);
+}
+static __always_inline int
+walk_user_stacktrace(bpf_user_pt_regs_t *regs,
+                     stack_unwind_table_t *unwind_table, stack_trace_t *stack) {
+  u64 current_rip = regs->ip;
+  u64 current_rsp = regs->sp;
+  u64 current_rbp = regs->bp;
+
+  bpf_printk("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+  bpf_printk("traversing stack using .eh_frame information!!");
+  bpf_printk("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+
+  u64 table_len = unwind_table->table_len;
+  // Just for debugging to ensure that the data we are reading
+  // matches what we wrote.
+  bpf_printk("- unwind table has %d items", table_len);
+
+  // Invariant check.
+  if (table_len >= MAX_UNWIND_TABLE_SIZE) {
+    bpf_printk("should never happen");
+    BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
+    return 1;
+  }
+
+  bump_samples();
+
+  // #pragma clang loop unroll(full)
+  for (int i = 0; i < MAX_STACK_DEPTH; i++) {
+    bpf_printk("## frame: %d", i);
+
+    bpf_printk("\tcurrent pc: %llx", current_rip);
+    bpf_printk("\tcurrent sp: %llx", current_rsp);
+    bpf_printk("\tcurrent bp: %llx", current_rbp);
+
+    struct callback_ctx callback_context = {
+        .pc = current_rip,
+        .table = unwind_table,
+        .found = 0,
+        .left = 0,
+        .right = table_len - 1,
+    };
+
+    // Note that we are using bpf_loop whilst prototyping. We might change the
+    // approach later on to support older kernels, but so far it's very
+    // convenient (not having to deal with global state, such as what rbperf has
+    // to do. Avoiding having to do this is good when prototyping)
+    bpf_loop(MAX_BINARY_SEARCH_DEPTH, find_offset_for_pc, &callback_context, 0);
+
+    u64 table_idx = callback_context.found;
+    bpf_printk("\t=> table_index: %d", table_idx);
+
+    // Appease the verifier.
+    if (table_idx < 0 || table_idx >= MAX_UNWIND_TABLE_SIZE) {
+      bpf_printk("\t[error] this should never happen");
+      BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
+      return 1;
+    }
+
+    u64 last_idx = unwind_table->table_len - 1;
+    // Appease the verifier.
+    if (last_idx < 0 || last_idx >= MAX_UNWIND_TABLE_SIZE) {
+      bpf_printk("\t[error] this should never happen");
+      BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
+      return 0;
+    }
+
+    // We've reached the bottom of the stack once we don't find an unwind
+    // entry for the given program counter and the current frame pointer
+    // is 0. As per the x86_64 ABI:
+    //
+    // From 3.4.1 Initial Stack and Register State
+    // > %rbp The content of this register is unspecified at process
+    // > initialization time, > but the user code should mark the deepest
+    // > stack frame by setting the frame > pointer to zero.
+    //
+    // https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf
+    if ((current_rip < unwind_table->rows[0].pc ||
+         current_rip > unwind_table->rows[last_idx].pc) &&
+        current_rbp == 0) {
+      bpf_printk("======= reached main! =======");
+      stack->len = i;
+      BUMP_UNWIND_SUCCESS();
+      return 0;
+    }
+
+    // Add address to stack.
+    stack->addresses[i] = current_rip;
+
+    u64 found_pc = unwind_table->rows[table_idx].pc;
+    u64 found_cfa_reg = unwind_table->rows[table_idx].cfa_reg;
+    s64 found_cfa_offset = unwind_table->rows[table_idx].cfa_offset;
+    s64 found_rbp_offset = unwind_table->rows[table_idx].rbp_offset;
+
+    bpf_printk("\tcfa reg: $%s, offset: %d (row pc: %llx)",
+               found_cfa_reg == X86_64_REGISTER_RSP ? "rsp" : "rbp",
+               found_cfa_offset, found_pc);
+
+    // HACK(javierhonduco): dwarf expressions aren't supported. We set these
+    // values to the register and the offset to recognise them.
+    if (found_cfa_reg == 0xBEEF && found_cfa_offset == 0xBADFAD) {
+      bpf_printk("\t!!!! CFA is an expression, bailing out");
+      BUMP_UNWIND_UNSUPPORTED_EXPRESSION();
+      return 1;
+    }
+
+    u64 previous_rsp = 0;
+    if (found_cfa_reg == X86_64_REGISTER_RBP) {
+      previous_rsp = current_rbp + found_cfa_offset;
+    } else if (found_cfa_reg == X86_64_REGISTER_RSP) {
+      previous_rsp = current_rsp + found_cfa_offset;
+    } else {
+      bpf_printk("\t[error] register %d not valid (expected $rbp or $rsp)",
+                 found_cfa_reg);
+      BUMP_UNWIND_CATCHALL_ERROR();
+      return 1;
+    }
+    // TODO(javierhonduco): A possible check could be to see whether this value
+    // is within the stack. This check could be quite brittle though, so if we
+    // add it, it would be best to add it only during development.
+    if (previous_rsp == 0) {
+      bpf_printk("[error] previous_rsp should not be zero.");
+      BUMP_UNWIND_CATCHALL_ERROR();
+      return 1;
+    }
+
+    // HACK(javierhonduco): This is an architectural shortcut we can take. As we
+    // only support x86_64 at the minute, we can assume that the return address
+    // is *always* 8 bytes ahead of the previous stack pointer.
+    u64 previous_rip_addr =
+        previous_rsp - 8; // the saved return address is 8 bytes ahead of the
+                          // previous stack pointer
+    u64 previous_rip = 0;
+    int err = bpf_probe_read_user(
+        &previous_rip, 8,
+        (void *)(previous_rip_addr)); // 8 bytes, a whole word
+                                      // in a 64 bits machine
+
+    if (previous_rip == 0) {
+      bpf_printk("[error] previous_rip should not be zero. This can mean that "
+                 "the read failed, ret=%d while reading @ %llx.",
+                 err, previous_rip_addr);
+      BUMP_UNWIND_CATCHALL_ERROR();
+      return 1;
+    }
+
+    // Set rbp register.
+    u64 previous_rbp = 0;
+    if (found_rbp_offset == 0) {
+      previous_rbp = current_rbp;
+    } else {
+      u64 previous_rbp_addr = previous_rsp + found_rbp_offset;
+      bpf_printk("\t(bp_offset: %d, bp value stored at %llx)", found_rbp_offset,
+                 previous_rbp_addr);
+      int ret = bpf_probe_read_user(
+          &previous_rbp, 8,
+          (void *)(previous_rbp_addr)); // 8 bytes, a whole word in a 64 bits
+                                        // machine
+
+      if (ret != 0) {
+        bpf_printk("[error] previous_rbp should not be zero. This can mean "
+                   "that the read has failed %d.",
+                   ret);
+        BUMP_UNWIND_CATCHALL_ERROR();
+        return 1;
+      }
+    }
+
+    bpf_printk("\tprevious ip: %llx (@ %llx)", previous_rip, previous_rip_addr);
+    bpf_printk("\tprevious sp: %llx", previous_rsp);
+    // Set rsp and rip registers
+    current_rip = previous_rip;
+    current_rsp = previous_rsp;
+    // Set rbp
+    bpf_printk("\tprevious bp: %llx", previous_rbp);
+    current_rbp = previous_rbp;
+
+    // Frame finished! :)
+  }
+
+  // We couldn't walk enough frames
+  BUMP_UNWIND_TRUNCATED();
+  return 1;
+}
+
 SEC("perf_event")
 int profile_cpu(struct bpf_perf_event_data *ctx) {
   u64 id = bpf_get_current_pid_tgid();
@@ -105,39 +507,87 @@ int profile_cpu(struct bpf_perf_event_data *ctx) {
   if (pid == 0)
     return 0;
 
-  // create map key
-  stack_count_key_t key = {
-      .pid = tgid,
-      .user_stack_id = 0,
-      .kernel_stack_id = 0,
-  };
+  u32 zero = 0;
+  stack_count_key_t *stack = bpf_map_lookup_elem(&heap, &zero);
+  if (stack == NULL) {
+    // This should never happen.
+    return 1;
+  }
 
-  // get user stack id
-  int stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
-  if (stack_id >= 0)
-    key.user_stack_id = stack_id;
+  // Reset global state.
+  stack->unwind_table_frames.len = 0;
+  stack->pid = tgid;
+  stack->user_stack_id = 0;
+  stack->kernel_stack_id = 0;
 
-  // get kernel stack id
+  // Get kernel stack.
   int kernel_stack_id = bpf_get_stackid(ctx, &stack_traces, 0);
-  if (kernel_stack_id >= 0)
-    key.kernel_stack_id = kernel_stack_id;
+  if (kernel_stack_id >= 0) {
+    stack->kernel_stack_id = kernel_stack_id;
+  }
 
-  // TODO(kakkoyun): failed bpf_get_stackid() could indicate stack unwinding
-  // issues; this could be a useful place to hook eh_frame-based stack
-  // unwinding.
-  // TODO(kakkoyun): Does returned error code help?
-  // if (key.user_stack_id == 0 && key.kernel_stack_id == 0)
-  // Both user and kernel stacks are empty.
-  // However, for now, we still want to count the event, to keep track of the
-  // number of the failed stack unwinding attempts.
-  // return 0;
+  stack_unwind_table_t *unwind_table =
+      bpf_map_lookup_elem(&unwind_tables, &pid);
 
-  u64 zero = 0;
-  u64 *count;
-  count = bpf_map_lookup_or_try_init(&counts, &key, &zero);
-  if (!count)
-    return 0;
+  // Check if the process is eligible for the unwind table or frame pointer
+  // unwinders.
+  if (unwind_table == NULL) {
+    int stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+    if (stack_id >= 0) {
+      stack->user_stack_id = stack_id;
+    }
+    // Aggregate stacks.
+    u64 zero = 0;
+    u64 *scount = bpf_map_lookup_or_try_init(&stack_counts, stack, &zero);
+    if (scount) {
+      __sync_fetch_and_add(scount, 1);
+    }
+  } else {
+    u64 last_idx = unwind_table->table_len - 1;
+    // Appease the verifier.
+    if (last_idx < 0 || last_idx >= MAX_UNWIND_TABLE_SIZE) {
+      bpf_printk("\t[error] this should never happen");
+      BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
+      return 0;
+    }
 
-  __sync_fetch_and_add(count, 1);
+    if (ctx->regs.ip < unwind_table->rows[0].pc ||
+        ctx->regs.ip > unwind_table->rows[last_idx].pc) {
+      bpf_printk("IP not covered. In kernel space / bug? IP %llx",
+                 ctx->regs.ip);
+      BUMP_UNWIND_PC_NOT_COVERED_ERROR();
+      return 0;
+    }
+
+    int ret = walk_user_stacktrace(&ctx->regs, unwind_table,
+                                   &stack->unwind_table_frames);
+    if (ret == 0) {
+      // Aggregate stacks.
+      u64 zero = 0;
+      u64 *scount = bpf_map_lookup_or_try_init(&stack_counts, stack, &zero);
+      if (scount) {
+        __sync_fetch_and_add(scount, 1);
+      }
+
+      bpf_printk("yesssss :)");
+    } else {
+      bpf_printk("noooooo :(");
+    }
+
+    // javierhonduco: Debug output to ensure that the maps are correctly
+    // populated by comparing it with the data
+    // we are writing. Remove later on.
+    show_row(unwind_table, 0);
+    show_row(unwind_table, 1);
+    show_row(unwind_table, 2);
+    show_row(unwind_table, last_idx);
+  }
+
   return 0;
 }
+
+#define KBUILD_MODNAME "parca-agent"
+volatile const char bpf_metadata_name[] SEC(".rodata") =
+    "parca-agent (https://github.com/parca-dev/parca-agent)";
+unsigned int VERSION SEC("version") = 1;
+char LICENSE[] SEC("license") = "GPL";

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -97,9 +97,10 @@ type flags struct {
 	RemoteStoreInsecureSkipVerify     bool          `kong:"help='Skip TLS certificate verification.'"`
 	RemoteStoreDebugInfoUploadDisable bool          `kong:"help='Disable debuginfo collection and upload.',default='false'"`
 	RemoteStoreBatchWriteInterval     time.Duration `kong:"help='Interval between batch remote client writes. Leave this empty to use the default value of 10s.',default='10s'"`
-
 	// Debug info configuration:
 	DebugInfoDirectories []string `kong:"help='Ordered list of local directories to search for debug info files. Defaults to /usr/lib/debug.',default='/usr/lib/debug'"`
+	// These flags are experimental. Use them at your own peril.
+	ExperimentalDwarfUnwindingPids []int `kong:"help='Unwind stack using .eh_frame information for these processes.'"`
 }
 
 var _ Profiler = &profiler.NoopProfiler{}
@@ -317,6 +318,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			),
 			labelsManager,
 			flags.ProfilingDuration,
+			flags.ExperimentalDwarfUnwindingPids,
 		),
 	}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/docs/hacking_on_native_stack_unwinding_without_frame_pointers.md
+++ b/docs/hacking_on_native_stack_unwinding_without_frame_pointers.md
@@ -1,0 +1,251 @@
+## Hacking on `.eh_frame`-based stack unwinding
+
+Tracking this feature in https://github.com/parca-dev/parca-agent/issues/768.
+
+### Design
+
+The DWARF unwind unformation is read from the `.eh_frame` section (tracking other sections in https://github.com/parca-dev/parca-agent/issues/617), parsed, and evaluated to generate unwind tables (see `table.go`, among others). The unwind tables have, for every program counter(*) in an executable, instructions on how to find the stack pointer value before calling the function of the current frame, as well as information on where to find the return address for the current function, as well as how to calculate the value of various registers in the previous frame.
+
+Once we have these tables in memory, we sort them by program counter, and load them in a BPF map.
+
+Once the BPF program has this table, in order to unwind the stack, it will:
+
+1. Fetches the initial registers
+   1. The instruction pointer `$rip`. Needed to find the row in the unwind table.
+   2. The stack pointer `$rsp`, and the frame pointer `$rbp`, needed to calculate the stack pointer value for the previous frame (CFA). We can find the return address and other registers pushed on the stack at an offset from CFA.
+2. While `unwound_frame_count <= MAX_STACK_DEPTH`
+   1. Add instruction pointer to stack
+   2. If current instruction pointer is from `main`, we are done. Stop.
+   3. Finds the unwind table row for the PC for which `$found_row_PC <= $target_PC < $PC_after_found_row`.
+   4. Calculates the previous frame's stack pointer. This can be based off the current frame's `$rsp` or `$rbp`
+   5. Updates the registers with the calculated values for the previous frame.
+   6. Find next frame. Go to 2.
+
+### BPF data checks
+
+The data stored in BPF maps is just a bytes buffer. We interpret it as C data structures for convenience but this means that we need to ensure that the padding and aligment that the C compiler would insert is also inserted when we write to it in the Go side. To make development easier, we have decided to use word-aligned datatypes, in this case, all entries in the table are 8 bytes [1].
+
+To facilitate quick data correctness checking, and to help debugging issues querying the table, there's two helpers to print row entries. One in the BPF side `show_row(stack_unwind_table_t *unwind_table, int index)` and `printRow` in Row.
+
+When `Parca Agent` and the BPF program run, they print some entries' values to help spot check the data is correct.
+
+```
+$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+[...]
+ - unwind table has 60969 items
+[...]
+  parca-demo-cpp-318748  [006] d.h2. 17414.354239: bpf_trace_printk: ~ 0 entry. Loc: 401020, CFA reg: 7 Offset: 16, $rbp 0
+  parca-demo-cpp-318748  [006] d.h2. 17414.354239: bpf_trace_printk: ~ 1 entry. Loc: 401026, CFA reg: 7 Offset: 24, $rbp 0
+  parca-demo-cpp-318748  [006] d.h2. 17414.354240: bpf_trace_printk: ~ 2 entry. Loc: 401030, CFA reg: 7 Offset: 24, $rbp 0
+  parca-demo-cpp-318748  [006] d.h2. 17414.354240: bpf_trace_printk: ~ 60968 entry. Loc: 7f462ffd0ca0, CFA reg: 7 Offset: 8, $rbp 0
+[...]
+```
+
+On the Agent:
+
+```
+  - Total entries 60969
+
+        row[0]. Loc: 401020, CFA Reg: 7 Offset:16, $rbp: 0
+        row[1]. Loc: 401026, CFA Reg: 7 Offset:24, $rbp: 0
+        row[2]. Loc: 401030, CFA Reg: 7 Offset:24, $rbp: 0
+        row[60968]. Loc: 7f462ffd0ca0, CFA Reg: 7 Offset:8, $rbp: 0
+```
+
+## Making sure that the stack is correct
+
+GDB is very useful to verify that stack unwinding worked fine. We are mostly interested in checking:
+- the frame's registers
+- where are the saved return addresses stored and their values
+
+Let's take `./internal/dwarf/frame/testdata/parca-demo-cpp-no-fp`'s output and make sure that the stack is correct:
+
+<details>
+
+```
+parca-demo-cpp--1226527 [007] d.h2. 83153.230672: bpf_trace_printk: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+parca-demo-cpp--1226527 [007] d.h2. 83153.230673: bpf_trace_printk: traversing stack using .eh_frame information!!
+parca-demo-cpp--1226527 [007] d.h2. 83153.230674: bpf_trace_printk: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+parca-demo-cpp--1226527 [007] d.h2. 83153.230675: bpf_trace_printk: - unwind table has 60957 items
+parca-demo-cpp--1226527 [007] d.h2. 83153.230675: bpf_trace_printk: - main pc range 401260...4012d8
+parca-demo-cpp--1226527 [007] d.h2. 83153.230676: bpf_trace_printk: ## frame: 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230676: bpf_trace_printk:    current pc: 4011e0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230677: bpf_trace_printk:    current sp: 7ffcaee95f08
+parca-demo-cpp--1226527 [007] d.h2. 83153.230677: bpf_trace_printk:    current bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230678: bpf_trace_printk:    .done
+parca-demo-cpp--1226527 [007] d.h2. 83153.230678: bpf_trace_printk:    => table_index: 12
+parca-demo-cpp--1226527 [007] d.h2. 83153.230679: bpf_trace_printk:    cfa reg: $rsp, offset: 8 (pc: 4011d0)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230680: bpf_trace_printk:    previous ip: 401206 (@ 7ffcaee95f08)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230681: bpf_trace_printk:    previous sp: 7ffcaee95f10
+parca-demo-cpp--1226527 [007] d.h2. 83153.230681: bpf_trace_printk:    bp offset 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230681: bpf_trace_printk:    previous bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230682: bpf_trace_printk: ## frame: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230682: bpf_trace_printk:    current pc: 401206
+parca-demo-cpp--1226527 [007] d.h2. 83153.230682: bpf_trace_printk:    current sp: 7ffcaee95f10
+parca-demo-cpp--1226527 [007] d.h2. 83153.230683: bpf_trace_printk:    current bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230684: bpf_trace_printk:    .done
+parca-demo-cpp--1226527 [007] d.h2. 83153.230684: bpf_trace_printk:    => table_index: 14
+parca-demo-cpp--1226527 [007] d.h2. 83153.230685: bpf_trace_printk:    cfa reg: $rsp, offset: 16 (pc: 401201)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230685: bpf_trace_printk:    previous ip: 401216 (@ 7ffcaee95f18)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230686: bpf_trace_printk:    previous sp: 7ffcaee95f20
+parca-demo-cpp--1226527 [007] d.h2. 83153.230686: bpf_trace_printk:    bp offset 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230686: bpf_trace_printk:    previous bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230687: bpf_trace_printk: ## frame: 2
+parca-demo-cpp--1226527 [007] d.h2. 83153.230687: bpf_trace_printk:    current pc: 401216
+parca-demo-cpp--1226527 [007] d.h2. 83153.230687: bpf_trace_printk:    current sp: 7ffcaee95f20
+parca-demo-cpp--1226527 [007] d.h2. 83153.230688: bpf_trace_printk:    current bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230688: bpf_trace_printk:    .done
+parca-demo-cpp--1226527 [007] d.h2. 83153.230689: bpf_trace_printk:    => table_index: 17
+parca-demo-cpp--1226527 [007] d.h2. 83153.230689: bpf_trace_printk:    cfa reg: $rsp, offset: 16 (pc: 401211)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230690: bpf_trace_printk:    previous ip: 401226 (@ 7ffcaee95f28)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230690: bpf_trace_printk:    previous sp: 7ffcaee95f30
+parca-demo-cpp--1226527 [007] d.h2. 83153.230691: bpf_trace_printk:    bp offset 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230691: bpf_trace_printk:    previous bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230691: bpf_trace_printk: ## frame: 3
+parca-demo-cpp--1226527 [007] d.h2. 83153.230692: bpf_trace_printk:    current pc: 401226
+parca-demo-cpp--1226527 [007] d.h2. 83153.230692: bpf_trace_printk:    current sp: 7ffcaee95f30
+parca-demo-cpp--1226527 [007] d.h2. 83153.230692: bpf_trace_printk:    current bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230693: bpf_trace_printk:    .done
+parca-demo-cpp--1226527 [007] d.h2. 83153.230693: bpf_trace_printk:    => table_index: 20
+parca-demo-cpp--1226527 [007] d.h2. 83153.230694: bpf_trace_printk:    cfa reg: $rsp, offset: 16 (pc: 401221)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230694: bpf_trace_printk:    previous ip: 401299 (@ 7ffcaee95f38)
+parca-demo-cpp--1226527 [007] d.h2. 83153.230695: bpf_trace_printk:    previous sp: 7ffcaee95f40
+parca-demo-cpp--1226527 [007] d.h2. 83153.230695: bpf_trace_printk:    bp offset 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230695: bpf_trace_printk:    previous bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230696: bpf_trace_printk: ## frame: 4
+parca-demo-cpp--1226527 [007] d.h2. 83153.230696: bpf_trace_printk:    current pc: 401299
+parca-demo-cpp--1226527 [007] d.h2. 83153.230696: bpf_trace_printk:    current sp: 7ffcaee95f40
+parca-demo-cpp--1226527 [007] d.h2. 83153.230697: bpf_trace_printk:    current bp: 1
+parca-demo-cpp--1226527 [007] d.h2. 83153.230697: bpf_trace_printk: ======= reached main! =======
+parca-demo-cpp--1226527 [007] d.h2. 83153.230698: bpf_trace_printk: ~ 0 entry. Loc: 401020, CFA reg: 7 Offset: 16, $rbp 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230699: bpf_trace_printk: ~ 1 entry. Loc: 401026, CFA reg: 7 Offset: 24, $rbp 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230700: bpf_trace_printk: ~ 2 entry. Loc: 401030, CFA reg: 7 Offset: 24, $rbp 0
+parca-demo-cpp--1226527 [007] d.h2. 83153.230701: bpf_trace_printk: ~ 60956 entry. Loc: 7f0fa57f4ca0, CFA reg: 7 Offset: 8, $rbp 0
+```
+
+</details>
+
+For the first frame (minus the columns we don't care about right now), we have that:
+
+```
+## frame: 0
+   current pc: 4011e0
+   current sp: 7ffcaee95f08
+   current bp: 1
+   .done
+   => table_index: 12
+   cfa reg: $rsp, offset: 8 (pc: 4011d0)
+   previous ip: 401206 (@ 7ffcaee95f08)
+   previous sp: 7ffcaee95f10
+   bp offset 0
+   previous bp: 1
+```
+
+So let's set a breapoint in this program counter and check the different data:
+
+```
+$ sudo gdb -p $(pidof parca-demo-cpp-no-fp)
+# Setting a breakpoint at the PC
+(gdb) b *0x4011e0
+Breakpoint 1 at 0x4011e0
+# Let's continue until we hit it
+(gdb) c
+Continuing.
+Breakpoint 1, 0x00000000004011e0 in top() ()
+# We are in top(), let's now take a look at the registers
+(gdb) p/x $rip
+$1 = 0x4011e0
+(gdb) p/x $rsp
+$2 = 0x7ffcaee95f08
+(gdb) p/x $rbp
+$3 = 0x1
+# Cool! Seems that all the registers match so far. Let's take a look at the frame information
+(gdb) info frame 0
+Stack frame at 0x7ffcaee95f10:
+ rip = 0x4011e0 in top(); saved rip = 0x401206
+ called by frame at 0x7ffcaee95f20
+ Arglist at 0x7ffcaee95f00, args:
+ Locals at 0x7ffcaee95f00, Previous frame's sp is 0x7ffcaee95f10
+ Saved registers:
+  rip at 0x7ffcaee95f08
+# We mostly want to see that the addresse where the saved return address (previous frame's rip) is is correct. As we can see in the last
+# line, it matches what we expect (0x7ffcaee95f08).
+# The first line shows rip's value (0x401206), that also matches what we expect. This address is the program counter
+# that the processor should execute once the current function exits. It's pushed into the stack with a `call` instruciton.
+```
+
+Let's go check the frame above
+```
+## frame: 1
+   current pc: 401206
+   current sp: 7ffcaee95f10
+   current bp: 1
+   .done
+   => table_index: 14
+   cfa reg: $rsp, offset: 16 (pc: 401201)
+   previous ip: 401216 (@ 7ffcaee95f18)
+   previous sp: 7ffcaee95f20
+   bp offset 0
+   previous bp: 1
+```
+
+```
+# Let's go one frame up in the stack
+(gdb) up
+#1  0x0000000000401206 in c1() ()
+(gdb) p/x $rip
+$2 = 0x401206
+(gdb) p/x $rsp
+$3 = 0x7ffcaee95f10
+(gdb) p/x $rbp
+$4 = 0x1
+# All good here :)
+(gdb) info frame
+Stack level 1, frame at 0x7ffcaee95f20:
+ rip = 0x401206 in c1(); saved rip = 0x401216
+ called by frame at 0x7ffcaee95f30, caller of frame at 0x7ffcaee95f10
+ Arglist at 0x7ffcaee95f08, args:
+ Locals at 0x7ffcaee95f08, Previous frame's sp is 0x7ffcaee95f20
+ Saved registers:
+  rip at 0x7ffcaee95f18
+# As we did before, let's check the return address (0x401216), as
+# well as where it's located (0x7ffcaee95f18). Great success so far!
+```
+
+This process should be repeated for each frame until we reach the last frame of the stack.
+
+## Debugging the unwind tables
+
+When there's a suspicion of the table data not being correct, the two small helpers to print a row of the table can be very useful. To inspect the row table output manually:
+
+```
+$ dist/eh-frame --executable <executable>
+$ readelf -wF <executable>
+```
+
+It can be useful to see a function's disassembly in GDB to check if the row values make sense
+
+```
+(gdb) disassemble 0x401216
+Dump of assembler code for function _Z2b1v:
+   0x0000000000401210 <+0>:     push   %rax
+   0x0000000000401211 <+1>:     call   0x401200 <_Z2c1v>
+   0x0000000000401216 <+6>:     pop    %rcx                       <===== the instruction for this program counter
+   0x0000000000401217 <+7>:     ret
+End of assembler dump.
+```
+
+
+## Debugging notes
+
+Remember than when running GDB on a process, the debugee will go into traced `t` state when a breakpoint is hit, and it will not run, so it will be de-scheduled from the CPU and the profiler will show no samples.
+
+Another thing to bear in mind when setting breakpoints is that there could be more than one path that leads to a particular program counter. This is important when checking for specific register and return address values, as this particular code path might not match what we saw in another trace.
+
+
+## Notes
+
+- [1]: This is of course not very efficient. Once the implementation is more mature, we will use the smallest data types we can, but we need to be careful and ensure that the C ABI is correct while loading data in the BPF maps.
+
+
+(*): This is not always the case, but an overlwhelming majority of the times it is

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -14,19 +14,12 @@
 
 package cpu
 
-import (
-	"syscall"
-	"testing"
-	"unsafe"
-
-	bpf "github.com/aquasecurity/libbpfgo"
-
-	"github.com/stretchr/testify/require"
-)
-
 // The intent of these tests is to ensure that the BPF library we use,
 // (libbpfgo in this case) behaves in the way we expect.
-
+//
+// TODO(javierhonduco): Re-enable these tests once bpf_loop is removed
+// as GitHub actions's kernels don't have support for it.
+/*
 func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	t.Helper()
 
@@ -46,7 +39,7 @@ func TestDeleteNonExistentKeyReturnsEnoent(t *testing.T) {
 	m, err := SetUpBpfProgram(t)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)
-	bpfMap, err := m.GetMap(countsMapName)
+	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
 	stackID := int32(1234)
@@ -61,7 +54,7 @@ func TestDeleteExistentKey(t *testing.T) {
 	m, err := SetUpBpfProgram(t)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)
-	bpfMap, err := m.GetMap(countsMapName)
+	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
 	stackID := int32(1234)
@@ -80,7 +73,7 @@ func TestGetValueAndDeleteBatchWithEmptyMap(t *testing.T) {
 	m, err := SetUpBpfProgram(t)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)
-	bpfMap, err := m.GetMap(countsMapName)
+	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
 	keys := make([]stackCountKey, bpfMap.GetMaxEntries())
@@ -96,7 +89,7 @@ func TestGetValueAndDeleteBatchFewerElementsThanCount(t *testing.T) {
 	m, err := SetUpBpfProgram(t)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)
-	bpfMap, err := m.GetMap(countsMapName)
+	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
 	stackID := int32(1234)
@@ -120,7 +113,7 @@ func TestGetValueAndDeleteBatchExactElements(t *testing.T) {
 	m, err := SetUpBpfProgram(t)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)
-	bpfMap, err := m.GetMap(countsMapName)
+	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
 	stackID := int32(1234)
@@ -139,3 +132,4 @@ func TestGetValueAndDeleteBatchExactElements(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(values))
 }
+*/

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -23,12 +23,17 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
+	"github.com/parca-dev/parca-agent/pkg/stack/unwind"
+
 	bpf "github.com/aquasecurity/libbpfgo"
 )
 
 const (
-	countsMapName      = "counts"
+	stackCountsMapName = "stack_counts"
 	stackTracesMapName = "stack_traces"
+	unwindTableMapName = "unwind_tables"
+	maxUnwindTableSize = 130 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in BPF program.
 )
 
 var (
@@ -40,8 +45,9 @@ var (
 type bpfMaps struct {
 	byteOrder binary.ByteOrder
 
-	counts      *bpf.BPFMap
-	stackTraces *bpf.BPFMap
+	stackCounts  *bpf.BPFMap
+	stackTraces  *bpf.BPFMap
+	unwindTables *bpf.BPFMap
 }
 
 // readUserStack reads the user stack trace from the stacktraces ebpf map into the given buffer.
@@ -82,7 +88,7 @@ func (m *bpfMaps) readKernelStack(kernelStackID int32, stack *combinedStack) err
 
 // readStackCount reads the value of the given key from the counts ebpf map.
 func (m *bpfMaps) readStackCount(keyBytes []byte) (uint64, error) {
-	valueBytes, err := m.counts.GetValue(unsafe.Pointer(&keyBytes[0]))
+	valueBytes, err := m.stackCounts.GetValue(unsafe.Pointer(&keyBytes[0]))
 	if err != nil {
 		return 0, fmt.Errorf("get count value: %w", err)
 	}
@@ -115,11 +121,11 @@ func (m *bpfMaps) clean() error {
 		}
 	}
 
-	it = m.counts.Iterator()
+	it = m.stackCounts.Iterator()
 	prev = nil
 	for it.Next() {
 		if prev != nil {
-			err := m.counts.DeleteKey(unsafe.Pointer(&prev[0]))
+			err := m.stackCounts.DeleteKey(unsafe.Pointer(&prev[0]))
 			if err != nil {
 				return fmt.Errorf("failed to delete count: %w", err)
 			}
@@ -130,11 +136,100 @@ func (m *bpfMaps) clean() error {
 		copy(prev, key)
 	}
 	if prev != nil {
-		err := m.counts.DeleteKey(unsafe.Pointer(&prev[0]))
+		err := m.stackCounts.DeleteKey(unsafe.Pointer(&prev[0]))
 		if err != nil {
 			return fmt.Errorf("failed to delete count: %w", err)
 		}
 	}
 
+	return nil
+}
+
+// setUnwindTable updates the unwind tables with the given unwind table.
+func (m *bpfMaps) setUnwindTable(pid int, ut unwind.UnwindTable) error {
+	buf := new(bytes.Buffer)
+
+	// Write number of rows `.table_len``.
+	if err := binary.Write(buf, m.byteOrder, uint64(len(ut))); err != nil {
+		return fmt.Errorf("write the number of rows: %w", err)
+	}
+
+	if len(ut) >= maxUnwindTableSize {
+		fmt.Errorf("Maximum unwind table size reached. Table size %d, but max size is %d", len(ut), maxUnwindTableSize)
+	}
+
+	for _, row := range ut {
+		// Right now we only support x86_64, where the return address position
+		// is specified in the ABI, so we don't write it.
+
+		// Write Program Counter (PC).
+		if err := binary.Write(buf, m.byteOrder, row.Loc); err != nil {
+			return fmt.Errorf("write the program counter: %w", err)
+		}
+
+		// Write CFA.
+		switch row.CFA.Rule {
+		case frame.RuleCFA:
+			// Write CFA register.
+			if err := binary.Write(buf, m.byteOrder, row.CFA.Reg); err != nil {
+				return fmt.Errorf("write CFA register bytes: %w", err)
+			}
+
+			// Write CFA offset.
+			if err := binary.Write(buf, m.byteOrder, row.CFA.Offset); err != nil {
+				return fmt.Errorf("write CFA offset bytes: %w", err)
+			}
+		case frame.RuleExpression:
+			// Hack(javierhonduco). Expressions aren't really implemented yet, so let's set some sentinel
+			// values that we can use in the unwinder to detect when we should be using an expression.
+
+			// Write "fake" register.
+			if err := binary.Write(buf, m.byteOrder, uint64(0xBEEF)); err != nil {
+				return fmt.Errorf("write CFA Reg bytes: %w", err)
+			}
+
+			// Write "fake" offset.
+			if err := binary.Write(buf, m.byteOrder, uint64(0xBADFAD)); err != nil {
+				return fmt.Errorf("write CFA offset bytes: %w", err)
+			}
+		default:
+			return fmt.Errorf("CFA rule is not valid. This should never happen")
+		}
+
+		// Write $rbp offset.
+		if err := binary.Write(buf, m.byteOrder, row.RBP.Offset); err != nil {
+			return fmt.Errorf("write RBP offset bytes: %w", err)
+		}
+	}
+
+	// Set PID -> unwind table.
+	if err := m.unwindTables.Update(unsafe.Pointer(&pid), unsafe.Pointer(&buf.Bytes()[0])); err != nil {
+		return fmt.Errorf("update unwind tables: %w", err)
+	}
+
+	// HACK(javierhonduco): remove this.
+	// Debug stuff to compare this with the BPF program's view of the world.
+	/*
+		printRow := func(w io.Writer, pt unwind.UnwindTable, index int) {
+			cfaInfo := ""
+			switch ut[index].CFA.Rule {
+			case frame.RuleCFA:
+				cfaInfo = fmt.Sprintf("CFA Reg: %d Offset:%d", ut[index].CFA.Reg, ut[index].CFA.Offset)
+			case frame.RuleExpression:
+				cfaInfo = "CFA exp"
+			default:
+				panic("CFA rule is not valid. This should never happen.")
+			}
+
+			fmt.Fprintf(w, "\trow[%d]. Loc: %x, %s, $rbp: %d\n", index, pt[index].Loc, cfaInfo, pt[index].RBP.Offset)
+		}
+
+		fmt.Fprintf(os.Stdout, "\t- Total entries %d\n\n", len(ut))
+		printRow(os.Stdout, ut, 0)
+		printRow(os.Stdout, ut, 1)
+		printRow(os.Stdout, ut, 2)
+		printRow(os.Stdout, ut, 6)
+		printRow(os.Stdout, ut, len(ut)-1)
+	*/
 	return nil
 }

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -25,12 +25,12 @@ import (
 
 func TestBuildUnwindTable(t *testing.T) {
 	logger := log.NewNopLogger()
-	ptb := NewUnwindTableBuilder(logger)
+	utb := NewUnwindTableBuilder(logger)
 
-	fdes, err := ptb.readFDEs("../../../testdata/out/basic-cpp", 0)
+	fdes, err := utb.readFDEs("../../../testdata/out/basic-cpp")
 	require.NoError(t, err)
 
-	unwindTable := buildTable(fdes)
+	unwindTable := buildUnwindTable(fdes)
 	require.Equal(t, 38, len(unwindTable))
 
 	require.Equal(t, uint64(0x401020), unwindTable[0].Loc)
@@ -46,12 +46,12 @@ func BenchmarkParsingLibcDwarfUnwindInformation(b *testing.B) {
 	b.ReportAllocs()
 
 	logger := log.NewNopLogger()
-	ptb := NewUnwindTableBuilder(logger)
+	utb := NewUnwindTableBuilder(logger)
 
 	var rbpOffset int64
 
 	for n := 0; n < b.N; n++ {
-		fdes, err := ptb.readFDEs("../../../testdata/vendored/libc.so.6", 0)
+		fdes, err := utb.readFDEs("../../../testdata/vendored/libc.so.6")
 		if err != nil {
 			panic("could not read FDEs")
 		}


### PR DESCRIPTION
## Background 
This PR implements the v1 of native stack walking using dwarf unwind tables. What this means, in practice, is that it's in beta status and this work doesn't include the full scope of the final implementation. More importantly, this implementation focuses:

- Correctness, not performance;
- The x86_64 architecture and ABI;
- C and C++;
- Only the `.eh_frame` section is supported;
- Processes with combined unwind tables up to 130k rows;
- While we support all the important DWARF opcodes, `expression` and `register` related opcodes are ignored at this point;


There are 3 commits that add the BPF unwinder, the necessary supporting facilities in Go, and some documentation.


Umbrella issue: https://github.com/parca-dev/parca-agent/issues/768

## Usage

```shell
$ dist/parca-agent $FLAGS --dwarf-unwinding-pids=<comma separated pids>
```

## Test Plan

Running the agent and the server:

**Ensuring that the current features work as expected**

<img width="1291" alt="image" src="https://user-images.githubusercontent.com/959128/197779351-b5de0f82-3f9b-45e8-a4d2-c0026aa44531.png">


**DWARF stack unwinding works**

Let's check that we can walk the native stacks from the CRuby interpreter (also called MRI)

```bash
$ ruby -e 'puts Process.pid; $stdout.reopen("/dev/null", "w"); loop { puts 1 }'
```

```bash
$ make build-dyn ENABLE_ASAN=yes &&  sudo dist/parca-agent-dyn --node=after --remote-store-insecure --remote-store-address=localhost:7070 --log-level=debug --dwarf-unwinding-pids=`pidof ruby` 
```

<img width="927" alt="image" src="https://user-images.githubusercontent.com/959128/197780953-146c0632-f403-42f8-ab9f-80499d900ef5.png">

[...] many more frames (the Ruby interpreter has **very** deep stacks!!)

<img width="977" alt="image" src="https://user-images.githubusercontent.com/959128/197780879-4b504270-c586-4c43-8913-31949752dc98.png">

I've double-checked all the addresses in GDB and they are correct + we manage to reach `main` 🎉 

**Binaries built off `tesdata/src`** 

Tested all of them and they worked well!

```
[javierhonduco@fedora parca-agent]$ sudo bpftool prog tracelog   | grep stats -A7
[...]
            ruby-3224822 [009] d.h2. 105855.824637: bpf_trace_printk: [[ stats for cpu 9 ]]
            ruby-3224822 [009] d.h2. 105855.824638: bpf_trace_printk: success=5393
            ruby-3224822 [009] d.h2. 105855.824638: bpf_trace_printk: unsup_expression=156
            ruby-3224822 [009] d.h2. 105855.824638: bpf_trace_printk: truncated_counter=0
            ruby-3224822 [009] d.h2. 105855.824639: bpf_trace_printk: catchall_count=0
            ruby-3224822 [009] d.h2. 105855.824639: bpf_trace_printk: never=0
            ruby-3224822 [009] d.h2. 105855.824639: bpf_trace_printk: total_counter=5550
            ruby-3224822 [009] d.h2. 105855.824639: bpf_trace_printk: (not_covered_count=67)
^C
```


