### PR TITLE
cpu/test: Ensure that unwind table can grow

### DIFF
--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/parca-dev/parca-agent/pkg/byteorder"
 
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +35,14 @@ func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 		BPFObjBuff: bpfObj,
 		BPFObjName: "parca",
 	})
+	require.NoError(t, err)
+
+	bpfMaps, err := initializeMaps(m, byteorder.GetHostByteOrder())
+	require.NoError(t, err)
+
+	// Enable DWARF unwinding so the unwind tables are created with a
+	// more representative size.
+	bpfMaps.adjustMapSizes(true)
 	require.NoError(t, err)
 
 	err = m.BPFLoadObject()


### PR DESCRIPTION
I sometimes compile this test statically and run it in a VM to ensure that everything works. By allocating the extra space for unwind tables we'll ensure that there are no issues increasing their size.

## Test Plan
Existing tests in CI

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>