### PR TITLE
metadata: Add missing container labels back

### DIFF
--- a/pkg/discovery/discovery_manager.go
+++ b/pkg/discovery/discovery_manager.go
@@ -323,8 +323,12 @@ func (m *Manager) allGroups() map[string][]*Group {
 	for _, groups := range tSets {
 		for _, group := range groups {
 			for _, pid := range group.PIDs {
+				allLabels := model.LabelSet{}.Merge(group.Labels)
+				for _, t := range group.Targets {
+					allLabels = allLabels.Merge(t)
+				}
 				// Overwrite the information we have here with the latest.
-				m.pidLabels.Put(pid, group.Labels)
+				m.pidLabels.Put(pid, allLabels)
 			}
 			m.callUpdateHooks(group.PIDs)
 		}

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -25,11 +25,18 @@ import (
 
 // PID is the process ID of the profiling target.
 // See https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_node/libc_554.html
-type PID int
+type PID int32
+
+// StackID consists of two parts: the first part is the process ID of the profiling target,
+// the second part is the thread ID of the stack trace has been collected from.
+type StackID struct {
+	PID  PID
+	TGID PID
+}
 
 // Profile represents a capture profile of a process.
 type Profile struct {
-	PID PID
+	ID StackID
 
 	Samples   []*profile.Sample
 	Locations []*profile.Location

--- a/pkg/symbol/symbol.go
+++ b/pkg/symbol/symbol.go
@@ -64,13 +64,12 @@ func (s *Symbolizer) Symbolize(prof *profiler.Profile) error {
 		}
 	}
 
-	pid := prof.PID
+	pid := prof.ID.PID
 	userJITedFunctions, err := s.resolveJITedFunctions(pid, prof.UserLocations)
 	if err != nil {
 		// Often some processes exit before symbols can be looked up.
 		// We also expect only a minority of processes to have a JIT and produce the perf map.
 		if errors.Is(err, perf.ErrProcStatusNotFound) || errors.Is(err, perf.ErrPerfMapNotFound) {
-			level.Debug(s.logger).Log("msg", "failed to obtain perf map for pid", "pid", pid, "err", err)
 			return nil
 		}
 		result = multierror.Append(result, fmt.Errorf("failed to resolve user JITed functions: %w", err))


### PR DESCRIPTION
* Merge profiles per process
* Provide Group target labels

Fixes #995 

### Tests

* `make dev/up`
* Check correct labels

<img width="765" alt="CleanShot 2022-11-14 at 15 40 48@2x" src="https://user-images.githubusercontent.com/536449/201688485-3811454d-8de7-421e-a0cc-660723fc50c9.png">

<img width="447" alt="CleanShot 2022-11-14 at 15 41 02@2x" src="https://user-images.githubusercontent.com/536449/201688501-2bc3a6f8-f184-4aea-b3eb-91fa3a8424cc.png">
