### PR TITLE
feat: set default node name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ internal/pprof:
 
 # other artifacts:
 $(OUT_DIR)/help.txt: $(OUT_BIN)
-	$(OUT_BIN) --help > $@
+	$(OUT_BIN) --help | sed 's/--node=".*" */--node="hostname"           /' >$@
 
 DOC_VERSION := "latest"
 .PHONY: deploy/manifests

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,8 @@ internal/pprof:
 
 # other artifacts:
 $(OUT_DIR)/help.txt: $(OUT_BIN)
+	# The default value of --node is dynamic and depends on the current host's name
+	# so we replace it with something static.
 	$(OUT_BIN) --help | sed 's/--node=".*" */--node="hostname"           /' >$@
 
 DOC_VERSION := "latest"

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Flags:
 
 [embedmd]:# (dist/help.txt)
 ```txt
-Usage: parca-agent --node=STRING
+Usage: parca-agent
 
 Flags:
   -h, --help                      Show context-sensitive help.
       --log-level="info"          Log level.
       --http-address=":7071"      Address to bind HTTP server to.
-      --node=STRING               The name of the node that the process is
+      --node="hostname"           The name of the node that the process is
                                   running on. If on Kubernetes, this must match
                                   the Kubernetes node name.
       --config-path="parca-agent.yaml"

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -125,6 +125,7 @@ func main() {
 
 	if flags.Node == "" && hostnameErr != nil {
 		level.Error(logger).Log("msg", "failed to get host name. Please set it with the --node flag", "err", hostnameErr)
+		os.Exit(1)
 	}
 
 	reg := prometheus.NewRegistry()

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -76,7 +76,7 @@ type flags struct {
 	LogLevel    string `kong:"enum='error,warn,info,debug',help='Log level.',default='info'"`
 	HTTPAddress string `kong:"help='Address to bind HTTP server to.',default=':7071'"`
 
-	Node string `kong:"required,help='The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name.'"`
+	Node string `kong:"help='The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name.',default='${hostname}'"`
 
 	ConfigPath string `default:"parca-agent.yaml" help:"Path to config file."`
 
@@ -114,10 +114,18 @@ type Profiler interface {
 }
 
 func main() {
+	hostname, hostnameErr := os.Hostname()
+
 	flags := flags{}
-	kong.Parse(&flags)
+	kong.Parse(&flags, kong.Vars{
+		"hostname": hostname,
+	})
 
 	logger := logger.NewLogger(flags.LogLevel, logger.LogFormatLogfmt, "parca-agent")
+
+	if flags.Node == "" && hostnameErr != nil {
+		level.Error(logger).Log("msg", "failed to get host name. Please set it with the --node flag", "err", hostnameErr)
+	}
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(


### PR DESCRIPTION
Maybe you've discuss it or thought about it some time ago?

This defaults `--node` to the host name provided by the kernel, which is correct if not running in a container. Making all `parca-agent` flags optional.