### PR TITLE
ci: ensure e2e runs when jsonnet files are updated

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,9 +41,10 @@ jobs:
               "Dockerfile*",
               "Makefile",
               "bpf/Makefile",
+              "deploy/**",
+              "e2e/**",
               "go.mod",
-              "go.sum",
-              "e2e/**"
+              "go.sum"
             ]
           skip_after_successful_duplicate: false
 

--- a/deploy/jsonnetfile.lock.json
+++ b/deploy/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "deploy/lib/parca"
         }
       },
-      "version": "abfdbf5f586990d7009953d85b1796d84ce2e126",
-      "sum": "aK56fC0SsHbSg0WZfRiDTntO72QJqftVgORDae2ilyg="
+      "version": "6ebca676a7d3ba4e3d6cabbc5b96ce90fd2c039f",
+      "sum": "dV/01U0S35vH3lC6ZYgzt/PHoUHZz9S9ReQM7Ucw480="
     },
     {
       "source": {


### PR DESCRIPTION
```
 parca: error: unknown flag --http-address, did you mean "--otlp-address"?
```

This fixes the E2E tests and downgrade the Parca Jsonnet lib until next release with new flags.