### PR TITLE
Lower the required memlock rlimit if dwarf unwinding is not enabled

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -174,9 +174,10 @@ u32 UNWIND_SAMPLES_COUNT = 7;
 BPF_HASH(debug_pids, int, u8, 32);
 BPF_HASH(stack_counts, stack_count_key_t, u64, MAX_STACK_COUNTS_ENTRIES);
 BPF_STACK_TRACE(stack_traces, MAX_STACK_TRACES);
-BPF_HASH(dwarf_stack_traces, int, stack_trace_t, MAX_STACK_TRACES);
+BPF_HASH(dwarf_stack_traces, int, stack_trace_t,
+         2); // Table size will be updated in userspace.
 BPF_HASH(unwind_tables, unwind_tables_key_t, stack_unwind_table_t,
-         2); // Table size updated in userspace.
+         2); // Table size will be updated in userspace.
 
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);

--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -174,8 +174,7 @@ u32 UNWIND_SAMPLES_COUNT = 7;
 BPF_HASH(debug_pids, int, u8, 32);
 BPF_HASH(stack_counts, stack_count_key_t, u64, MAX_STACK_COUNTS_ENTRIES);
 BPF_STACK_TRACE(stack_traces, MAX_STACK_TRACES);
-BPF_HASH(dwarf_stack_traces, int, stack_trace_t,
-         2); // Table size will be updated in userspace.
+BPF_HASH(dwarf_stack_traces, int, stack_trace_t, MAX_STACK_TRACES);
 BPF_HASH(unwind_tables, unwind_tables_key_t, stack_unwind_table_t,
          2); // Table size will be updated in userspace.
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -74,7 +74,7 @@ var (
 
 const (
 	// Use `sudo bpftool map` to determine the size of the maps.
-	defaultMemlockRLimit                   = 10 * 1024 * 1024  // ~10MB
+	defaultMemlockRLimit                   = 16 * 1024 * 1024  // ~16MB
 	defaultMemlockRLimitWithDWARFUnwinding = 512 * 1024 * 1024 // ~512MB
 )
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -73,7 +73,8 @@ var (
 )
 
 const (
-	defaultMemlockRLimit = 4096 << 20 // ~4GB
+	defaultMemlockRLimit                   = 256 * 1024 * 1024 // ~256MB
+	defaultMemlockRLimitWithDWARFUnwinding = 4096 << 20        // ~4GB
 )
 
 type flags struct {
@@ -152,6 +153,11 @@ func main() {
 
 	intro := figure.NewColorFigure("Parca Agent ", "roman", "yellow", true)
 	intro.Print()
+
+	if flags.ExperimentalEnableDWARFUnwinding && flags.MemlockRlimit != 0 && flags.MemlockRlimit < defaultMemlockRLimitWithDWARFUnwinding {
+		level.Warn(logger).Log("msg", "memlock rlimit is too low for DWARF unwinding. Setting it to the minimum required value", "min", defaultMemlockRLimitWithDWARFUnwinding)
+		flags.MemlockRlimit = defaultMemlockRLimitWithDWARFUnwinding
+	}
 
 	if err := run(logger, reg, flags); err != nil {
 		level.Error(logger).Log("err", err)

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -74,7 +74,7 @@ var (
 
 const (
 	// Use `sudo bpftool map` to determine the size of the maps.
-	defaultMemlockRLimit                   = 256 * 1024 * 1024 // ~256MB
+	defaultMemlockRLimit                   = 10 * 1024 * 1024  // ~10MB
 	defaultMemlockRLimitWithDWARFUnwinding = 512 * 1024 * 1024 // ~512MB
 )
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -73,8 +73,9 @@ var (
 )
 
 const (
+	// Use `sudo bpftool map` to determine the size of the maps.
 	defaultMemlockRLimit                   = 256 * 1024 * 1024 // ~256MB
-	defaultMemlockRLimitWithDWARFUnwinding = 4096 << 20        // ~4GB
+	defaultMemlockRLimitWithDWARFUnwinding = 512 * 1024 * 1024 // ~512MB
 )
 
 type flags struct {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -304,8 +304,8 @@ func (p *CPU) Run(ctx context.Context) error {
 		return fmt.Errorf("failure updating: %w", err)
 	}
 
-	if err := p.bpfMaps.load(); err != nil {
-		return fmt.Errorf("failed to load maps: %w", err)
+	if err := p.bpfMaps.create(); err != nil {
+		return fmt.Errorf("failed to create maps: %w", err)
 	}
 
 	if debugEnabled {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>


Outputs of `bpftool map`:

<p> 
DWARF Unwinding Enabled

<details>

```text
100: percpu_array  name heap  flags 0x0
	key 4B  value 1056B  max_entries 1  memlock 36864B
	btf_id 323
	pids parca-agent(1884277)
101: prog_array  name programs  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
	owner_prog_type perf_event  owner jited
	btf_id 323
	pids parca-agent(1884277)
102: hash  name debug_pids  flags 0x0
	key 4B  value 1B  max_entries 32  memlock 4096B
	btf_id 323
	pids parca-agent(1884277)
103: hash  name stack_counts  flags 0x0
	key 20B  value 8B  max_entries 10240  memlock 327680B
	btf_id 323
	pids parca-agent(1884277)
104: stack_trace  name stack_traces  flags 0x0
	key 4B  value 1016B  max_entries 1024  memlock 1048576B
	pids parca-agent(1884277)
105: hash  name dwarf_stack_tra  flags 0x0
	key 4B  value 1024B  max_entries 1024  memlock 1056768B
	btf_id 323
	pids parca-agent(1884277)
106: hash  name unwind_tables  flags 0x0
	key 8B  value 4000032B  max_entries 100  memlock 400007168B
	btf_id 323
	pids parca-agent(1884277)
107: percpu_array  name percpu_stats  flags 0x0
	key 4B  value 4B  max_entries 10  memlock 4096B
	btf_id 323
	pids parca-agent(1884277)
109: array  name parca.rodata  flags 0x480
	key 4B  value 1491B  max_entries 1  memlock 4096B
	btf_id 323  frozen
	pids parca-agent(1884277)
110: array  name parca.data  flags 0x400
	key 4B  value 28B  max_entries 1  memlock 4096B
	btf_id 323
	pids parca-agent(1884277)
111: array  name .rodata.str1.1  flags 0x480
	key 4B  value 8B  max_entries 1  memlock 4096B
	frozen
	pids parca-agent(1884277)
```

</details>

</p>

<p> DWARF Unwinding Disabled

<details>

```text

[sudo] password for kakkoyun:
2: array  name iterator.rodata  flags 0x480
	key 4B  value 98B  max_entries 1  memlock 4096B
	btf_id 38  frozen
304: percpu_array  name heap  flags 0x0
	key 4B  value 1056B  max_entries 1  memlock 36864B
	btf_id 485
	pids parca-agent(1998974)
305: prog_array  name programs  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
	owner_prog_type perf_event  owner jited
	btf_id 485
	pids parca-agent(1998974)
306: hash  name debug_pids  flags 0x0
	key 4B  value 1B  max_entries 32  memlock 4096B
	btf_id 485
	pids parca-agent(1998974)
307: hash  name stack_counts  flags 0x0
	key 20B  value 8B  max_entries 10240  memlock 327680B
	btf_id 485
	pids parca-agent(1998974)
308: stack_trace  name stack_traces  flags 0x0
	key 4B  value 1016B  max_entries 1024  memlock 1048576B
	pids parca-agent(1998974)
309: hash  name dwarf_stack_tra  flags 0x0
	key 4B  value 1024B  max_entries 2  memlock 4096B
	btf_id 485
	pids parca-agent(1998974)
310: hash  name unwind_tables  flags 0x0
	key 8B  value 4000032B  max_entries 2  memlock 8003584B
	btf_id 485
	pids parca-agent(1998974)
311: percpu_array  name percpu_stats  flags 0x0
	key 4B  value 4B  max_entries 10  memlock 4096B
	btf_id 485
	pids parca-agent(1998974)
313: array  name parca.rodata  flags 0x480
	key 4B  value 1491B  max_entries 1  memlock 4096B
	btf_id 485  frozen
	pids parca-agent(1998974)
314: array  name parca.data  flags 0x400
	key 4B  value 28B  max_entries 1  memlock 4096B
	btf_id 485
	pids parca-agent(1998974)
315: array  name .rodata.str1.1  flags 0x480
	key 4B  value 8B  max_entries 1  memlock 4096B
	frozen
	pids parca-agent(1998974)
318: array  flags 0x0
	key 4B  value 32B  max_entries 1  memlock 4096B
319: array  name pid_iter.rodata  flags 0x480
	key 4B  value 4B  max_entries 1  memlock 4096B
	btf_id 494  frozen
	pids bpftool(1999086)
320: array  flags 0x0
	key 4B  value 32B  max_entries 1  memlock 4096B
```

</details>

</p>