### PR TITLE
ci(e2e): simplify setup

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,7 +39,7 @@ jobs:
               "bpf/Makefile",
               "go.mod",
               "go.sum",
-              "e2e"
+              "e2e/**"
             ]
           skip_after_successful_duplicate: false
 
@@ -212,9 +212,7 @@ jobs:
 
   run-end-to-end-tests:
     name: run end-to-end tests
-    # e2e tests need nested virtualisation which is only available
-    # on macos runners when using GitHub-hosted runners.
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     needs: build-and-push-container
     permissions:
       contents: read
@@ -226,23 +224,20 @@ jobs:
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # tag=v3.3.1
         with:
           go-version-file: .go-version
+          cache: true
 
       - name: Set up jsonnet
         run: ./env-jsonnet.sh
 
-      - name: Set up jq
-        run: brew install jq
-
-      - name: start minikube
+      - name: Set up Minikube
         uses: medyagh/setup-minikube@b127ace2ffdece4eb28e7dedb9da39f495ab7af0 # tag=v0.0.8
         with:
           minikube-version: ${{ env.MINIKUBE_VERSION }}
-
-      - name: Set up kubectl
-        run: brew install kubectl
+          driver: none
+          kubernetes-version: stable # Determined by Minikube version
 
       - name: Run e2e tests
-        run: make actions-e2e
+        run: make actions-e2e E2E_KUBECONTEXT=minikube
 
       - name: Upload kubectl logs
         run: ./e2e/e2e-dump.sh

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ E2E_KUBECONTEXT := parca-e2e
 .PHONY: actions-e2e
 actions-e2e:
 	# If running locally, first run:
-	#    minikube --profile=$(E2E_KUBECONTEXT) start
+	#    minikube --profile=$(E2E_KUBECONTEXT) start --driver=virtualbox
 	./e2e/ci-e2e.sh $(VERSION) $(E2E_KUBECONTEXT)
 	$(GO) test -v ./e2e --context "$(E2E_KUBECONTEXT)"
 	# If running locally, you can now delete the cluster:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifeq ($(GITHUB_SHA),)
 else
 	COMMIT := $(shell echo $(GITHUB_SHA) | cut -c1-8)
 endif
-VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '$(BRANCH)$(COMMIT)'))
+VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '$(subst /,-,$(BRANCH))$(COMMIT)'))
 
 # renovate: datasource=docker depName=docker.io/goreleaser/goreleaser-cross
 GOLANG_CROSS_VERSION := v1.19.3
@@ -311,10 +311,16 @@ dev/up: deploy/manifests
 dev/down:
 	source ./scripts/local-dev.sh && down
 
+E2E_KUBECONTEXT := parca-e2e
+
 .PHONY: actions-e2e
 actions-e2e:
-	cd deploy; source ./../e2e/ci-e2e.sh && run "virtualbox" $(VERSION)
+	# If running locally, first run:
+	#    minikube --profile=$(E2E_KUBECONTEXT) start
+	./e2e/ci-e2e.sh $(VERSION) $(E2E_KUBECONTEXT)
 	$(GO) test -v ./e2e --kubeconfig "$(HOME)/.kube/config"
+	# If running locally, you can now delete the cluster:
+	#    minikube --profile=$(E2E_KUBECONTEXT) delete
 
 .PHONY: $(DOCKER_BUILDER)
 $(DOCKER_BUILDER): Dockerfile.cross-builder | $(OUT_DIR) check_$(CMD_DOCKER)

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ actions-e2e:
 	# If running locally, first run:
 	#    minikube --profile=$(E2E_KUBECONTEXT) start
 	./e2e/ci-e2e.sh $(VERSION) $(E2E_KUBECONTEXT)
-	$(GO) test -v ./e2e --kubeconfig "$(HOME)/.kube/config"
+	$(GO) test -v ./e2e --context "$(E2E_KUBECONTEXT)"
 	# If running locally, you can now delete the cluster:
 	#    minikube --profile=$(E2E_KUBECONTEXT) delete
 

--- a/deploy/jsonnetfile.json
+++ b/deploy/jsonnetfile.json
@@ -3,20 +3,20 @@
   "dependencies": [
     {
       "source": {
-        "local": {
-          "directory": "lib/parca-agent"
-        }
-      },
-      "version": ""
-    },
-        {
-      "source": {
         "git": {
           "remote": "https://github.com/parca-dev/parca.git",
           "subdir": "deploy/lib/parca"
         }
       },
-      "version": "main"
+      "version": "v0.12.1"
+    },
+    {
+      "source": {
+        "local": {
+          "directory": "lib/parca-agent"
+        }
+      },
+      "version": ""
     }
   ],
   "legacyImports": true

--- a/deploy/jsonnetfile.json
+++ b/deploy/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "deploy/lib/parca"
         }
       },
-      "version": "v0.12.1"
+      "version": "v0.14.0"
     },
     {
       "source": {

--- a/deploy/jsonnetfile.lock.json
+++ b/deploy/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "deploy/lib/parca"
         }
       },
-      "version": "d6402ad5b0fd83893b6dfa1bbb624318d9965072",
-      "sum": "/RmMMeipvEOtW5qYPUoiExRY+ZSe76SbyIVipCg3m0w="
+      "version": "6366c222643be15032e5e38dc9e13045578f880a",
+      "sum": "dn2ryBP/B+FFwFEwuNYXKSU6tFSoSsjm/wf7QNczTKY="
     },
     {
       "source": {

--- a/deploy/jsonnetfile.lock.json
+++ b/deploy/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "deploy/lib/parca"
         }
       },
-      "version": "6366c222643be15032e5e38dc9e13045578f880a",
-      "sum": "dn2ryBP/B+FFwFEwuNYXKSU6tFSoSsjm/wf7QNczTKY="
+      "version": "e5c9635cdd2772059bdbb37c4301829125261d05",
+      "sum": "/RmMMeipvEOtW5qYPUoiExRY+ZSe76SbyIVipCg3m0w="
     },
     {
       "source": {

--- a/e2e/ci-e2e.sh
+++ b/e2e/ci-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2022 The Parca Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,79 +13,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-################################################################################
-#
-# This script is meant to be run from the root of this project
-#
-################################################################################
-
 set -euox pipefail
 
-function run() {
-    # Driver set to virtualbox by default if not specified
-    DRIVER=${1-virtualbox}
-    VERSION=$2
+# renovate: datasource=github-releases depName=parca-dev/parca
+SERVER_VERSION='v0.12.1'
 
-    minikube_up "$DRIVER"
-    generate_manifests "$VERSION"
-    deploy
-}
+AGENT_VERSION="${1?Parca Agent version must be provided}"
+KUBECONTEXT="${2?Kubernetes context must be provided}"
 
-# Create local minikube cluster and deploys the dev env for parca and parca agent
-function minikube_up() {
-    # can be virtualbox, vmwarefusion, kvm2, vmware, none, docker, podman, ssh
-    DRIVER=$1
+ROOT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
 
-    echo "Spinning up a parca dev cluster"
-    minikube start -p parca-e2e \
-        --container-runtime=docker \
-        --insecure-registry="localhost:5000" \
-        --driver="$DRIVER" \
-        --feature-gates=EphemeralContainers=true \
-        --kubernetes-version=v1.22.3 \
-        --docker-opt dns=8.8.8.8 \
-        --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
+KUBECTL=(kubectl --context="${KUBECONTEXT}")
 
-    eval "$(minikube -p parca-e2e docker-env)"
-}
+function dump_deploy_status() {
+    kubectl get all --all-namespaces
 
-# Delete minikube instance
-function minikube_down() {
-    echo "Deleting parca-e2e cluster"
-    minikube delete -p parca-e2e
+    echo ">>> Printing Parca logs..."
+    "${KUBECTL[@]}" --namespace=parca logs --selector='app.kubernetes.io/name=parca'
+
+    echo '>>> Printing Parca Agent logs...'
+    "${KUBECTL[@]}" --namespace=parca logs --selector='app.kubernetes.io/name=parca-agent'
 }
 
 # Configure clusters to run latest commit in Parca agent
 function deploy() {
-    echo "fetching parca binary"
-    SERVER_LATEST_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='v:refname' https://github.com/parca-dev/parca.git 'v*.*.*' | tail -1 | cut -d/ -f3)
-    echo "Server version: $SERVER_LATEST_VERSION"
+    trap dump_deploy_status EXIT
 
-    #AGENT_LATEST_VERSION=$(curl -sSf https://api.github.com/repos/parca-dev/parca-agent/releases/latest | jq -r .tag_name)
+    if ! "${KUBECTL[@]}" get namespace parca >/dev/null; then
+        "${KUBECTL[@]}" create namespace parca
+    fi
 
-    kubectl create namespace parca
+    make -C deploy vendor
+    jsonnet \
+        --tla-str version="${AGENT_VERSION}" \
+        --tla-str serverVersion="${SERVER_VERSION}" \
+        --jpath deploy/vendor \
+        deploy/e2e.jsonnet \
+        | kubectl apply --filename=-
 
-    kubectl apply -f https://github.com/parca-dev/parca/releases/download/"$SERVER_LATEST_VERSION"/kubernetes-manifest.yaml
-    kubectl -n parca rollout status deployment/parca --timeout=2m
+    "${KUBECTL[@]}" --namespace=parca rollout status deployment/parca --timeout=2m
+    "${KUBECTL[@]}" --namespace=parca rollout status daemonset/parca-agent --timeout=2m
 
-    #kubectl apply -f https://github.com/parca-dev/parca-agent/releases/download/"$AGENT_LATEST_VERSION"/kubernetes-manifest.yaml
-    kubectl apply -f ./manifests/local/
-    kubectl -n parca rollout status daemonset/parca-agent --timeout=2m
-
-    echo "Connecting to Parca and Parca agent"
-
+    echo '>>> Profiling system for 5 minutes...'
     sleep 300
-
-    kubectl get all -A
 }
 
-# Build image with latest commit
-function generate_manifests() {
-    VERSION=$1
-
-    rm -rf manifests/local
-    mkdir -p manifests/local
-
-    make vendor
-    jsonnet --tla-str version="$VERSION" -J vendor e2e.jsonnet -m manifests/local | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}'
+function main() {
+    deploy
 }
+
+main "${@}"

--- a/e2e/ci-e2e.sh
+++ b/e2e/ci-e2e.sh
@@ -16,7 +16,7 @@
 set -euox pipefail
 
 # renovate: datasource=github-releases depName=parca-dev/parca
-SERVER_VERSION='v0.12.1'
+SERVER_VERSION='v0.14.0'
 
 AGENT_VERSION="${1?Parca Agent version must be provided}"
 KUBECONTEXT="${2?Kubernetes context must be provided}"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -30,11 +30,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	pb "github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1"
 )
 
-var kubeconfig = flag.String("kubeconfig", "~/.kube/config", "kube config path")
+var kubecontext = flag.String("context", "", "The name of the kubeconfig context to use")
 
 // Checks for parca-server and parca-agent pods and returns pod names if true
 // Returns empty string if no pods are found.
@@ -70,7 +71,11 @@ func TestGRPCIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	cfg, err := GetKubeConfig(*kubeconfig)
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{CurrentContext: *kubecontext},
+	)
+	cfg, err := kubeConfig.ClientConfig()
 	require.NoError(t, err)
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -87,11 +87,12 @@ func TestGRPCIntegration(t *testing.T) {
 	}
 	defer serverCloser()
 
-	agentCloser, err := StartPortForward(ctx, cfg, "https", parcaAgent, ns, "7071")
-	if err != nil {
-		require.NoError(t, err, "failed to start port forwarding Parca Agent: %v", err)
-	}
-	defer agentCloser()
+	// // Port 7071 may already be in use by docker-proxy on the host (e.g. Minikube with none driver)
+	// agentCloser, err := StartPortForward(ctx, cfg, "https", parcaAgent, ns, "7072:7071")
+	// if err != nil {
+	// 	require.NoError(t, err, "failed to start port forwarding Parca Agent: %v", err)
+	// }
+	// defer agentCloser()
 
 	t.Log("Starting tests")
 	conn, err := grpc.Dial("127.0.0.1:7070", grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -92,12 +92,9 @@ func TestGRPCIntegration(t *testing.T) {
 	}
 	defer serverCloser()
 
-	// // Port 7071 may already be in use by docker-proxy on the host (e.g. Minikube with none driver)
-	// agentCloser, err := StartPortForward(ctx, cfg, "https", parcaAgent, ns, "7072:7071")
-	// if err != nil {
-	// 	require.NoError(t, err, "failed to start port forwarding Parca Agent: %v", err)
-	// }
-	// defer agentCloser()
+	// If port-forwarding the agent, the port TCP/7071 may already
+	// be in used on the host by docker-proxy (e.g. Minikube with none driver),
+	// ensure to use a different local port (e.g. "7072:7071")
 
 	t.Log("Starting tests")
 	conn, err := grpc.Dial("127.0.0.1:7070", grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
+      "description": "Group parca packages",
+      "matchSourceUrls": ["https://github.com/parca-dev/parca"],
+      "groupName": "parca"
+    },
+    {
       "description": "Use custom versioning for libbpfgo",
       "matchPackageNames": ["github.com/aquasecurity/libbpfgo"],
       "automerge": false,

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     {
       "description": "Group parca packages",
       "matchSourceUrls": ["https://github.com/parca-dev/parca"],
+      "stabilityDays": 0,
       "groupName": "parca"
     },
     {

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -67,7 +67,9 @@ function up() {
             --nodes="${NODE_COUNT}" \
             --cpus=2 \
             --memory=8gb \
-            --disk-size=20gb
+            --disk-size=20gb \
+            --docker-opt dns=8.8.8.8 \
+            --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
     fi
     # Switch kubectl to the minikube context
     mk update-context

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -65,12 +65,9 @@ function up() {
         mk start \
             --driver="${DRIVER}" \
             --nodes="${NODE_COUNT}" \
-            --kubernetes-version=v1.23.3 \
             --cpus=2 \
             --memory=8gb \
-            --disk-size=20gb \
-            --docker-opt dns=8.8.8.8 \
-            --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
+            --disk-size=20gb
     fi
     # Switch kubectl to the minikube context
     mk update-context

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -65,6 +65,7 @@ function up() {
         mk start \
             --driver="${DRIVER}" \
             --nodes="${NODE_COUNT}" \
+            --kubernetes-version=stable \
             --cpus=2 \
             --memory=8gb \
             --disk-size=20gb \


### PR DESCRIPTION
* Use Minikube's `none` driver to run Kubernetes on GH runner directly
* Only take care of the deployment in `ci-e2e.sh`, wrapping the `minikube` CLI does not add a lot of value and is complex depending on the driver used and host machine, everything is taken care by the setup action here, otherwise it's a simple `minikube start` (a simple comment on how to do it locally has been added with a mandatory Kube context parameter as a safe guard from unintentional deployments)
* Use Minikube's `stable` Kubernetes version (v1.25 currently), this should improve compatibility/stability. It will be bumped with each Minikube updates
* Hide PSP resources from Jsonnet output (removed in K8s v1.25) 
* Remove Minikube's `--feature-gates=EphemeralContainers=true`, now stable in v1.25
* ~~Remove Minikube's `--docker-opt default-ulimit=memlock=`, the bump should be taken care of by the agent~~
* Use a single Jsonnet command for the full deployment, increases flexibility
* Pin Parca server version
* Pipe Jsonnet output directly into `kubectl apply` (avoid going by YAML to disk in between)
* The port 7071 is already by `docker-proxy` on the host (this is one took me the most time to figure out as the error message was obscure and I had to create a local reproduction which once done was pretty quick to spot the issue). I removed the port-forward to the agent as it is unused at moment, another port like 7072 could be used in the future
* Use default config loading chain (`KUBECONFIG` env var, `~/.kube/config`) in e2e and add k8s context flag 

Closes #962