### PR TITLE
.eh_frame/parser: Only collect registers used for unwinding

### DIFF
--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -20,9 +20,9 @@ import (
 	"unsafe"
 
 	bpf "github.com/aquasecurity/libbpfgo"
-	"github.com/parca-dev/parca-agent/pkg/byteorder"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca-agent/pkg/byteorder"
 )
 
 // The intent of these tests is to ensure that the BPF library we use,

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -38,6 +38,7 @@ func TestBuildUnwindTable(t *testing.T) {
 
 	require.Equal(t, frame.DWRule{Rule: frame.RuleOffset, Offset: -8}, unwindTable[0].RA)
 	require.Equal(t, frame.DWRule{Rule: frame.RuleCFA, Reg: 0x7, Offset: 8}, unwindTable[0].CFA)
+	require.Equal(t, frame.DWRule{Rule: frame.RuleUnknown, Reg: 0x0, Offset: 0}, unwindTable[0].RBP)
 }
 
 var rbpOffsetResult int64


### PR DESCRIPTION
We used maps to track every register, but we only need rbp, rsp (to calculate the CFA) and the return address.

Note that we don't need the return address offset for x86_64 but we'll need it for arm64 and this code will have to be modified to account for this architecture.

```
$ go test -v github.com/parca-dev/parca-agent/pkg/stack/unwind -bench=.  -count=30 > /tmp/new2
```

Not relying on maps yields a non-trivial perf improvement:

```
$ benchstat /tmp/old /tmp/new
name                                 old time/op    new time/op    delta
ParsingLibcUnwindInformation-12        15.5ms ±30%    11.8ms ±25%  -23.71%  (p=0.000 n=30+30)
ParsingRedpandaUnwindInformation-12    75.9ms ±12%    64.0ms ±11%  -15.68%  (p=0.000 n=30+29)

name                                 old alloc/op   new alloc/op   delta
ParsingLibcUnwindInformation-12        5.60MB ± 0%    4.63MB ± 0%  -17.32%  (p=0.000 n=28+30)
ParsingRedpandaUnwindInformation-12    55.2MB ± 0%    53.7MB ± 0%   -2.59%  (p=0.000 n=30+29)

name                                 old allocs/op  new allocs/op  delta
ParsingLibcUnwindInformation-12         79.0k ± 0%     63.9k ± 0%  -19.07%  (p=0.000 n=30+30)
ParsingRedpandaUnwindInformation-12      916k ± 0%      783k ± 0%  -14.58%  (p=0.000 n=30+30)
```