### PR TITLE
ci: deconflict docker/lxd iptables rule for snapcraft builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,14 +236,18 @@ jobs:
           name: parca-agent-dist-release
           path: dist
 
-      - name: Install snapcraft
-        run: |
-          sudo snap install snapcraft --classic --channel=7.x/stable
-
       - name: Setup LXD (for Snapcraft)
         uses: whywaita/setup-lxd@16e1bb2e132ea11dfa2a8b8be7750cb9ab1ccbcd # tag=v1.0.0
         with:
           lxd_version: latest/stable
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic --channel=7.x/stable
+
+          # Unbork LXD networking due to conflict with Docker iptables rules
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
 
       - name: Build snaps
         run: |

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -162,6 +162,10 @@ jobs:
         run: |
           sudo snap install snapcraft --channel 7.x/stable --classic
 
+          # Unbork LXD networking due to conflict with Docker iptables rules
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+
       - name: Build snaps
         run: |
           # Copy the metadata.json is so snapcraft can parse it for version info


### PR DESCRIPTION
Fixes #1048 

Github has slowly been changing the meaning of `ubuntu-latest` in their actions runners. Until recently, this was allocating Ubuntu 20.04 VMs for the builds, but has recently changed to 22.04.

In 22.04, there is a conflict between the version of Docker that is installed in the runners, and LXD. The result is that LXD containers cannot reach the internet when both Docker and LXD are installed. This is a small fix to the iptables rules on the actions runner that ensures the build can succeed.

Example run of this succeeding in a test branch in my fork: https://github.com/jnsgruk/parca-agent/actions/runs/3513824216