### PR TITLE
.eh_frame: Shard unwind table

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Show kernel version
+        run: uname -a
+
       - name: Test
         run: |
           make test ENABLE_RACE=yes

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -272,9 +272,17 @@ func (p *CPU) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get stack traces map: %w", err)
 	}
-	unwindTables, err := m.GetMap(unwindTableMapName)
+	unwindTable1, err := m.GetMap(unwindTable1MapName)
 	if err != nil {
-		return fmt.Errorf("get unwind tables map: %w", err)
+		return fmt.Errorf("get unwind table 1 map: %w", err)
+	}
+	unwindTable2, err := m.GetMap(unwindTable2MapName)
+	if err != nil {
+		return fmt.Errorf("get unwind table 2 map: %w", err)
+	}
+	unwindTable3, err := m.GetMap(unwindTable3MapName)
+	if err != nil {
+		return fmt.Errorf("get unwind table 3 map: %w", err)
 	}
 
 	dwarfStackTraces, err := m.GetMap(dwarfStackTracesMapName)
@@ -287,7 +295,9 @@ func (p *CPU) Run(ctx context.Context) error {
 		stackCounts:      stackCounts,
 		stackTraces:      stackTraces,
 		dwarfStackTraces: dwarfStackTraces,
-		unwindTables:     unwindTables,
+		unwindTable1:     unwindTable1,
+		unwindTable2:     unwindTable2,
+		unwindTable3:     unwindTable3,
 	}
 
 	ticker := time.NewTicker(p.profilingDuration)

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -129,6 +129,11 @@ func (ptb *UnwindTableBuilder) UnwindTableForPid(pid int) (UnwindTable, error) {
 		}
 
 		rows := buildUnwindTable(fdes)
+		if len(rows) == 0 {
+			level.Error(ptb.logger).Log("msg", "unwind table empty for", "obj", executablePath)
+			continue
+		}
+
 		level.Info(ptb.logger).Log("msg", "adding tables for mapped executable", "path", executablePath, "rows", len(rows), "low pc", fmt.Sprintf("%x", rows[0].Loc), "high pc", fmt.Sprintf("%x", rows[len(rows)-1].Loc))
 
 		aslrElegible, err := executable.IsASLRElegible(executablePath)


### PR DESCRIPTION
This commits range-shards the unwind table bumping the maximum table size from 250k elements to 750k, allowing us to profile larger executables.


## Test Plan

While running all these tests, `sudo bpftool prog tracelog | grep error` returned no results.

The stats looked similar in all the below, but for Postgres:
``` 
      postmaster-123830  [007] d.h2.  9831.335675: bpf_trace_printk: [[ stats for cpu 7 ]]
      postmaster-123830  [007] d.h2.  9831.335677: bpf_trace_printk: success=349
      postmaster-123830  [007] d.h2.  9831.335678: bpf_trace_printk: unsup_expression=0
      postmaster-123830  [007] d.h2.  9831.335679: bpf_trace_printk: truncated=0
      postmaster-123830  [007] d.h2.  9831.335680: bpf_trace_printk: catchall=0
      postmaster-123830  [007] d.h2.  9831.335681: bpf_trace_printk: never=0
      postmaster-123830  [007] d.h2.  9831.335683: bpf_trace_printk: total_counter=350
      postmaster-123830  [007] d.h2.  9831.335684: bpf_trace_printk: (not_covered=287)
```

### Minikube (kernel 5.10)
<details>
<img width="935" alt="image" src="https://user-images.githubusercontent.com/959128/200622097-3e46e2e9-2f92-4a79-8109-7502aeebcca3.png">
</details>

### CRuby (no fp, dynamically loaded, no PIE)
<details>
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/959128/200622240-02bafb21-63dc-4860-9d7f-37a409d97294.png">
</details>

### CRuby
<details>
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/959128/200622240-02bafb21-63dc-4860-9d7f-37a409d97294.png">
</details>

### Golang process (walked with fp)
<details>
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/959128/200622408-a5ca3b31-d820-4b1f-ad52-90e556b4bcaa.png">
</details>


### Redpanda (table too big before this commit)
<details>
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/959128/200622604-5243226f-ecf6-4153-8f17-6e2b3ec8d055.png">
</details>

### SystemD (table too big before this commit)
<details>
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/959128/200622943-f30df7e3-eff4-4cd2-a7fb-00e4146cf53f.png">
</details>

### Postgres (table too big before this commit)
<details>
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/959128/200623074-9e0bbcf9-06cb-4dc9-9d99-744620c02f0d.png">
</details>


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>