### PR TITLE
Add initial kernel testing infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
             [
               "**.go",
               ".github/workflows/build.yml",
+              ".github/workflows/vmtest.yml",
               ".go-version",
               "3rdparty",
               "Makefile",
@@ -115,3 +116,15 @@ jobs:
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
+
+      - name: Build initramfs
+        run: |
+          go install github.com/florianl/bluebox@v0.0.1
+          make initramfs
+
+      - name: Upload initramfs
+        uses: actions/upload-artifact@v3
+        with:
+          name: initramfs
+          path: |
+            kerneltest/initramfs.cpio

--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -1,0 +1,25 @@
+name: vmtest
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+
+jobs:
+  kernel-tests:
+    name: Kernel tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    runs-on: ubuntu-latest
+    steps:
+        - name: Check out the code
+          uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        - name: Install dependencies
+          run: sudo apt -y install qemu-system-x86 curl
+        - name: Download previously generated initramfs
+          uses: actions/download-artifact@v3
+          with:
+            name: initramfs
+            path: kerneltest/
+        - name: Run tests
+          run: ./kerneltest/vmtest.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ minikube-*
 *.snap
 snap/local/parca-agent
 snap/local/metadata.json
+
+# kernel test stuff
+kerneltest/cpu.test
+kerneltest/initramfs.cpio
+kerneltest/logs/vm_log_*.txt
+kerneltest/kernels/linux-*.bz

--- a/env.sh
+++ b/env.sh
@@ -12,3 +12,7 @@ go install "mvdan.cc/gofumpt@${GOFUMPT_VERSION}"
 # renovate: datasource=go depName=github.com/golangci/golangci-lint
 GOLANGCI_LINT_VERSION='v1.50.1'
 go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+
+# renovate: datasource=go depName=github.com/florianl/bluebox
+BLUEBOX_VERSION='v0.0.1'
+go install "github.com/florianl/bluebox@${BLUEBOX_VERSION}"

--- a/kerneltest/kernels/README.md
+++ b/kerneltest/kernels/README.md
@@ -1,0 +1,1 @@
+The kernel images will be downloaded in this directory.

--- a/kerneltest/logs/README.md
+++ b/kerneltest/logs/README.md
@@ -1,0 +1,1 @@
+The logs from the VMs will be written in this directory.

--- a/kerneltest/vmtest.sh
+++ b/kerneltest/vmtest.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+# TODO: host the kernels ourselves to not use cilium's quotas
+download_kernel() {
+    kernel_version=$1
+    echo "downloading kernel $kernel_version"
+    curl -o "kerneltest/kernels/linux-$kernel_version.bz" -s -L -O --fail "https://github.com/cilium/ci-kernels/raw/master/linux-$kernel_version.bz"
+}
+
+use_kernel() {
+    kernel_version=$1
+    if [ ! -f "kerneltest/kernels/linux-$kernel_version.bz" ]; then
+        echo "kernel $kernel_version not found"
+        download_kernel "$kernel_version"
+    fi
+}
+
+github_start() {
+    kernel_version=$1
+    [[ -z "${GITHUB_ACTIONS}" ]] || echo "::group:: running tests on kernel $kernel_version"
+}
+
+github_end() {
+    kernel_version=$1
+    [[ -z "${GITHUB_ACTIONS}" ]] || echo "::endgroup::"
+}
+
+test_info() {
+    kernel_version=$1
+    cat <<EOT >"kerneltest/logs/vm_log_$kernel_version.txt"
+============================================================
+- date: $(date)
+- git revision: $(git rev-parse HEAD)-$(git diff-index --quiet HEAD || echo dirty)
+- vm kernel: $kernel_version
+- qemu version: $(qemu-system-x86_64 --version | head -1)
+============================================================
+EOT
+}
+
+vm_run() {
+    kernel_version=$1
+    memory=$2
+    echo "running tests in qemu"
+    github_start "$kernel_version"
+    test_info "$kernel_version"
+    # kernel.panic=-1 and -no-reboot ensures we won't get stuck on kernel panic.
+    qemu-system-x86_64 -no-reboot -append 'printk.devkmsg=on kernel.panic=-1 crashkernel=256M' \
+        -nographic -append "console=ttyS0" -m "$memory" -kernel "kerneltest/kernels/linux-$kernel_version.bz" \
+        -initrd kerneltest/initramfs.cpio | tee -a "kerneltest/logs/vm_log_$kernel_version.txt"
+    github_end "$kernel_version"
+}
+
+did_test_pass() {
+    kernel_version=$1
+    grep PASS "kerneltest/logs/vm_log_$kernel_version.txt" >/dev/null
+}
+
+check_executable() {
+    executable=$1
+    if ! command -v "$executable" &>/dev/null; then
+        echo "$executable could not be found"
+        exit 1
+    fi
+}
+
+run_tests() {
+    # Initial checks.
+    check_executable "curl"
+    check_executable "qemu-system-x86_64"
+
+    # Run the tests.
+    kernel_versions=("5.4" "5.10" "5.18" "5.19")
+
+    for kernel in "${kernel_versions[@]}"; do
+        use_kernel "$kernel"
+        vm_run "$kernel" "1.5G"
+    done
+
+    failed_tests=0
+    passed_test=0
+    echo "============="
+    echo "Test results:"
+    echo "============="
+    for kernel in "${kernel_versions[@]}"; do
+        if did_test_pass "$kernel"; then
+            echo "- ✅ $kernel"
+            passed_test=$((passed_test + 1))
+        else
+            echo "- ❌ $kernel"
+            failed_tests=$((failed_tests + 1))
+        fi
+    done
+
+    echo
+    echo "Test summary: $passed_test passed, $failed_tests failed"
+
+    if [ "$failed_tests" -gt 0 ]; then
+        echo "(See logs in kerneltest/logs/)"
+        exit 1
+    fi
+
+    # BUG(<= 4.19): The verifier spotted the loop (back-edge) and it's not happy, we need to unroll it here.
+    # It works in newer kernels thanks to BPF bounded loops (note this is different from the bpf_loop helper).
+    #
+    # use_kernel "4.19"
+    # run_tests "4.19" "1.5G"
+    # did_test_pass "4.19"
+}
+
+run_tests


### PR DESCRIPTION
This PR ensures that we can load the BPF program in different kernels with 1.6G of available memory.

See https://github.com/parca-dev/parca-agent/issues/1141

### Running locally

```
$ ./env.sh # to install bluebox
```

`qemu-system-x86_64` and `curl` should be installed, too.


```
$ time make vmtest
[...]
Test summary: 4 passed, 0 failed

real	0m53.361s
user	0m55.341s
sys	0m2.298s
```


### Test Plan
**locally, happy path**


```
$ make vmtest
[...]
=============
Test results:
=============
- ✅ 5.4
- ✅ 5.10
- ✅ 5.18
- ✅ 5.19

Test summary: 4 passed, 0 failed
```

**locally, error path**

```
$ make vmtest
[...]
=============
Test results:
=============
- ✅ 5.4
- ❌ 5.10
- ✅ 5.18
- ✅ 5.19

Test summary: 3 passed, 1 failed
(See logs in kerneltest/logs/)
make: *** [Makefile:222: vmtest] Error 1
```
**GH Actions**

See the `Kernel tests` action below

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/959128/210776704-c8363a0a-315e-403d-9c63-7c1ff9dd0c6f.png">


## TODO
- [x] Return the right status code
- [x] create `/kernels` and `/logs` directories
- [x] Fix batch tests so they are only run if the kernel supports them (we need this anyways once we use batch map APIs)
- [x] Set memlock to non unlimited
- [ ] Create our own repo where to host the kernels. Alternatively we could cache them on GH actions
- [ ] Decide how and when to run in CI (e.g. on PR or periodically? individual jobs or as-is?). We can decide this now or later on


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>