### PR TITLE
WIP: wait for build to complete instead

### DIFF
--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -1,9 +1,13 @@
 name: vmtest
 on:
-  workflow_run:
-    workflows: [Build]
-    types:
-      - completed
+  push:
+    branches:
+    - main
+    - release-*
+  pull_request:
+    branches:
+    - main
+    - release-*
 
 jobs:
   kernel-tests:
@@ -21,6 +25,12 @@ jobs:
             echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
         - name: Install dependencies
           run: sudo apt -y install qemu-system-x86 curl
+        - name: Wait for build to succeed
+          uses: lewagon/wait-on-check-action@v1.2.0
+          with:
+            ref: ${{ github.ref }}
+            check-name: Build
+            wait-interval: 10
         - name: Download previously generated initramfs
           uses: dawidd6/action-download-artifact@v2
           with:

--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -12,8 +12,6 @@ on:
 jobs:
   kernel-tests:
     name: Kernel tests
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
     runs-on: ubuntu-latest
     steps:
         - name: Check out the code
@@ -26,10 +24,11 @@ jobs:
         - name: Install dependencies
           run: sudo apt -y install qemu-system-x86 curl
         - name: Wait for build to succeed
-          uses: lewagon/wait-on-check-action@v1.2.0
+          uses: lewagon/wait-on-check-action@master
           with:
-            ref: ${{ github.ref }}
+            ref: ${{ github.event.pull_request.head.sha }}
             check-name: Build
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
             wait-interval: 10
         - name: Download previously generated initramfs
           uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
The current `workflow_run` is not great because:
- it doesn't allow us to iterate on PRs when changing the workflow
- the status doesn't show in the UI
- (TODO investigate not pushed SHAs)

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>