### PR TITLE
Introduce debug-process-names and experimental-enable-dwarf-unwinding

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -108,8 +108,11 @@ type flags struct {
 	DebuginfoStrip               bool          `kong:"help='Only upload information needed for symbolization. If false the exact binary the agent sees will be uploaded unmodified.',default='true'"`
 	DebuginfoUploadCacheDuration time.Duration `kong:"help='The duration to cache debuginfo upload exists checks for.',default='5m'"`
 
+	// Hidden debug flags (only for debugging):
+	DebugProcessNames []string `kong:"help='Only attach profilers to specified processes. comm name will be used to match the given matchers. Accepts Go regex syntax (https://pkg.go.dev/regexp/syntax).',hidden=''"`
+
 	// These flags are experimental. Use them at your own peril.
-	ExperimentalDwarfUnwindingPids []int `kong:"help='Unwind stack using .eh_frame information for these processes.',hidden=''"`
+	ExperimentalEnableDWARFUnwinding bool `kong:"help='Unwind stack using .eh_frame information.',hidden=''"`
 }
 
 var _ Profiler = &profiler.NoopProfiler{}
@@ -341,7 +344,8 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			labelsManager,
 			flags.ProfilingDuration,
 			flags.MemlockRlimit,
-			flags.ExperimentalDwarfUnwindingPids,
+			flags.DebugProcessNames,
+			flags.ExperimentalEnableDWARFUnwinding,
 		),
 	}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -23,7 +23,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"regexp"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -36,6 +38,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
 
 	"github.com/parca-dev/parca-agent/pkg/address"
@@ -89,8 +92,10 @@ type CPU struct {
 	lastSuccessfulProfileStartedAt time.Time
 	lastProfileStartedAt           time.Time
 
-	MemlockRlimit      uint64
-	dwarfUnwindingPIDs []int
+	memlockRlimit uint64
+
+	debugProcessNames    []string
+	enableDWARFUnwinding bool
 }
 
 func NewCPUProfiler(
@@ -104,7 +109,8 @@ func NewCPUProfiler(
 	labelsManager profiler.LabelsManager,
 	profilingDuration time.Duration,
 	memlockRlimit uint64,
-	dwarfUnwindingPIDs []int,
+	debugProcessNames []string,
+	enableDWARFUnwinding bool,
 ) *CPU {
 	return &CPU{
 		logger: logger,
@@ -127,8 +133,10 @@ func NewCPUProfiler(
 		byteOrder: byteorder.GetHostByteOrder(),
 		metrics:   newMetrics(reg),
 
-		MemlockRlimit:      memlockRlimit,
-		dwarfUnwindingPIDs: dwarfUnwindingPIDs,
+		memlockRlimit: memlockRlimit,
+
+		debugProcessNames:    debugProcessNames,
+		enableDWARFUnwinding: enableDWARFUnwinding,
 	}
 }
 
@@ -190,7 +198,7 @@ func (p *CPU) Run(ctx context.Context) error {
 	defer m.Close()
 
 	// Always need to be used after bpf.NewModuleFromBufferArgs to avoid limit override.
-	rLimit, err := profiler.BumpMemlock(p.MemlockRlimit, p.MemlockRlimit)
+	rLimit, err := profiler.BumpMemlock(p.memlockRlimit, p.memlockRlimit)
 	if err != nil {
 		return fmt.Errorf("bump memlock rlimit: %w", err)
 	}
@@ -263,53 +271,39 @@ func (p *CPU) Run(ctx context.Context) error {
 		return fmt.Errorf("failure updating: %w", err)
 	}
 
-	stackCounts, err := m.GetMap(stackCountsMapName)
+	p.bpfMaps, err = initializeMaps(m, p.byteOrder)
 	if err != nil {
-		return fmt.Errorf("get counts map: %w", err)
+		return fmt.Errorf("failed to initialize eBPF maps: %w", err)
 	}
 
-	stackTraces, err := m.GetMap(stackTracesMapName)
-	if err != nil {
-		return fmt.Errorf("get stack traces map: %w", err)
-	}
-	unwindTable1, err := m.GetMap(unwindTable1MapName)
-	if err != nil {
-		return fmt.Errorf("get unwind table 1 map: %w", err)
-	}
-	unwindTable2, err := m.GetMap(unwindTable2MapName)
-	if err != nil {
-		return fmt.Errorf("get unwind table 2 map: %w", err)
-	}
-	unwindTable3, err := m.GetMap(unwindTable3MapName)
-	if err != nil {
-		return fmt.Errorf("get unwind table 3 map: %w", err)
-	}
+	if len(p.debugProcessNames) > 0 {
+		level.Info(p.logger).Log("msg", "process names specified, debugging processes", "metchers", strings.Join(p.debugProcessNames, ", "))
+		pfs, err := procfs.NewDefaultFS()
+		if err != nil {
+			return fmt.Errorf("failed to create procfs: %w", err)
+		}
 
-	dwarfStackTraces, err := m.GetMap(dwarfStackTracesMapName)
-	if err != nil {
-		return fmt.Errorf("get dwarf stack traces map: %w", err)
-	}
+		var matchers []*regexp.Regexp
+		for _, exp := range p.debugProcessNames {
+			regex, err := regexp.Compile(exp)
+			if err != nil {
+				return fmt.Errorf("failed to compile regex: %w", err)
+			}
+			matchers = append(matchers, regex)
+		}
 
-	p.bpfMaps = &bpfMaps{
-		byteOrder:        p.byteOrder,
-		stackCounts:      stackCounts,
-		stackTraces:      stackTraces,
-		dwarfStackTraces: dwarfStackTraces,
-		unwindTable1:     unwindTable1,
-		unwindTable2:     unwindTable2,
-		unwindTable3:     unwindTable3,
+		if len(matchers) > 0 {
+			level.Debug(p.logger).Log("msg", "debug process matchers found, starting process watcher")
+			// Update the debug pids map.
+			if err := p.bpfMaps.enableDebug(); err != nil {
+				return fmt.Errorf("failed to enable debug: %w", err)
+			}
+			go p.watchProcesses(ctx, pfs, matchers)
+		}
 	}
 
 	ticker := time.NewTicker(p.profilingDuration)
 	defer ticker.Stop()
-
-	// Update unwind tables for the given pids.
-	for _, pid := range p.dwarfUnwindingPIDs {
-		level.Info(p.logger).Log("msg", "adding unwind tables", "pid", pid)
-		if err := p.addUnwindTables(pid); err != nil {
-			level.Error(p.logger).Log("msg", "failed to write unwind tables", "pid", pid, "err", err)
-		}
-	}
 
 	level.Debug(p.logger).Log("msg", "start profiling loop")
 	for {
@@ -385,6 +379,77 @@ func (p *CPU) Run(ctx context.Context) error {
 	}
 }
 
+func (p *CPU) watchProcesses(ctx context.Context, pfs procfs.FS, matchers []*regexp.Regexp) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		procs, err := pfs.AllProcs()
+		if err != nil {
+			level.Error(p.logger).Log("msg", "failed to list processes", "err", err)
+			continue
+		}
+
+		pids := []int{}
+		for _, proc := range procs {
+			comm, err := proc.Comm()
+			if err != nil {
+				level.Error(p.logger).Log("msg", "failed to get process name", "err", err)
+				continue
+			}
+
+			if comm == "" {
+				continue
+			}
+
+			for _, m := range matchers {
+				if m.MatchString(comm) {
+					level.Info(p.logger).Log("msg", "match found; debugging process", "pid", proc.PID, "comm", comm)
+					pids = append(pids, proc.PID)
+				}
+			}
+		}
+
+		if len(pids) > 0 {
+			level.Debug(p.logger).Log("msg", "updating debug pids map", "pids", fmt.Sprintf("%v", pids))
+			// Only meant to be used for debugging, it is not safe to use in production.
+			if err := p.bpfMaps.setDebugPIDs(pids); err != nil {
+				level.Warn(p.logger).Log("msg", "failed to update debug pids map", "err", err)
+			}
+		} else {
+			level.Debug(p.logger).Log("msg", "no processes matched the provided regex")
+			if err := p.bpfMaps.setDebugPIDs(nil); err != nil {
+				level.Warn(p.logger).Log("msg", "failed to update debug pids map", "err", err)
+			}
+			continue
+		}
+
+		// Can only be enabled when a debug process name is specified.
+		if p.enableDWARFUnwinding {
+			// Update unwind tables for the given pids.
+			for _, pid := range pids {
+				level.Info(p.logger).Log("msg", "adding unwind tables", "pid", pid)
+
+				pt, err := p.unwindTableBuilder.UnwindTableForPid(pid)
+				if err != nil {
+					level.Warn(p.logger).Log("msg", "failed to build unwind table", "pid", pid, "err", err)
+					continue
+				}
+
+				if err := p.bpfMaps.setUnwindTable(pid, pt); err != nil {
+					level.Warn(p.logger).Log("msg", "failed to update unwind tables", "pid", pid, "err", err)
+				}
+			}
+		}
+	}
+}
+
 func (p *CPU) report(lastError error, processLastErrors map[int]error) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -395,18 +460,6 @@ func (p *CPU) report(lastError error, processLastErrors map[int]error) {
 	}
 	p.lastError = lastError
 	p.processLastErrors = processLastErrors
-}
-
-func (p *CPU) addUnwindTables(pid int) error {
-	pt, err := p.unwindTableBuilder.UnwindTableForPid(pid)
-	if err != nil {
-		return fmt.Errorf("failed to build unwind table: %w", err)
-	}
-
-	if err := p.bpfMaps.setUnwindTable(pid, pt); err != nil {
-		return fmt.Errorf("failed to update unwind table: %w", err)
-	}
-	return nil
 }
 
 type (

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -50,6 +50,10 @@ func (t UnwindTable) Len() int           { return len(t) }
 func (t UnwindTable) Less(i, j int) bool { return t[i].Loc < t[j].Loc }
 func (t UnwindTable) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
+// TODO(kakkoyun): Unify with existing process maps mechanisms.
+// - pkg/process/mappings.go
+// The rest of thec ode base share a cache for process maps.
+
 // processMaps returns a map of file-backed memory mappings for a given
 // process which contains at least one executable section. The value of
 // mapping contains the metadata for the first mapping for each file, no

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -52,7 +52,7 @@ func (t UnwindTable) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
 // TODO(kakkoyun): Unify with existing process maps mechanisms.
 // - pkg/process/mappings.go
-// The rest of thec ode base share a cache for process maps.
+// The rest of the code base share a cache for process maps.
 
 // processMaps returns a map of file-backed memory mappings for a given
 // process which contains at least one executable section. The value of

--- a/scripts/local-run.sh
+++ b/scripts/local-run.sh
@@ -34,7 +34,7 @@ DEBUG=${DEBUG:-false}
 trap 'kill $(jobs -p); exit 0' EXIT
 
 (
-    $PARCA --config-path="../parca/parca.yaml"
+    $PARCA --config-path="../parca/parca.yaml" --port=:7070
 ) &
 
 (


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

```
// Hidden debug flags (only for debugging):
--debug-process-names []string 
Only attach profilers to specified processes. comm name will be used to match the given matchers. Accepts Go regex syntax (https://pkg.go.dev/regexp/syntax).

// These flags are experimental. Use them at your own peril.
--experimental-enable-dwarf-unwinding bool 
Unwind stack using .eh_frame information.
```
## Test

1. `sudo ./scripts/local-run.sh` with **`testdata/out/basic-cpp-no-fp`**:

<details>

```shell
sudo "${PARCA_AGENT}" \
            --node=local-test \
            --http-address=:7071 \
            --log-level=debug \
            --experimental-enable-dwarf-unwinding \
            --debug-process-names=basic-cpp-no-fp \
            --remote-store-address=localhost:7070 \
            --remote-store-insecure
```
<img width="1799" alt="CleanShot 2022-11-17 at 10 54 19@2x" src="https://user-images.githubusercontent.com/536449/202415459-3ec1c23e-f7cd-40a6-93d4-f3701b2b1e6d.png">

</details>

2.  `sudo ./scripts/local-run.sh` with **CRuby interpreter**:

<details>

```shell
sudo "${PARCA_AGENT}" \
            --node=local-test \
            --http-address=:7071 \
            --log-level=debug \
            --experimental-enable-dwarf-unwinding \
            --debug-process-names=ruby \
            --remote-store-address=localhost:7070 \
            --remote-store-insecure
```

<img width="1790" alt="CleanShot 2022-11-17 at 14 59 16@2x" src="https://user-images.githubusercontent.com/536449/202466087-034fa4d1-2c0a-4b04-8172-ba2d97874a53.png">


<img width="590" alt="CleanShot 2022-11-17 at 14 59 02@2x" src="https://user-images.githubusercontent.com/536449/202466105-df8c4420-cf42-4d40-8cd3-824678b805ad.png">

</details>

3. `make dev/up` with Minikube

<details>

![CleanShot 2022-11-16 at 16 48 16](https://user-images.githubusercontent.com/536449/202228027-1ae2220b-72a4-40ac-9f94-75695bba1db6.png)

<img width="476" alt="CleanShot 2022-11-16 at 16 51 04@2x" src="https://user-images.githubusercontent.com/536449/202228259-c9130708-e8bf-4ad6-9bc7-41b042cca487.png">

</details>