### PR TITLE
pkg/debuginfo: ensureUploaded benchmark

### DIFF
--- a/pkg/debuginfo/client.go
+++ b/pkg/debuginfo/client.go
@@ -21,17 +21,26 @@ import (
 	"google.golang.org/grpc"
 )
 
-type NoopClient struct{}
+type NoopClient struct {
+	ShouldInitiateUploadF func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error)
+	InitiateUploadF       func(in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error)
+}
 
 func (c *NoopClient) Upload(ctx context.Context, opts ...grpc.CallOption) (debuginfopb.DebuginfoService_UploadClient, error) {
 	return nil, nil
 }
 
 func (c *NoopClient) ShouldInitiateUpload(ctx context.Context, in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
+	if c.ShouldInitiateUploadF != nil {
+		return c.ShouldInitiateUploadF(in, opts...)
+	}
 	return &debuginfopb.ShouldInitiateUploadResponse{}, nil
 }
 
 func (c *NoopClient) InitiateUpload(ctx context.Context, in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error) {
+	if c.InitiateUploadF != nil {
+		return c.InitiateUploadF(in, opts...)
+	}
 	return &debuginfopb.InitiateUploadResponse{}, nil
 }
 

--- a/pkg/debuginfo/client.go
+++ b/pkg/debuginfo/client.go
@@ -21,26 +21,17 @@ import (
 	"google.golang.org/grpc"
 )
 
-type NoopClient struct {
-	ShouldInitiateUploadF func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error)
-	InitiateUploadF       func(in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error)
-}
+type NoopClient struct{}
 
 func (c *NoopClient) Upload(ctx context.Context, opts ...grpc.CallOption) (debuginfopb.DebuginfoService_UploadClient, error) {
 	return nil, nil
 }
 
 func (c *NoopClient) ShouldInitiateUpload(ctx context.Context, in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
-	if c.ShouldInitiateUploadF != nil {
-		return c.ShouldInitiateUploadF(in, opts...)
-	}
 	return &debuginfopb.ShouldInitiateUploadResponse{}, nil
 }
 
 func (c *NoopClient) InitiateUpload(ctx context.Context, in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error) {
-	if c.InitiateUploadF != nil {
-		return c.InitiateUploadF(in, opts...)
-	}
 	return &debuginfopb.InitiateUploadResponse{}, nil
 }
 

--- a/pkg/debuginfo/client_test.go
+++ b/pkg/debuginfo/client_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package debuginfo
+
+import (
+	"context"
+
+	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
+	"google.golang.org/grpc"
+)
+
+type testClient struct {
+	UploadF               func(opts ...grpc.CallOption) (debuginfopb.DebuginfoService_UploadClient, error)
+	ShouldInitiateUploadF func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error)
+	InitiateUploadF       func(in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error)
+	MarkUploadFinishedF   func(in *debuginfopb.MarkUploadFinishedRequest, opts ...grpc.CallOption) (*debuginfopb.MarkUploadFinishedResponse, error)
+}
+
+func (c *testClient) Upload(ctx context.Context, opts ...grpc.CallOption) (debuginfopb.DebuginfoService_UploadClient, error) {
+	if c.UploadF != nil {
+		return c.UploadF(opts...)
+	}
+	return nil, nil
+}
+
+func (c *testClient) ShouldInitiateUpload(ctx context.Context, in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
+	if c.ShouldInitiateUploadF != nil {
+		return c.ShouldInitiateUploadF(in, opts...)
+	}
+	return &debuginfopb.ShouldInitiateUploadResponse{}, nil
+}
+
+func (c *testClient) InitiateUpload(ctx context.Context, in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error) {
+	if c.InitiateUploadF != nil {
+		return c.InitiateUploadF(in, opts...)
+	}
+	return &debuginfopb.InitiateUploadResponse{}, nil
+}
+
+func (c *testClient) MarkUploadFinished(ctx context.Context, in *debuginfopb.MarkUploadFinishedRequest, opts ...grpc.CallOption) (*debuginfopb.MarkUploadFinishedResponse, error) {
+	if c.MarkUploadFinishedF != nil {
+		return c.MarkUploadFinishedF(in, opts...)
+	}
+	return &debuginfopb.MarkUploadFinishedResponse{}, nil
+}

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package debuginfo
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/google/pprof/profile"
+	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/parca-dev/parca-agent/pkg/objectfile"
+)
+
+func BenchmarkEnsureUploadedAlreadyExists(b *testing.B) {
+	name := filepath.Join("../../internal/pprof/binutils/testdata", "exe_linux_64")
+	o, err := objectfile.Open(name, &profile.Mapping{
+		Start:  0x5400000,
+		Limit:  0x5401000,
+		Offset: 0,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	c := &NoopClient{
+		ShouldInitiateUploadF: func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
+			resp := debuginfopb.ShouldInitiateUploadResponse{
+				ShouldInitiateUpload: true,
+			}
+			return &resp, nil
+		},
+		InitiateUploadF: func(in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "already exists")
+		},
+	}
+	debuginfoProcessor := New(
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		c,
+		2*time.Minute,
+		5*time.Minute,
+		[]string{"/usr/lib/debug"},
+		true,
+		"/tmp",
+	)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err = debuginfoProcessor.ensureUploaded(
+			ctx,
+			&objectfile.MappedObjectFile{ObjectFile: o},
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -42,7 +42,7 @@ func BenchmarkEnsureUploadedAlreadyExists(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	c := &NoopClient{
+	c := &testClient{
 		ShouldInitiateUploadF: func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
 			resp := debuginfopb.ShouldInitiateUploadResponse{
 				ShouldInitiateUpload: true,


### PR DESCRIPTION
@brancz [mentioned](https://github.com/parca-dev/parca-agent/pull/1138#issuecomment-1354576440) that `EnsureUploaded` has a room for perf improvements.

> Judging by what I'm seeing on demo I think we have much bigger fish to fry right now (allocations in EnsureUploaded and profiler loop stacks look like they should give us a major wins).

I found a TODO comment that mentions caching the hash, so I was thinking to prepare a benchmark for that code path to begin with.

```
// TODO: We should be able to cache the hash further to avoid
// re-hashing the same binary and getting to the same result
// again.
```

```
$ go test -benchmem -run=. -bench ^BenchmarkEnsureUploadedAlreadyExists$ ./pkg/debuginfo/
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/debuginfo
cpu: Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz
BenchmarkEnsureUploadedAlreadyExists-2 1000000 1131 ns/op 138 B/op 7 allocs/op
```

I guess the hashes can be cached (`buildID` is a key) in a `sync.Map` since the files are uploaded concurrently.