### PR TITLE
elfwriter_test: Add all types in the symbol table

### DIFF
--- a/pkg/elfwriter/aggregating_elfwriter_test.go
+++ b/pkg/elfwriter/aggregating_elfwriter_test.go
@@ -96,7 +96,7 @@ func TestAggregatingWriter_Write(t *testing.T) {
 				FileHeader: &inElf.FileHeader,
 				Sections:   cleanLinks(secDebug),
 			},
-			expectedNumberOfSections: len(secDebug) + 2, // shstrtab, SHT_NULL
+			expectedNumberOfSections: len(secDebug) + 1, // SHT_NULL
 			isSymbolizable:           true,
 			hasDWARF:                 true,
 		},
@@ -107,7 +107,7 @@ func TestAggregatingWriter_Write(t *testing.T) {
 				Sections:       cleanLinks(secDebug),
 				SectionHeaders: []elf.SectionHeader{inElf.Section(".text").SectionHeader},
 			},
-			expectedNumberOfSections: len(secDebug) + 3, // shstrtab, SHT_NULL, .text
+			expectedNumberOfSections: len(secDebug) + 2, // SHT_NULL, .text
 			isSymbolizable:           true,
 			hasDWARF:                 true,
 		},

--- a/pkg/elfwriter/elfwriter_test.go
+++ b/pkg/elfwriter/elfwriter_test.go
@@ -37,7 +37,9 @@ var isSymbolTable = func(s *elf.Section) bool {
 		s.Name == ".dynsym" ||
 		s.Name == ".strtab" ||
 		s.Name == ".dynstr" ||
-		s.Type == elf.SHT_SYMTAB
+		s.Type == elf.SHT_SYMTAB ||
+		s.Type == elf.SHT_DYNSYM ||
+		s.Type == elf.SHT_STRTAB
 }
 
 var isGoSymbolTable = func(s *elf.Section) bool {
@@ -142,7 +144,7 @@ func TestWriter_Write(t *testing.T) {
 				FileHeader: &inElf.FileHeader,
 				Sections:   secDebug,
 			},
-			expectedNumberOfSections: len(secDebug) + 2, // shstrtab, SHT_NULL
+			expectedNumberOfSections: len(secDebug) + 1, // SHT_NULL
 			isSymbolizable:           true,
 			hasDWARF:                 true,
 		},
@@ -153,7 +155,7 @@ func TestWriter_Write(t *testing.T) {
 				Sections:       secDebug,
 				SectionHeaders: []elf.SectionHeader{inElf.Section(textSectionName).SectionHeader},
 			},
-			expectedNumberOfSections: len(secDebug) + 3, // shstrtab, SHT_NULL, .text
+			expectedNumberOfSections: len(secDebug) + 2, // SHT_NULL, .text
 			isSymbolizable:           true,
 			hasDWARF:                 true,
 		},


### PR DESCRIPTION
This is just to be in sync with the debuginfo extractor of parca agent. Doesn't change anything in the result produced by the tests.

Signed-off-by: Vaishali Thakkar <me.vaishalithakkar@gmail.com>