### PR TITLE
.eh_frame/parser: Add redpanda to benchmark

### DIFF
--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -42,16 +42,16 @@ func TestBuildUnwindTable(t *testing.T) {
 
 var rbpOffsetResult int64
 
-func BenchmarkParsingLibcDwarfUnwindInformation(b *testing.B) {
+func benchmarkParsingDwarfUnwindInformation(b *testing.B, executable string) {
+	b.Helper()
 	b.ReportAllocs()
 
 	logger := log.NewNopLogger()
+	var rbpOffset int64
 	utb := NewUnwindTableBuilder(logger)
 
-	var rbpOffset int64
-
 	for n := 0; n < b.N; n++ {
-		fdes, err := utb.readFDEs("../../../testdata/vendored/libc.so.6")
+		fdes, err := utb.readFDEs(executable)
 		if err != nil {
 			panic("could not read FDEs")
 		}
@@ -70,4 +70,12 @@ func BenchmarkParsingLibcDwarfUnwindInformation(b *testing.B) {
 	}
 	// Make sure that the compiler won't optimize out the benchmark.
 	rbpOffsetResult = rbpOffset
+}
+
+func BenchmarkParsingLibcUnwindInformation(b *testing.B) {
+	benchmarkParsingDwarfUnwindInformation(b, "../../../testdata/vendored/libc.so.6")
+}
+
+func BenchmarkParsingRedpandaUnwindInformation(b *testing.B) {
+	benchmarkParsingDwarfUnwindInformation(b, "../../../testdata/vendored/redpanda")
 }


### PR DESCRIPTION
## Test Plan

```
$ go test -v github.com/parca-dev/parca-agent/pkg/stack/unwind -bench=.
=== RUN   TestBuildUnwindTable
--- PASS: TestBuildUnwindTable (0.00s)
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/stack/unwind
cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
BenchmarkParsingLibcUnwindInformation
BenchmarkParsingLibcUnwindInformation-12                      57          43231125 ns/op        32710595 B/op     149598 allocs/op
BenchmarkParsingRedpandaUnwindInformation
BenchmarkParsingRedpandaUnwindInformation-12                   4         273076838 ns/op        524039788 B/op   2205965 allocs/op
PASS
ok      github.com/parca-dev/parca-agent/pkg/stack/unwind       5.774s
```