### PR TITLE
deploy: Add missing path prefixes to PodSecurityPolicy

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -144,6 +144,12 @@ function(params) {
           pathPrefix: '/sys',
         },
         {
+          pathPrefix: '/boot',
+        },
+        {
+          pathPrefix: '/var/run/dbus',
+        },
+        {
           pathPrefix: '/run',
         },
         {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Fixes #1028 