### PR TITLE
bpf: Ensure that the hashing code is unrolled

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -406,8 +406,9 @@ static __always_inline void add_stacks(struct bpf_perf_event_data *ctx,
   }
 
   if (method == STACK_WALKING_METHOD_DWARF) {
-    int stack_hash = MurmurHash2((u32 *)unwind_state->stack.addresses,
-                                 MAX_STACK_DEPTH * sizeof(u32), 0);
+    int stack_hash =
+        MurmurHash2((u32 *)unwind_state->stack.addresses,
+                    MAX_STACK_DEPTH * sizeof(u64) / sizeof(u32), 0);
     bpf_printk("stack hash %d", stack_hash);
     stack_key.user_stack_id_dwarf = stack_hash;
     stack_key.user_stack_id = 0;

--- a/bpf/cpu/hash.h
+++ b/bpf/cpu/hash.h
@@ -17,8 +17,11 @@ uint32_t MurmurHash2(const void *key, int len, uint32_t seed) {
   /* Mix 4 bytes at a time into the hash */
 
   const unsigned char *data = (const unsigned char *)key;
-
-  while (len >= 4) {
+  // MAX_STACK_DEPTH * 2 = 256 (because we hash 32 bits at a time).
+  for (int i = 0; i < 256; i++) {
+    if (len < 4) {
+      break;
+    }
     uint32_t k = *(uint32_t *)data;
 
     k *= m;


### PR DESCRIPTION
Fixes https://github.com/parca-dev/parca-agent/issues/991#issuecomment-1315796852

## Test Plan:

```
[javierhonduco@fedora parca-agent]$ sudo bpftool prog tracelog   | grep stats -A7
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143991: bpf_trace_printk: [[ stats for cpu 4 ]]
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143991: bpf_trace_printk: success=449
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143991: bpf_trace_printk: unsup_expression=0
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143992: bpf_trace_printk: truncated=0
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143992: bpf_trace_printk: catchall=0
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143992: bpf_trace_printk: never=0
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143992: bpf_trace_printk: total_counter=450
 basic-cpp-no-fp-4043219 [004] d.h2. 558229.143993: bpf_trace_printk: (not_covered=0)
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>