### PR TITLE
Native stack walking with DWARF v2

### DIFF
--- a/bpf/common.h
+++ b/bpf/common.h
@@ -29,6 +29,11 @@ typedef __u16 __be16;
 typedef __u32 __be32;
 typedef __u32 __wsum;
 
+enum {
+	false = 0,
+	true = 1,
+};
+
 typedef _Bool bool;
 typedef u64 phys_addr_t;
 

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -7,6 +7,7 @@
 
 typedef unsigned char __u8;
 typedef short unsigned int __u16;
+typedef short signed int __s16;
 typedef unsigned int __u32;
 
 typedef int __s32;
@@ -17,6 +18,7 @@ typedef __u64 u64;
 
 typedef __u8 u8;
 typedef __u16 u16;
+typedef __s16 s16;
 typedef __u32 u32;
 
 

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -23,6 +23,13 @@ const (
 	RuleCFA // Value is rule.Reg + rule.Offset
 )
 
+// From 3.4.1 Initial Stack and Register State
+// https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf
+const (
+	X86_64FramePointer = 6 // $rbp
+	X86_64StackPointer = 7 // $rsp
+)
+
 // DWRule wrapper of rule defined for register values.
 type DWRule struct {
 	Rule       Rule

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -247,6 +247,21 @@ func (p *CPU) Run(ctx context.Context) error {
 	p.lastProfileStartedAt = time.Now()
 	p.mtx.Unlock()
 
+	prog, err := m.GetProgram("walk_user_stacktrace_impl")
+	if err != nil {
+		return fmt.Errorf("get bpf program: %w", err)
+	}
+	programs, err := m.GetMap(programsMapName)
+	if err != nil {
+		return fmt.Errorf("get programs map: %w", err)
+	}
+
+	fd := prog.FileDescriptor()
+	zero := uint32(0)
+	if err := programs.Update(unsafe.Pointer(&zero), unsafe.Pointer(&fd)); err != nil {
+		return fmt.Errorf("failure updating: %w", err)
+	}
+
 	stackCounts, err := m.GetMap(stackCountsMapName)
 	if err != nil {
 		return fmt.Errorf("get counts map: %w", err)

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -14,12 +14,19 @@
 
 package cpu
 
+import (
+	"syscall"
+	"testing"
+	"unsafe"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+
+	"github.com/stretchr/testify/require"
+)
+
 // The intent of these tests is to ensure that the BPF library we use,
 // (libbpfgo in this case) behaves in the way we expect.
-//
-// TODO(javierhonduco): Re-enable these tests once bpf_loop is removed
-// as GitHub actions's kernels don't have support for it.
-/*
+
 func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	t.Helper()
 
@@ -132,4 +139,3 @@ func TestGetValueAndDeleteBatchExactElements(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(values))
 }
-*/

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -169,7 +169,7 @@ func (m *bpfMaps) setUnwindTable(pid int, ut unwind.UnwindTable) error {
 	}
 
 	if len(ut) >= maxUnwindTableSize {
-		fmt.Errorf("Maximum unwind table size reached. Table size %d, but max size is %d", len(ut), maxUnwindTableSize)
+		return fmt.Errorf("maximum unwind table size reached. Table size %d, but max size is %d", len(ut), maxUnwindTableSize)
 	}
 
 	for _, row := range ut {

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -33,6 +33,7 @@ const (
 	stackCountsMapName = "stack_counts"
 	stackTracesMapName = "stack_traces"
 	unwindTableMapName = "unwind_tables"
+	programsMapName    = "programs"
 	// With the current row structure, the max items we can store is 262k.
 	maxUnwindTableSize = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in BPF program.
 )
@@ -60,6 +61,7 @@ type bpfMaps struct {
 	stackCounts  *bpf.BPFMap
 	stackTraces  *bpf.BPFMap
 	unwindTables *bpf.BPFMap
+	programs     *bpf.BPFMap
 }
 
 // readUserStack reads the user stack trace from the stacktraces ebpf map into the given buffer.
@@ -189,9 +191,9 @@ func (m *bpfMaps) setUnwindTable(pid int, ut unwind.UnwindTable) error {
 		case frame.RuleCFA:
 			// Write CFA register.
 			var CFARegister uint16
-			if row.CFA.Reg == 6 {
+			if row.CFA.Reg == frame.X86_64FramePointer {
 				CFARegister = uint16(CFARegisterRbp)
-			} else if row.CFA.Reg == 7 {
+			} else if row.CFA.Reg == frame.X86_64StackPointer {
 				CFARegister = uint16(CFARegisterRsp)
 			}
 


### PR DESCRIPTION
This PR implements the v2 of the DWARF stack unwinder:

- The first commit reduces the unwind table size by half, allowing for more entries to fit in the table;
- The second commit removes `bpf_loop`, reducing the minimum required kernel version;
- The third commit reenables the CPU tests;

The details for each commit can be found in their commit message.

## Test Plan

Ensured, visually, that the stacks are correct:

**`testdata/out/basic-cpp-no-fp`**:

<details>
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/959128/199458962-2a491edd-1f70-4b4c-88e8-8b3b4491cff0.png">
</details>

**CRuby interpreter**

<details>
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/959128/199459108-6033bca0-9207-41c1-ac0e-00cd82cbddb7.png">
[...]
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/959128/199459047-0fd13b7c-1816-4e0c-9a07-328f37d17442.png">
</details>