### PR TITLE
Eliminate CGo usage from cgroup package

### DIFF
--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -23,54 +23,8 @@ import (
 	"unsafe"
 
 	"github.com/prometheus/procfs"
+	"golang.org/x/sys/unix"
 )
-
-/*
-#define _GNU_SOURCE
-#include <stdlib.h>
-#include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <stdint.h>
-
-struct cgid_file_handle
-{
-  //struct file_handle handle;
-  unsigned int handle_bytes;
-  int handle_type;
-  uint64_t cgid;
-};
-
-uint64_t get_cgroupid(char *path) {
-  struct cgid_file_handle *h;
-  int mount_id;
-  int err;
-  uint64_t ret;
-
-  h = malloc(sizeof(struct cgid_file_handle));
-  if (!h)
-    return 0;
-
-  h->handle_bytes = 8;
-  err = name_to_handle_at(AT_FDCWD, path, (struct file_handle *)h, &mount_id, 0);
-  if (err != 0) {
-    free(h);
-    return 0;
-  }
-
-  if (h->handle_bytes != 8) {
-    free(h);
-    return 0;
-  }
-
-  ret = h->cgid;
-  free(h);
-
-  return ret;
-}
-*/
-import "C"
 
 // FindContainerGroup returns the cgroup with the cpu controller or first systemd slice cgroup.
 func FindContainerGroup(cgroups []procfs.Cgroup) procfs.Cgroup {
@@ -119,12 +73,14 @@ func PathV2AddMountpoint(path string) (string, error) {
 
 // ID returns the cgroup2 ID of a path.
 func ID(pathWithMountpoint string) (uint64, error) {
-	cPathWithMountpoint := C.CString(pathWithMountpoint)
-	ret := uint64(C.get_cgroupid(cPathWithMountpoint))
-	C.free(unsafe.Pointer(cPathWithMountpoint))
-	if ret == 0 {
-		return 0, fmt.Errorf("GetCgroupID on %q failed", pathWithMountpoint)
+	hf, _, err := unix.NameToHandleAt(unix.AT_FDCWD, pathWithMountpoint, 0)
+	if err != nil {
+		return 0, fmt.Errorf("GetCgroupID on %q failed: %w", pathWithMountpoint, err)
 	}
+	if hf.Size() != 8 {
+		return 0, fmt.Errorf("GetCgroupID on %q failed: unexpected size", pathWithMountpoint)
+	}
+	ret := *(*uint64)(unsafe.Pointer(&hf.Bytes()[0]))
 	return ret, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

We should remove as many CGo dependencies as possible. Switching from Go to C code at runtime always comes with increased costs in terms of CPU usage, so that is another reason to avoid mixed code.

### TODO
- [ ] Checkout: https://github.com/iovisor/bcc/blob/master/examples/cgroupid/cgroupid.c
