### PR TITLE
Conditionally set unwind tables map size

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -29,9 +29,6 @@
 #define MAX_STACK_TRACES 1024
 // Number of items in the stack counts aggregation map.
 #define MAX_STACK_COUNTS_ENTRIES 10240
-// Size of the `<(pid, shard_id), unwind_table>` mapping. Determines how many
-// processes we can unwind.
-#define MAX_PID_MAP_SIZE 100
 // Binary search iterations for dwarf based stack walking.
 // 2^20 can bisect ~1_048_576 entries.
 #define MAX_BINARY_SEARCH_DEPTH 20
@@ -178,7 +175,7 @@ BPF_HASH(stack_counts, stack_count_key_t, u64, MAX_STACK_COUNTS_ENTRIES);
 BPF_STACK_TRACE(stack_traces, MAX_STACK_TRACES);
 BPF_HASH(dwarf_stack_traces, int, stack_trace_t, MAX_STACK_TRACES);
 BPF_HASH(unwind_tables, unwind_tables_key_t, stack_unwind_table_t,
-         MAX_PID_MAP_SIZE);
+         2); // Table size updated in userspace.
 
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -38,6 +38,7 @@ const (
 	programsMapName         = "programs"
 
 	// With the current row structure, the max items we can store is 262k per map.
+	unwindTableMaxEntries = 100
 	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in BPF program.
 	unwindTableShardCount = 3
 	maxUnwindSize         = maxUnwindTableSize * unwindTableShardCount


### PR DESCRIPTION
Right now, we set the unwind tables map size to 100 elements. This means that we havce to allocate and lock roughly 100 elements * 250k entries * 16 bytes per entry ~= 400 MB, just for this map.

We are currently working on some optimisations that will result in lower memory required for the unwind tables, but this will take some weeks to land, so in the meantime, this commit reduces the default unwind tables map size to 2, which would be around 8MB, and only bump it to a 100 elements if dwarf based unwinding is enabled.

We still want to allocate and lock some memory even if we know that dwarf unwinding is disabled, as in the future this would be transparently enabled and it's highly likely that at least few processes (or mappings, soon) will use the dwarf based unwind approach. This way we will at least ensure that we can already allocate enough for 500k unwind rows.

**Test Plan**

by default:
```
[javierhonduco@fedora parca-agent]$ sudo bpftool map | grep unwind_tables -A2
70: hash  name unwind_tables  flags 0x0
        key 8B  value 4000032B  max_entries 2  memlock 8003584B
        btf_id 254
```

with `--experimental-enable-dwarf-unwinding`
```
[javierhonduco@fedora parca-agent]$ sudo bpftool map | grep unwind_tables -A2
47: hash  name unwind_tables  flags 0x0
        key 8B  value 4000032B  max_entries 100  memlock 400007168B
        btf_id 230
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>