### PR TITLE
.eh_frame: Don't allocate the full unwind table by default

### DIFF
--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-delve/delve/pkg/dwarf/regnum"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/procfs"
 
 	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
@@ -190,39 +191,44 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string) error {
 
 	for _, fde := range fdes {
 		fmt.Fprintf(writer, "=> Function start: %x, Function end: %x\n", fde.Begin(), fde.End())
-		tableRows := buildTableRows(fde)
-		fmt.Fprintf(writer, "\t(found %d rows)\n", len(tableRows))
-		for _, tableRow := range tableRows {
+
+		frameContext := frame.ExecuteDwarfProgram(fde, nil)
+		for insCtx := frameContext.Next(); frameContext.HasNext(); insCtx = frameContext.Next() {
+			unwindRow := unwindTableRow(insCtx)
+
+			if unwindRow == nil {
+				break
+			}
 			//nolint:exhaustive
-			switch tableRow.CFA.Rule {
+			switch unwindRow.CFA.Rule {
 			case frame.RuleCFA:
-				CFAReg := x64RegisterToString(tableRow.CFA.Reg)
-				fmt.Fprintf(writer, "\tLoc: %x CFA: $%s=%-4d", tableRow.Loc, CFAReg, tableRow.CFA.Offset)
+				CFAReg := x64RegisterToString(unwindRow.CFA.Reg)
+				fmt.Fprintf(writer, "\tLoc: %x CFA: $%s=%-4d", unwindRow.Loc, CFAReg, unwindRow.CFA.Offset)
 			case frame.RuleExpression:
-				expressionID := ExpressionIdentifier(tableRow.CFA.Expression)
+				expressionID := ExpressionIdentifier(unwindRow.CFA.Expression)
 				if expressionID == ExpressionUnknown {
-					fmt.Fprintf(writer, "\tLoc: %x CFA: exp     ", tableRow.Loc)
+					fmt.Fprintf(writer, "\tLoc: %x CFA: exp     ", unwindRow.Loc)
 				} else {
-					fmt.Fprintf(writer, "\tLoc: %x CFA: exp (plt %d)", tableRow.Loc, expressionID)
+					fmt.Fprintf(writer, "\tLoc: %x CFA: exp (plt %d)", unwindRow.Loc, expressionID)
 				}
 			default:
-				return fmt.Errorf("CFA rule is not valid. This should never happen")
+				return multierror.Append(fmt.Errorf("CFA rule is not valid. This should never happen"))
 			}
 
 			// RuleRegister
 			//nolint:exhaustive
-			switch tableRow.RBP.Rule {
+			switch unwindRow.RBP.Rule {
 			case frame.RuleUndefined:
 				fmt.Fprintf(writer, "\tRBP: u")
 			case frame.RuleRegister:
-				RBPReg := x64RegisterToString(tableRow.RBP.Reg)
+				RBPReg := x64RegisterToString(unwindRow.RBP.Reg)
 				fmt.Fprintf(writer, "\tRBP: $%s", RBPReg)
 			case frame.RuleOffset:
-				fmt.Fprintf(writer, "\tRBP: c%-4d", tableRow.RBP.Offset)
+				fmt.Fprintf(writer, "\tRBP: c%-4d", unwindRow.RBP.Offset)
 			case frame.RuleExpression:
 				fmt.Fprintf(writer, "\tRBP: exp")
 			default:
-				panic(fmt.Sprintf("Got rule %d for RBP, which wasn't expected", tableRow.RBP.Rule))
+				panic(fmt.Sprintf("Got rule %d for RBP, which wasn't expected", unwindRow.RBP.Rule))
 			}
 
 			fmt.Fprintf(writer, "\n")
@@ -261,9 +267,12 @@ func (ptb *UnwindTableBuilder) readFDEs(path string) (frame.FrameDescriptionEntr
 }
 
 func buildUnwindTable(fdes frame.FrameDescriptionEntries) UnwindTable {
-	table := make(UnwindTable, 0, len(fdes))
+	table := make(UnwindTable, 0)
 	for _, fde := range fdes {
-		table = append(table, buildTableRows(fde)...)
+		frameContext := frame.ExecuteDwarfProgram(fde, nil)
+		for insCtx := frameContext.Next(); frameContext.HasNext(); insCtx = frameContext.Next() {
+			table = append(table, *unwindTableRow(insCtx))
+		}
 	}
 	return table
 }
@@ -284,37 +293,32 @@ type UnwindTableRow struct {
 	RA frame.DWRule
 }
 
-func buildTableRows(fde *frame.FrameDescriptionEntry) []UnwindTableRow {
-	rows := make([]UnwindTableRow, 0)
-
-	frameContext := frame.ExecuteDwarfProgram(fde)
-
-	instructionContexts := frameContext.InstructionContexts()
-
-	for _, instructionContext := range instructionContexts {
-		row := UnwindTableRow{
-			Loc: instructionContext.Loc(),
-			CFA: instructionContext.CFA,
-		}
-
-		// Deal with saved return address.
-		rule, found := instructionContext.Regs[instructionContext.RetAddrReg]
-		if found {
-			row.RA = rule
-		} else {
-			// The saved return address must be specified.
-			panic("no saved return address found")
-		}
-
-		// Deal with $rbp.
-		rule, found = instructionContext.Regs[regnum.AMD64_Rbp]
-		if found {
-			row.RBP = rule
-		}
-
-		rows = append(rows, row)
+func unwindTableRow(instructionContext *frame.InstructionContext) *UnwindTableRow {
+	if instructionContext == nil {
+		return nil
 	}
-	return rows
+
+	row := UnwindTableRow{
+		Loc: instructionContext.Loc(),
+		CFA: instructionContext.CFA,
+	}
+
+	// Deal with saved return address.
+	rule, found := instructionContext.Regs[instructionContext.RetAddrReg]
+	if found {
+		row.RA = rule
+	} else {
+		// The saved return address must be specified.
+		panic("no saved return address found")
+	}
+
+	// Deal with $rbp.
+	rule, found = instructionContext.Regs[regnum.AMD64_Rbp]
+	if found {
+		row.RBP = rule
+	}
+
+	return &row
 }
 
 func pointerSize(arch elf.Machine) int {

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -57,13 +57,14 @@ func BenchmarkParsingLibcDwarfUnwindInformation(b *testing.B) {
 		}
 
 		for _, fde := range fdes {
-			tableRows := buildTableRows(fde)
-			for _, tableRow := range tableRows {
-				if tableRow.RBP.Rule == frame.RuleUndefined || tableRow.RBP.Offset == 0 {
+			frameContext := frame.ExecuteDwarfProgram(fde, nil)
+			for insCtx := frameContext.Next(); frameContext.HasNext(); insCtx = frameContext.Next() {
+				unwindRow := unwindTableRow(insCtx)
+				if unwindRow.RBP.Rule == frame.RuleUndefined || unwindRow.RBP.Offset == 0 {
 					// u
 					rbpOffset = 0
 				} else {
-					rbpOffset = tableRow.RBP.Offset
+					rbpOffset = unwindRow.RBP.Offset
 				}
 			}
 		}


### PR DESCRIPTION
As we are going to enable DWARF-based unwinding by default soon, which
means that the DWARF unwind information parser and the table generation
will be called significantly more times.

During prototyping, some shortcuts were taken, such as generating the
unwind table ahead of time. The unwind table is an array of unwind rows,
which for "medium-sized" binaries it can reach 200k entries. For the largest
binaries we've seen, the unwind tables were up to 2M entries big.

Generating and keeping these large slices in memory is not good for
performance, as we need to re-allocate them multiple times when
regrowing the backing memory buffer, as well as copying the data over, if
necessary.

While we could reasonably estimate the final size of the buffer using the
`.text` size as a proxy, this is not necessary for the majority of
cases, and we can process one unwind entry at a time.

This is what this commits implements. It refactors the table generation
code to change from returning said unwind table in a slice, to accepting
a callback function that can then process each element in the way it
finds it suitable.

Note that there are way more optimisations that we could do to speed up
the code but we'll first profile this code in production once we carry
out the monolithic unwind table work, as its architecture will reduce
the redundant work.

__Note__: The unwind generation table is still generating the full table ahead
of time. This would have to be changed to take advantage of this new API.

## Benchmarks

```
$ go test -v github.com/parca-dev/parca-agent/pkg/stack/unwind -bench=. -count=30
```

```
[javierhonduco@fedora parca-agent]$ benchstat /tmp/old /tmp/new
name                                  old time/op    new time/op    delta
ParsingLibcDwarfUnwindInformation-12    34.5ms ±43%    10.8ms ±32%  -68.60%  (p=0.000 n=30+30)

name                                  old alloc/op   new alloc/op   delta
ParsingLibcDwarfUnwindInformation-12    32.7MB ± 0%     5.6MB ± 0%  -82.80%  (p=0.000 n=30+29)

name                                  old allocs/op  new allocs/op  delta
ParsingLibcDwarfUnwindInformation-12      150k ± 0%       83k ± 0%  -44.76%  (p=0.000 n=30+30)
```