### PR TITLE
Fix debuginfo upload

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -377,7 +377,7 @@ func (p *CPU) Run(ctx context.Context) error {
 					objFiles = append(objFiles, objFile)
 				}
 				// Upload debug information of the discovered object files.
-				p.debuginfoManager.EnsureUploaded(ctx, objFiles)
+				go p.debuginfoManager.EnsureUploaded(ctx, objFiles)
 			}
 		}
 


### PR DESCRIPTION
https://github.com/parca-dev/parca-agent/commit/99d1c7927379775e328c9db0222dd6169db6a116, added an upper bound to the number of parallel uploads.

Unfortunately this also caused two issues:
1. The Agent is not sending all the profiles it generates
2. It doesn't respond to SIGINT properly (see below)

```
level=info name=parca-agent ts=2022-11-17T15:34:25.025241777Z caller=unwind_table.go:137 msg="adding tables for mapped executable" path=/proc/1/root/usr/lib64/libc.so.6 rows=24801 lowpc=28000 highpc=19a270
level=info name=parca-agent ts=2022-11-17T15:34:25.046834622Z caller=unwind_table.go:123 msg="finding tables for mapped executable" path=/proc/1/root/usr/lib64/libselinux.so.1 startingaddress=7f302414c000
level=info name=parca-agent ts=2022-11-17T15:34:25.068440816Z caller=unwind_table.go:137 msg="adding tables for mapped executable" path=/proc/1/root/usr/lib64/libselinux.so.1 rows=3124 lowpc=6020 highpc=1fa00
^Clevel=warn name=parca-agent ts=2022-11-17T15:34:49.589945727Z caller=discovery_manager.go:195 msg="unable to start provider" provider=systemd/0 error="context canceled"
^C^C^C^C^C^C^Z
[2]+  Stopped
```

~~Which made me think there's some sort of deadlock somewhere. I am not totally sure whether this is the correct fix, but it definitely prevents the issues mentioned above.~~

It seems that the errogroup `Wait()` is taking too long to return, causing a profiling loop to be skipped. This code works because executing the whole things in a goroutine makes the wait not block the call-site.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>