### PR TITLE
.eh_frame: Initial ASLR support

### DIFF
--- a/pkg/executable/executable.go
+++ b/pkg/executable/executable.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package executable
+
+import (
+	"debug/elf"
+	"fmt"
+)
+
+// IsASLRElegible returns whether the elf executable could be elegible for
+// address space layout randomization (ASLR).
+//
+// Whether to enable ASLR for a process is decided in this kernel code
+// path (https://github.com/torvalds/linux/blob/v5.0/fs/binfmt_elf.c#L955).
+//
+// Note(javierhonduco): This check is a bit simplistic and might not work
+// for every case. We might want to check across multiple kernels. It probably
+// won't be correct for the dynamic loader itself. See link above.
+func IsASLRElegible(path string) (bool, error) {
+	elfFile, err := elf.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("failed opening elf file with %w", err)
+	}
+	defer elfFile.Close()
+
+	return elfFile.FileHeader.Type == elf.ET_DYN, nil
+}

--- a/pkg/executable/executable_test.go
+++ b/pkg/executable/executable_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package executable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestASLRDisabled(t *testing.T) {
+	aslrEnabled, err := IsASLRElegible("../../testdata/out/basic-cpp")
+	require.NoError(t, err)
+	require.Equal(t, false, aslrEnabled)
+}
+
+func TestASLREnabled(t *testing.T) {
+	aslrEnabled, err := IsASLRElegible("../../testdata/out/basic-cpp-plt-pie")
+	require.NoError(t, err)
+	require.Equal(t, true, aslrEnabled)
+}


### PR DESCRIPTION
Right now, processes that are loaded at a randomized address won't work
with the current dwarf-based stack unwinding code. The reason for this
is that the program counters aren't adjusted accordingly.

This commit adds a new package under `pkg/executable` that will host
code specific to executables. The `IsASLRElegible` is documented inline,
it's a pretty basic function and doesn't handle some edge cases, but
this should do for most of the processes I've tried in my host (see test
plan of this PR and in the upcoming sharded unwind table work).

In the future, this will be refactored in a more cohesive module that
will do more groundwork necessary for other parts of the profiler.
Caching will be added later on, too.

The first commit updates the testdata repository which adds the PIE executables.

## Test Plan

**Added unittest**
```
[javierhonduco@fedora parca-agent]$ go test -v github.com/parca-dev/parca-agent/pkg/executable
=== RUN   TestASLRDisabled
--- PASS: TestASLRDisabled (0.00s)
=== RUN   TestASLREnabled
--- PASS: TestASLREnabled (0.00s)
PASS
ok      github.com/parca-dev/parca-agent/pkg/executable (cached)
```



**e2e test**

``` 
./testdata/out/basic-cpp-plt-pie
``` 

``` 
make build-dyn ENABLE_ASAN=yes &&  sudo dist/parca-agent-dyn --node=test --remote-store-insecure --remote-store-address=localhost:7070 --experimental-dwarf-unwinding-pids=`pidof basic-cpp-plt-pie`
``` 

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/959128/200555188-e9c5a3fe-b064-4416-8bd0-2f4d860fb238.png">
