### PR TITLE
ci: Do not clean before running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,9 +101,7 @@ jobs:
         run: uname -a
 
       - name: Test
-        run: |
-          make clean bpf
-          make test ENABLE_RACE=yes
+        run: make test ENABLE_RACE=yes
 
       - name: Test unwind tables
         run: make test-dwarf-unwind-tables


### PR DESCRIPTION
Unsure sure why `make clean` is present. It should not be necessary

Sample of previous executions (they seem quite variable):
- 1.00mins: (https://github.com/parca-dev/parca-agent/actions/runs/3881975408/jobs/6621935520
- 2.47mins: https://github.com/parca-dev/parca-agent/actions/runs/3803239571/jobs/6469477128
- 3.39mins: https://github.com/parca-dev/parca-agent/actions/runs/3743606728/jobs/6355970546
- 3.43mins: https://github.com/parca-dev/parca-agent/actions/runs/3847317028/jobs/6553629022

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>