### PR TITLE
metadata: Refactor metadata provider

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -385,7 +385,8 @@ static __always_inline void add_stacks(struct bpf_perf_event_data *ctx, u64 id,
                                        unwind_state_t *unwind_state) {
   u64 zero = 0;
   stack_count_key_t stack_key = {};
-  // The first 32 bits of the key are the tgid/tid and the last 32 bits are the pid.
+  // The first 32 bits of the key are the tgid/tid and the last 32 bits are the
+  // pid.
   stack_key.pid = id >> 32;
   stack_key.tgid = id;
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/common-nighthawk/go-figure"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/goburrow/cache"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/keybase/go-ps"
 	okrun "github.com/oklog/run"
@@ -281,11 +280,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			),
 			discovery.NewSystemdConfig(),
 		}
-		discoveryManager = discovery.NewManager(logger, reg,
-			discovery.WithProcessLabelCache(cache.New(
-				cache.WithExpireAfterWrite(flags.ProfilingDuration*2),
-			)),
-		)
+		discoveryManager = discovery.NewManager(logger, reg)
 		if err := discoveryManager.ApplyConfig(ctx, map[string]discovery.Configs{"all": configs}); err != nil {
 			cancel()
 			return err
@@ -309,8 +304,8 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 	labelsManager := labels.NewManager(
 		logger,
 		// All the metadata providers work best-effort.
-		[]*metadata.Provider{
-			metadata.ServiceDiscovery(discoveryManager),
+		[]metadata.Provider{
+			metadata.ServiceDiscovery(logger, discoveryManager),
 			metadata.Target(flags.Node, flags.MetadataExternalLabels),
 			metadata.Cgroup(),
 			metadata.Compiler(),
@@ -318,9 +313,8 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			metadata.System(),
 		},
 		cfg.RelabelConfigs,
+		flags.ProfilingDuration, // Cache durations are calculated from profiling duration.
 	)
-
-	discoveryManager.RegisterUpdateHook(labelsManager.InvalidateCachesForPIDs)
 
 	profilers := []Profiler{
 		cpu.NewCPUProfiler(

--- a/pkg/metadata/cgroup.go
+++ b/pkg/metadata/cgroup.go
@@ -22,8 +22,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-func Cgroup() *Provider {
-	return &Provider{"cgroup", func(pid int) (model.LabelSet, error) {
+func Cgroup() Provider {
+	return &StatelessProvider{"cgroup", func(pid int) (model.LabelSet, error) {
 		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 		if err != nil {
 			return nil, err

--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -48,47 +48,48 @@ func (p *compilerProvider) ShouldCacheLabels() bool {
 func Compiler() Provider {
 	onceCompiler.Do(initialiseCache)
 
-	return &compilerProvider{StatelessProvider{"compiler", func(pid int) (model.LabelSet, error) {
-		process, err := ps.FindProcess(pid)
-		if err != nil {
-			return nil, err
-		}
-		if process == nil {
-			return nil, fmt.Errorf("process %d not found", pid)
-		}
-
-		path, err := process.Path()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get path for process %d: %w", pid, err)
-		}
-		elf, err := elf.Open(path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open ELF file for process %d: %w", pid, err)
-		}
-		defer elf.Close()
-
-		buildID, err := buildid.BuildID(path)
-		if err != nil {
-			return nil, fmt.Errorf("buildID failed")
-		}
-
-		value, ok := c.GetIfPresent(buildID)
-		if ok {
-			cachedLabels, ok := value.(model.LabelSet)
-			if !ok {
-				panic("The buildID cache contained the wrong type. This should never happen")
+	return &compilerProvider{
+		StatelessProvider{"compiler", func(pid int) (model.LabelSet, error) {
+			process, err := ps.FindProcess(pid)
+			if err != nil {
+				return nil, err
 			}
-			return cachedLabels, nil
-		}
+			if process == nil {
+				return nil, fmt.Errorf("process %d not found", pid)
+			}
 
-		labels := model.LabelSet{
-			"compiler": model.LabelValue(ainur.Compiler(elf)),
-			"stripped": model.LabelValue(fmt.Sprintf("%t", ainur.Stripped(elf))),
-			"static":   model.LabelValue(fmt.Sprintf("%t", ainur.Static(elf))),
-		}
+			path, err := process.Path()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get path for process %d: %w", pid, err)
+			}
+			elf, err := elf.Open(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open ELF file for process %d: %w", pid, err)
+			}
+			defer elf.Close()
 
-		c.Put(buildID, labels)
-		return labels, nil
-	}},
+			buildID, err := buildid.BuildID(path)
+			if err != nil {
+				return nil, fmt.Errorf("buildID failed")
+			}
+
+			value, ok := c.GetIfPresent(buildID)
+			if ok {
+				cachedLabels, ok := value.(model.LabelSet)
+				if !ok {
+					panic("The buildID cache contained the wrong type. This should never happen")
+				}
+				return cachedLabels, nil
+			}
+
+			labels := model.LabelSet{
+				"compiler": model.LabelValue(ainur.Compiler(elf)),
+				"stripped": model.LabelValue(fmt.Sprintf("%t", ainur.Stripped(elf))),
+				"static":   model.LabelValue(fmt.Sprintf("%t", ainur.Static(elf))),
+			}
+
+			c.Put(buildID, labels)
+			return labels, nil
+		}},
 	}
 }

--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -40,7 +40,7 @@ type compilerProvider struct {
 	StatelessProvider
 }
 
-func (p *compilerProvider) ShouldCacheLabels() bool {
+func (p *compilerProvider) ShouldCache() bool {
 	return false
 }
 

--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -36,11 +36,19 @@ func initialiseCache() {
 	c = burrow.New(burrow.WithMaximumSize(128))
 }
 
+type compilerProvider struct {
+	StatelessProvider
+}
+
+func (p *compilerProvider) ShouldCacheLabels() bool {
+	return false
+}
+
 // Compiler provides metadata for determined compiler.
-func Compiler() *Provider {
+func Compiler() Provider {
 	onceCompiler.Do(initialiseCache)
 
-	return &Provider{"compiler", func(pid int) (model.LabelSet, error) {
+	return &compilerProvider{StatelessProvider{"compiler", func(pid int) (model.LabelSet, error) {
 		process, err := ps.FindProcess(pid)
 		if err != nil {
 			return nil, err
@@ -81,5 +89,6 @@ func Compiler() *Provider {
 
 		c.Put(buildID, labels)
 		return labels, nil
-	}}
+	}},
+	}
 }

--- a/pkg/metadata/labels/manager.go
+++ b/pkg/metadata/labels/manager.go
@@ -51,9 +51,9 @@ func NewManager(logger log.Logger, providers []metadata.Provider, relabelConfigs
 		mtx:            &sync.RWMutex{},
 		relabelConfigs: relabelConfigs,
 
-		labelCache: cache.New(cache.WithExpireAfterAccess(profilingDuration * 3)),
+		labelCache: cache.New(cache.WithExpireAfterWrite(profilingDuration * 3)),
 		// Making cache durations shorter than label cache will not make any visible difference.
-		providerCache: cache.New(cache.WithExpireAfterAccess(profilingDuration * 6 * 10)),
+		providerCache: cache.New(cache.WithExpireAfterWrite(profilingDuration * 6 * 10)),
 	}
 }
 
@@ -75,7 +75,7 @@ func (m *Manager) labelSet(name string, pid uint64) model.LabelSet {
 	}
 
 	for _, provider := range m.providers {
-		shouldCache := provider.ShouldCacheLabels()
+		shouldCache := provider.ShouldCache()
 		if shouldCache {
 			key := providerCacheKey(name, provider.Name(), pid)
 			if cached, ok := m.providerCache.GetIfPresent(key); ok {

--- a/pkg/metadata/labels/manager.go
+++ b/pkg/metadata/labels/manager.go
@@ -14,6 +14,7 @@
 package labels
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -30,21 +31,29 @@ import (
 
 // Manager is responsible for aggregating, mutating, and serving process labels.
 type Manager struct {
-	logger         log.Logger
-	providers      []*metadata.Provider
-	relabelConfigs []*relabel.Config
+	logger log.Logger
+
+	providers     []metadata.Provider
+	providerCache cache.Cache
+
 	mtx            *sync.RWMutex
-	caches         map[string]cache.Cache
+	relabelConfigs []*relabel.Config
+
+	labelCache cache.Cache
 }
 
 // New returns an initialized Manager.
-func NewManager(logger log.Logger, providers []*metadata.Provider, relabelConfigs []*relabel.Config) *Manager {
+func NewManager(logger log.Logger, providers []metadata.Provider, relabelConfigs []*relabel.Config, profilingDuration time.Duration) *Manager {
 	return &Manager{
-		logger:         logger,
-		providers:      providers,
-		relabelConfigs: relabelConfigs,
+		logger:    logger,
+		providers: providers,
+
 		mtx:            &sync.RWMutex{},
-		caches:         make(map[string]cache.Cache),
+		relabelConfigs: relabelConfigs,
+
+		labelCache: cache.New(cache.WithExpireAfterAccess(profilingDuration * 3)),
+		// Making cache durations shorter than label cache will not make any visible difference.
+		providerCache: cache.New(cache.WithExpireAfterAccess(profilingDuration * 6 * 10)),
 	}
 }
 
@@ -53,23 +62,8 @@ func (m *Manager) ApplyConfig(relabelConfigs []*relabel.Config) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	m.relabelConfigs = relabelConfigs
-	for _, cache := range m.caches {
-		cache.InvalidateAll()
-	}
+	m.labelCache.InvalidateAll()
 	return nil
-}
-
-// InvalidateCachesForPIDs invalidate all label caches for given PIDs.
-func (m *Manager) InvalidateCachesForPIDs(pids []int) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	for _, pid := range pids {
-		for _, cache := range m.caches {
-			cache.Invalidate(pid)
-		}
-		level.Debug(m.logger).Log("msg", "invalidated all label caches for process", "pid", pid)
-	}
 }
 
 // labelSet fetches process specific labels to the profile.
@@ -81,6 +75,14 @@ func (m *Manager) labelSet(name string, pid uint64) model.LabelSet {
 	}
 
 	for _, provider := range m.providers {
+		shouldCache := provider.ShouldCacheLabels()
+		if shouldCache {
+			if cached, ok := m.providerCache.GetIfPresent(providerCacheKey(name, provider.Name(), pid)); ok {
+				labelSet = labelSet.Merge(cached.(model.LabelSet))
+				continue
+			}
+		}
+
 		// Add service discovery metadata, such as the Kubernetes pod where the
 		// process is running, among others.
 		lbl, err := provider.Labels(int(pid))
@@ -89,22 +91,20 @@ func (m *Manager) labelSet(name string, pid uint64) model.LabelSet {
 			// level.Debug(p.logger).Log("msg", "failed to get metadata", "provider", provider.Name(), "err", err)
 			continue
 		}
-		for k, v := range lbl {
-			labelSet[k] = v
+		labelSet = labelSet.Merge(lbl)
+
+		if shouldCache {
+			// Stateless providers are cached for a longer period of time.
+			m.providerCache.Put(providerCacheKey(name, provider.Name(), pid), labelSet)
 		}
 	}
 
 	return labelSet
 }
 
-func (m *Manager) processRelabel(lbls labels.Labels) labels.Labels {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-	return relabel.Process(lbls, m.relabelConfigs...)
-}
-
 // Labels returns a labels.Labels with relabel configs applied.
 // Returns nil if set is dropped.
+// This method is only used by the UI for troubleshooting.
 func (m *Manager) Labels(name string, pid uint64) labels.Labels {
 	labelSet, ok := m.getIfCached(name, pid)
 	if ok {
@@ -122,7 +122,6 @@ func (m *Manager) Labels(name string, pid uint64) labels.Labels {
 
 	// This path is only used by the UI for troubleshooting,
 	// it is not necessary to cache these labels at the moment
-
 	return lbls
 }
 
@@ -146,24 +145,33 @@ func (m *Manager) LabelSet(name string, pid uint64) model.LabelSet {
 	}
 
 	m.cache(name, pid, labelSet)
-
 	return labelSet
+}
+
+func (m *Manager) processRelabel(lbls labels.Labels) labels.Labels {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	return relabel.Process(lbls, m.relabelConfigs...)
+}
+
+func labelCacheKey(profiler string, pid uint64) string {
+	return fmt.Sprintf("%s:%d", profiler, pid)
+}
+
+func providerCacheKey(profiler, provider string, pid uint64) string {
+	return fmt.Sprintf("%s:%s:%d", profiler, provider, pid)
 }
 
 // getIfCached retrieved a labelSet if it has been cached.
 func (m *Manager) getIfCached(profiler string, pid uint64) (model.LabelSet, bool) {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	if _, ok := m.caches[profiler]; ok {
-		if lset, ok := m.caches[profiler].GetIfPresent(int(pid)); ok {
-			labelSet, ok := lset.(model.LabelSet)
-			if ok {
-				level.Debug(m.logger).Log("msg", "label cache hit", "provider", profiler, "pid", pid)
-				return labelSet, true
-			}
-			level.Error(m.logger).Log("msg", "failed to assert cached label set type", "profiler", profiler, "pid", pid)
+	if lset, ok := m.labelCache.GetIfPresent(labelCacheKey(profiler, pid)); ok {
+		labelSet, ok := lset.(model.LabelSet)
+		if ok {
+			level.Debug(m.logger).Log("msg", "label cache hit", "provider", profiler, "pid", pid)
+			return labelSet, true
 		}
+		level.Error(m.logger).Log("msg", "failed to assert cached label set type", "profiler", profiler, "pid", pid)
 	}
 
 	level.Debug(m.logger).Log("msg", "label cache miss", "provider", profiler, "pid", pid)
@@ -173,14 +181,7 @@ func (m *Manager) getIfCached(profiler string, pid uint64) (model.LabelSet, bool
 // cache caches a given labelSet for a profiler/pid pair.
 // It creates the cache for the provider if does not exist.
 func (m *Manager) cache(profiler string, pid uint64, labelSet model.LabelSet) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	if _, ok := m.caches[profiler]; !ok {
-		m.caches[profiler] = cache.New(cache.WithExpireAfterAccess(10 * time.Minute))
-	}
-
-	m.caches[profiler].Put(int(pid), labelSet)
+	m.labelCache.Put(labelCacheKey(profiler, pid), labelSet)
 }
 
 // labelSetToLabels converts a model.LabelSet to labels.Labels.

--- a/pkg/metadata/labels/manager_test.go
+++ b/pkg/metadata/labels/manager_test.go
@@ -79,31 +79,3 @@ func TestManager(t *testing.T) {
 	require.Nil(t, lm.LabelSet("fake_profiler", 2))
 	require.Nil(t, lm.Labels("fake_profiler", 2))
 }
-
-func TestApplyConfig(t *testing.T) {
-	t.Parallel()
-
-	lm := labels.NewManager(log.NewNopLogger(), []metadata.Provider{}, []*relabel.Config{}, time.Second)
-
-	lm.ApplyConfig([]*relabel.Config{
-		{
-			SourceLabels: model.LabelNames{"node", "pid"},
-			Separator:    ";",
-			Regex:        relabel.MustNewRegexp(`(.*)`),
-			Replacement:  "$1",
-			TargetLabel:  "node_pid",
-			Action:       relabel.Replace,
-		},
-	})
-
-	require.Equal(t, labels.NewManager(log.NewNopLogger(), []metadata.Provider{}, []*relabel.Config{
-		{
-			SourceLabels: model.LabelNames{"node", "pid"},
-			Separator:    ";",
-			Regex:        relabel.MustNewRegexp(`(.*)`),
-			Replacement:  "$1",
-			TargetLabel:  "node_pid",
-			Action:       relabel.Replace,
-		},
-	}, time.Second), lm)
-}

--- a/pkg/metadata/labels/manager_test.go
+++ b/pkg/metadata/labels/manager_test.go
@@ -15,6 +15,7 @@ package labels_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
@@ -31,7 +32,7 @@ func TestManager(t *testing.T) {
 
 	lm := labels.NewManager(
 		log.NewNopLogger(),
-		[]*metadata.Provider{
+		[]metadata.Provider{
 			metadata.Target("test", map[string]string{}),
 		},
 		[]*relabel.Config{
@@ -53,6 +54,7 @@ func TestManager(t *testing.T) {
 				Action:       relabel.Drop,
 			},
 		},
+		time.Second,
 	)
 
 	// Should have the node_pid label
@@ -81,7 +83,7 @@ func TestManager(t *testing.T) {
 func TestApplyConfig(t *testing.T) {
 	t.Parallel()
 
-	lm := labels.NewManager(log.NewNopLogger(), []*metadata.Provider{}, []*relabel.Config{})
+	lm := labels.NewManager(log.NewNopLogger(), []metadata.Provider{}, []*relabel.Config{}, time.Second)
 
 	lm.ApplyConfig([]*relabel.Config{
 		{
@@ -94,7 +96,7 @@ func TestApplyConfig(t *testing.T) {
 		},
 	})
 
-	require.Equal(t, labels.NewManager(log.NewNopLogger(), []*metadata.Provider{}, []*relabel.Config{
+	require.Equal(t, labels.NewManager(log.NewNopLogger(), []metadata.Provider{}, []*relabel.Config{
 		{
 			SourceLabels: model.LabelNames{"node", "pid"},
 			Separator:    ";",
@@ -103,5 +105,5 @@ func TestApplyConfig(t *testing.T) {
 			TargetLabel:  "node_pid",
 			Action:       relabel.Replace,
 		},
-	}), lm)
+	}, time.Second), lm)
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -24,7 +24,7 @@ import (
 type Provider interface {
 	Labels(pid int) (model.LabelSet, error)
 	Name() string
-	ShouldCacheLabels() bool
+	ShouldCache() bool
 }
 
 type StatelessProvider struct {
@@ -40,7 +40,7 @@ func (p *StatelessProvider) Name() string {
 	return p.name
 }
 
-func (p *StatelessProvider) ShouldCacheLabels() bool {
+func (p *StatelessProvider) ShouldCache() bool {
 	return true
 }
 
@@ -70,7 +70,7 @@ func (p *StatefulProvider) Name() string {
 	return p.name
 }
 
-func (p *StatefulProvider) ShouldCacheLabels() bool {
+func (p *StatefulProvider) ShouldCache() bool {
 	return false
 }
 

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -15,18 +15,67 @@
 package metadata
 
 import (
+	"errors"
+	"sync"
+
 	"github.com/prometheus/common/model"
 )
 
-type Provider struct {
+type Provider interface {
+	Labels(pid int) (model.LabelSet, error)
+	Name() string
+	ShouldCacheLabels() bool
+}
+
+type StatelessProvider struct {
 	name      string
 	labelFunc func(pid int) (model.LabelSet, error)
 }
 
-func (p *Provider) Labels(pid int) (model.LabelSet, error) {
+func (p *StatelessProvider) Labels(pid int) (model.LabelSet, error) {
 	return p.labelFunc(pid)
 }
 
-func (p *Provider) Name() string {
+func (p *StatelessProvider) Name() string {
 	return p.name
+}
+
+func (p *StatelessProvider) ShouldCacheLabels() bool {
+	return true
+}
+
+type StatefulProvider struct {
+	name string
+
+	mtx   *sync.RWMutex
+	state map[int]model.LabelSet
+}
+
+func (p *StatefulProvider) Labels(pid int) (model.LabelSet, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.state == nil {
+		return nil, errors.New("state not initialized")
+	}
+
+	v, ok := p.state[pid]
+	if !ok {
+		return model.LabelSet{}, errors.New("not found")
+	}
+	return v, nil
+}
+
+func (p *StatefulProvider) Name() string {
+	return p.name
+}
+
+func (p *StatefulProvider) ShouldCacheLabels() bool {
+	return false
+}
+
+func (p *StatefulProvider) update(state map[int]model.LabelSet) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.state = state
 }

--- a/pkg/metadata/process.go
+++ b/pkg/metadata/process.go
@@ -15,12 +15,14 @@
 package metadata
 
 import (
+	"strconv"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/procfs"
 )
 
-func Process() *Provider {
-	return &Provider{"process", func(pid int) (model.LabelSet, error) {
+func Process() Provider {
+	return &StatelessProvider{"process", func(pid int) (model.LabelSet, error) {
 		p, err := procfs.NewProc(pid)
 		if err != nil {
 			return nil, err
@@ -35,9 +37,16 @@ func Process() *Provider {
 		if err != nil {
 			return nil, err
 		}
+
+		stat, err := p.Stat()
+		if err != nil {
+			return nil, err
+		}
+
 		return model.LabelSet{
 			"comm":       model.LabelValue(comm),
 			"executable": model.LabelValue(executable),
+			"ppid":       model.LabelValue(strconv.Itoa(stat.PPID)),
 		}, nil
 	}}
 }

--- a/pkg/metadata/service_discovery.go
+++ b/pkg/metadata/service_discovery.go
@@ -15,12 +15,56 @@
 package metadata
 
 import (
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+
 	"github.com/parca-dev/parca-agent/pkg/discovery"
 )
 
 // ServiceDiscovery metadata provider.
-func ServiceDiscovery(m *discovery.Manager) *Provider {
-	return &Provider{
-		"service discovery", m.ProcessLabels,
+func ServiceDiscovery(logger log.Logger, m *discovery.Manager) Provider {
+	provider := &StatefulProvider{
+		name:  "service discovery",
+		state: map[int]model.LabelSet{},
+		mtx:   &sync.RWMutex{},
 	}
+
+	go func() {
+		defer level.Warn(logger).Log("msg", "service discovery metadata provider exited")
+
+		for tSets := range m.SyncCh() {
+			state := map[int]model.LabelSet{}
+			// Update process labels.
+			for _, groups := range tSets {
+				for _, group := range groups {
+					for _, pid := range group.PIDs {
+						// Overwrite the information we have here with the latest.
+						allLabels := model.LabelSet{}
+						for k, v := range group.Labels {
+							allLabels[k] = v
+						}
+						for _, t := range group.Targets {
+							for k, v := range t {
+								allLabels[k] = v
+							}
+						}
+
+						_, ok := state[pid]
+						if ok {
+							state[pid] = state[pid].Merge(allLabels)
+						} else {
+							state[pid] = allLabels
+						}
+					}
+				}
+			}
+
+			provider.update(state)
+		}
+	}()
+
+	return provider
 }

--- a/pkg/metadata/system.go
+++ b/pkg/metadata/system.go
@@ -29,33 +29,21 @@ var (
 	once   sync.Once
 )
 
-func int8SliceToString(arr []int8) string {
-	var b strings.Builder
-	for _, v := range arr {
-		// NUL byte, as it's a C string.
-		if v == 0 {
-			break
-		}
-		b.WriteByte(byte(v))
-	}
-	return b.String()
+type systemProvider struct {
+	StatelessProvider
 }
 
-func kernelRelease() (string, error) {
-	var uname syscall.Utsname
-	if err := syscall.Uname(&uname); err != nil {
-		return "", err
-	}
-
-	return int8SliceToString(uname.Release[:]), nil
+func (p *systemProvider) ShouldCacheLabels() bool {
+	return false
 }
 
 // System provides metadata for the current system.
-func System() *Provider {
+func System() Provider {
 	once.Do(setMetadata)
-	return &Provider{"system", func(_ int) (model.LabelSet, error) {
+
+	return &systemProvider{StatelessProvider{"system", func(_ int) (model.LabelSet, error) {
 		return labels, nil
-	}}
+	}}}
 }
 
 // Call the system metadata getters just once as they will not
@@ -78,4 +66,25 @@ func setMetadata() {
 		"kernel_release": model.LabelValue(release),
 		"agent_revision": model.LabelValue(revision),
 	}
+}
+
+func int8SliceToString(arr []int8) string {
+	var b strings.Builder
+	for _, v := range arr {
+		// NUL byte, as it's a C string.
+		if v == 0 {
+			break
+		}
+		b.WriteByte(byte(v))
+	}
+	return b.String()
+}
+
+func kernelRelease() (string, error) {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return "", err
+	}
+
+	return int8SliceToString(uname.Release[:]), nil
 }

--- a/pkg/metadata/system.go
+++ b/pkg/metadata/system.go
@@ -33,7 +33,7 @@ type systemProvider struct {
 	StatelessProvider
 }
 
-func (p *systemProvider) ShouldCacheLabels() bool {
+func (p *systemProvider) ShouldCache() bool {
 	return false
 }
 

--- a/pkg/metadata/target.go
+++ b/pkg/metadata/target.go
@@ -21,9 +21,9 @@ import (
 )
 
 // Target metadata provider.
-func Target(node string, externalLabels map[string]string) *Provider {
+func Target(node string, externalLabels map[string]string) Provider {
 	target := targetLabels(node, externalLabels)
-	return &Provider{"target", func(pid int) (model.LabelSet, error) {
+	return &StatelessProvider{"target", func(pid int) (model.LabelSet, error) {
 		labels := model.LabelSet{}
 		for labelname, labelvalue := range target {
 			if !strings.HasPrefix(string(labelname), "__") {


### PR DESCRIPTION
* Cache labels by the provider
* Reduce the number of layer cache
* Refactor to ensure separation of concerns
* Add `ppid` for parent process ids