### PR TITLE
bpf: Reduce BPF map memory usage

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -29,9 +29,9 @@
 #define MAX_STACK_TRACES 1024
 // Number of items in the stack counts aggregation map.
 #define MAX_STACK_COUNTS_ENTRIES 10240
-// Size of the `<PID, unwind_table>` mapping. Determines how many
+// Size of the `<(pid, shard_id), unwind_table>` mapping. Determines how many
 // processes we can unwind.
-#define MAX_PID_MAP_SIZE 256
+#define MAX_PID_MAP_SIZE 100
 // Binary search iterations for dwarf based stack walking.
 // 2^20 can bisect ~1_048_576 entries.
 #define MAX_BINARY_SEARCH_DEPTH 20
@@ -104,6 +104,11 @@ typedef struct stack_count_key {
   int user_stack_id_dwarf;
 } stack_count_key_t;
 
+typedef struct unwind_tables_key {
+  int pid;
+  int shard;
+} unwind_tables_key_t;
+
 typedef struct unwind_state {
   u64 ip;
   u64 sp;
@@ -165,9 +170,8 @@ u32 UNWIND_SAMPLES_COUNT = 7;
 BPF_HASH(stack_counts, stack_count_key_t, u64, MAX_STACK_COUNTS_ENTRIES);
 BPF_STACK_TRACE(stack_traces, MAX_STACK_TRACES);
 BPF_HASH(dwarf_stack_traces, int, stack_trace_t, MAX_STACK_TRACES);
-BPF_HASH(unwind_table_1, pid_t, stack_unwind_table_t, MAX_PID_MAP_SIZE);
-BPF_HASH(unwind_table_2, pid_t, stack_unwind_table_t, MAX_PID_MAP_SIZE);
-BPF_HASH(unwind_table_3, pid_t, stack_unwind_table_t, MAX_PID_MAP_SIZE);
+BPF_HASH(unwind_tables, unwind_tables_key_t, stack_unwind_table_t,
+         MAX_PID_MAP_SIZE);
 
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -340,7 +344,9 @@ static __always_inline void show_row(stack_unwind_table_t *unwind_table,
 // Finds whether a process should be unwound using the unwind
 // tables.
 static __always_inline bool has_unwind_information(pid_t pid) {
-  stack_unwind_table_t *shard1 = bpf_map_lookup_elem(&unwind_table_1, &pid);
+  unwind_tables_key_t key = {.pid = pid, .shard = 0};
+
+  stack_unwind_table_t *shard1 = bpf_map_lookup_elem(&unwind_tables, &key);
   if (shard1) {
     return true;
   }
@@ -353,7 +359,9 @@ static __always_inline bool has_unwind_information(pid_t pid) {
 // `has_unwind_information()`.
 static __always_inline stack_unwind_table_t *find_unwind_table(pid_t pid,
                                                                u64 pc) {
-  stack_unwind_table_t *shard1 = bpf_map_lookup_elem(&unwind_table_1, &pid);
+  unwind_tables_key_t key = {.pid = pid, .shard = 0};
+
+  stack_unwind_table_t *shard1 = bpf_map_lookup_elem(&unwind_tables, &key);
   if (shard1) {
     if (shard1->low_pc <= pc && pc <= shard1->high_pc) {
       bpf_printk("\t Shard 1");
@@ -361,7 +369,8 @@ static __always_inline stack_unwind_table_t *find_unwind_table(pid_t pid,
     }
   }
 
-  stack_unwind_table_t *shard2 = bpf_map_lookup_elem(&unwind_table_2, &pid);
+  key.shard = 1;
+  stack_unwind_table_t *shard2 = bpf_map_lookup_elem(&unwind_tables, &key);
   if (shard2) {
     if (shard2->low_pc <= pc && pc <= shard2->high_pc) {
       bpf_printk("\t Shard 2");
@@ -369,7 +378,8 @@ static __always_inline stack_unwind_table_t *find_unwind_table(pid_t pid,
     }
   }
 
-  stack_unwind_table_t *shard3 = bpf_map_lookup_elem(&unwind_table_3, &pid);
+  key.shard = 2;
+  stack_unwind_table_t *shard3 = bpf_map_lookup_elem(&unwind_tables, &key);
   if (shard3) {
     if (shard3->low_pc <= pc && pc <= shard3->high_pc) {
       bpf_printk("\t Shard 3");

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -272,17 +272,9 @@ func (p *CPU) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get stack traces map: %w", err)
 	}
-	unwindTable1, err := m.GetMap(unwindTable1MapName)
+	unwindTables, err := m.GetMap(unwindTablesMapName)
 	if err != nil {
-		return fmt.Errorf("get unwind table 1 map: %w", err)
-	}
-	unwindTable2, err := m.GetMap(unwindTable2MapName)
-	if err != nil {
-		return fmt.Errorf("get unwind table 2 map: %w", err)
-	}
-	unwindTable3, err := m.GetMap(unwindTable3MapName)
-	if err != nil {
-		return fmt.Errorf("get unwind table 3 map: %w", err)
+		return fmt.Errorf("get unwind tables map: %w", err)
 	}
 
 	dwarfStackTraces, err := m.GetMap(dwarfStackTracesMapName)
@@ -295,9 +287,7 @@ func (p *CPU) Run(ctx context.Context) error {
 		stackCounts:      stackCounts,
 		stackTraces:      stackTraces,
 		dwarfStackTraces: dwarfStackTraces,
-		unwindTable1:     unwindTable1,
-		unwindTable2:     unwindTable2,
-		unwindTable3:     unwindTable3,
+		unwindTables:     unwindTables,
 	}
 
 	ticker := time.NewTicker(p.profilingDuration)


### PR DESCRIPTION
Reduce BPF map memory usage by using one BPF map for the multiple shards.

When sharding was introduced, multiple BPF maps were added for each of the shards. This is very wasteful as the kernel must preallocate **and** lock the memory, so it can never be paged out.

The other issue is that machines with low memory count would not have enough memory to create all the maps.

Before this commit we were using 3 shards * 256 (MAX_PID_MAP_SIZE ) * 64B * 2 (size of each row) * 250k MAX_UNWIND_TABLE_SIZE + other metadata that's not too big ~= 24.6GB. This is obviously a ridiculous amount of memory.

This commit changes the sharded table scheme to just use one BPF map where they key is (pid, shard_id) with the same size, so it will roughly lock 8GB. This number is still rather large. I've reduced `MAX_PID_MAP_SIZE` to 100, which brings the locked memory now to 3.2GB.

The good news is that by using a single BPF map we can easily fine-tune the shard size to a more reasonable value in the future.

Memory usage should be reduced in the userspace code, too, as before we were naively adding all the shards to their buffer and then writting them. This commits reuses the created buffer and never holds the whole, BPF-friendly unwind table in memory.

## Testplan
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/959128/202516460-68dd5a79-08c2-4b3f-bdee-01369e75e5b0.png">


No errors:
```
[javierhonduco@fedora parca-agent]$ sudo bpftool prog tracelog      | grep error
^C
[javierhonduco@fedora parca-agent]$
```

We hit the 2nd shard
```
[javierhonduco@fedora parca-agent]$ sudo bpftool prog tracelog      | grep -i shard | grep -v 'Shard 1'
      postmaster-736637  [004] d.h2.  5730.961535: bpf_trace_printk:     Shard 2
      postmaster-736637  [004] d.h2.  5730.961540: bpf_trace_printk:     Shard 2
      postmaster-736637  [010] d.h2.  5731.401629: bpf_trace_printk:     Shard 2
      postmaster-736637  [002] d.h2.  5732.581626: bpf_trace_printk:     Shard 2
      postmaster-736637  [002] d.h2.  5732.581631: bpf_trace_printk:     Shard 2
      postmaster-736637  [003] d.h2.  5735.131818: bpf_trace_printk:     Shard 2
      postmaster-736637  [003] d.h2.  5735.131823: bpf_trace_printk:     Shard 2
      postmaster-736637  [001] d.h2.  5736.231871: bpf_trace_printk:     Shard 2
      postmaster-736637  [001] d.h2.  5736.231876: bpf_trace_printk:     Shard 2
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>