### PR TITLE
Bump unwind table shards from 3 to 6

### DIFF
--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -39,8 +39,8 @@ const (
 
 	// With the current row structure, the max items we can store is 262k per map.
 	unwindTableMaxEntries = 100
-	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in BPF program.
-	unwindTableShardCount = 3
+	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in the BPF program.
+	unwindTableShardCount = 6          // Always needs to be sync with MAX_SHARDS in the BPF program.
 	maxUnwindSize         = maxUnwindTableSize * unwindTableShardCount
 )
 


### PR DESCRIPTION
Going from 0.75M to 1.5M unwind table rows in total. This will unblock some large binaries.

**Test plan**

Profiling systemd worked
<img width="1696" alt="image" src="https://user-images.githubusercontent.com/959128/204282750-7b134d16-43bd-4abd-a2eb-339dc9c3f424.png">
