### PR TITLE
ci: fix snap build for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,10 +217,16 @@ jobs:
           make sign-container
 
   snap:
+    name: Build snap
     runs-on: ubuntu-latest
     needs: binaries
     timeout-minutes: 30
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        with:
+          fetch-depth: 0
+
       - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # tag=v3.0.1
         with:
           name: parca-agent-dist-release


### PR DESCRIPTION
Fixes #1027 

The snap build action that happens for a release was missing a checkout, this PR fixes that.