### PR TITLE
pkg/objectfile:remove cache size and expired duratioin limit

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -349,7 +349,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				ksym.NewKsymCache(logger, reg),
 			),
 			process.NewMappingFileCache(logger),
-			objectfile.NewCache(20, flags.ProfilingDuration),
+			objectfile.NewCache(),
 			profileWriter,
 			debuginfo.New(
 				log.With(logger, "component", "debuginfo"),

--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -111,15 +111,16 @@ func (c *mappingFileCache) mappingForPID(pid int) ([]*profile.Mapping, error) {
 				}
 				continue
 			}
-			defer fElf.Close()
 
 			m.BuildID, err = buildid.BuildID(&buildid.ElfFile{Path: abs, File: fElf})
 			if err != nil {
 				if !errors.Is(err, os.ErrNotExist) {
 					level.Debug(c.logger).Log("msg", "failed to read object build ID", "object", abs, "err", err)
 				}
+				fElf.Close()
 				continue
 			}
+			fElf.Close()
 		}
 	}
 


### PR DESCRIPTION
Because the object file cache use the mapping id as key, 
so it is no need to add cache limit and expired duration.