### PR TITLE
.eh_frame: Reuse unwind context and reduce copies

### DIFF
--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -30,7 +30,7 @@ func TestBuildUnwindTable(t *testing.T) {
 	fdes, err := utb.readFDEs("../../../testdata/out/basic-cpp")
 	require.NoError(t, err)
 
-	unwindTable := buildUnwindTable(fdes)
+	unwindTable := utb.buildUnwindTable(fdes)
 	require.Equal(t, 38, len(unwindTable))
 
 	require.Equal(t, uint64(0x401020), unwindTable[0].Loc)
@@ -57,8 +57,9 @@ func benchmarkParsingDwarfUnwindInformation(b *testing.B, executable string) {
 			panic("could not read FDEs")
 		}
 
+		unwindContext := frame.NewContext()
 		for _, fde := range fdes {
-			frameContext := frame.ExecuteDwarfProgram(fde, nil)
+			frameContext := frame.ExecuteDwarfProgram(fde, unwindContext)
 			for insCtx := frameContext.Next(); frameContext.HasNext(); insCtx = frameContext.Next() {
 				unwindRow := unwindTableRow(insCtx)
 				if unwindRow.RBP.Rule == frame.RuleUndefined || unwindRow.RBP.Offset == 0 {


### PR DESCRIPTION
of the initial context.

Improvements due to:

- avoiding copies of the initial CIE instructions (bytes.Buffer -> bytes.Reader)
- fewer Context object allocations
- due to the above, GC pressure was considerably reduced, which was the main objective of this changes as Parca Agent's CPU budget for the GC is already too high

resulting in ~4x less allocated memory and improvements in the runtime:

```
$ go test -v github.com/parca-dev/parca-agent/pkg/stack/unwind -bench=. -count=30
```

```
$ benchstat /tmp/main-6ad1efd /tmp/new
name                                 old time/op    new time/op    delta
ParsingLibcUnwindInformation-12        11.5ms ±14%     3.3ms ±17%  -70.82%  (p=0.000 n=26+29)
ParsingRedpandaUnwindInformation-12    66.1ms ±22%    37.7ms ± 2%  -42.99%  (p=0.000 n=30+30)

name                                 old alloc/op   new alloc/op   delta
ParsingLibcUnwindInformation-12        4.63MB ± 0%    1.09MB ± 0%  -76.38%  (p=0.000 n=29+28)
ParsingRedpandaUnwindInformation-12    53.7MB ± 0%    14.1MB ± 0%  -73.78%  (p=0.000 n=30+29)

name                                 old allocs/op  new allocs/op  delta
ParsingLibcUnwindInformation-12         63.9k ± 0%     41.8k ± 0%  -34.58%  (p=0.000 n=30+30)
ParsingRedpandaUnwindInformation-12      783k ± 0%      527k ± 0%  -32.62%  (p=0.000 n=30+30)
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>