### PR TITLE
.eh_frame: Add helpers for memory mappings

### DIFF
--- a/pkg/stack/unwind/maps.go
+++ b/pkg/stack/unwind/maps.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"fmt"
+
+	"github.com/prometheus/procfs"
+)
+
+// ExecutableMapping represents an executable memory mapping.
+type ExecutableMapping struct {
+	LoadAddr   uint64
+	StartAddr  uint64
+	EndAddr    uint64
+	Executable string
+	mainExec   bool
+}
+
+// IsMainObject returns whether this executable is the "main executable".
+// which triggered the loading of all the other mappings.
+//
+// We care about this because if Linux ASLR is enabled, we have to
+// modify the loaded addresses for the main object.
+func (pm *ExecutableMapping) IsMainObject() bool {
+	return pm.mainExec
+}
+
+// IsJitted returns whether an executable mapping is JITed or not.
+// The detection is done by checking if the executable mapping is
+// not backed by a file.
+//
+// We don't check for the writeable flag as `mprotect(2)` may be
+// called to make it r+w only.
+func (pm *ExecutableMapping) IsJitted() bool {
+	return pm.Executable == ""
+}
+
+// IsNotFileBacked returns whether the mapping is not backed by a
+// file, such as JIT or vDSO sections.
+func (pm *ExecutableMapping) IsNotFileBacked() bool {
+	return pm.IsJitted() || pm.IsSpecial()
+}
+
+// IsSpecial returns whether the file mapping is a "special" region,
+// such as the mappings for vDSOs `[vdso]` and others.
+func (pm *ExecutableMapping) IsSpecial() bool {
+	return len(pm.Executable) > 0 && pm.Executable[0] == '['
+}
+
+func (pm *ExecutableMapping) String() string {
+	return fmt.Sprintf("ExecutableMapping {LoadAddr: 0x%x, StartAddr: 0x%x, EndAddr: 0x%x, Executable:%s}", pm.LoadAddr, pm.StartAddr, pm.EndAddr, pm.Executable)
+}
+
+type ExecutableMappings []*ExecutableMapping
+
+// HasJitted returns if there's at least one JIT'ed mapping.
+func (pm ExecutableMappings) HasJitted() bool {
+	for _, execMapping := range pm {
+		if execMapping.IsJitted() {
+			return true
+		}
+	}
+	return false
+}
+
+// executableMappingCount returns the number of executable mappings
+// in the passed `rawMappings`.
+func executableMappingCount(rawMappings []*procfs.ProcMap) uint {
+	var executableMappingCount uint
+	for _, rawMapping := range rawMappings {
+		if rawMapping.Perms.Execute {
+			executableMappingCount += 1
+		}
+	}
+	return executableMappingCount
+}
+
+// ExecutableMappings returns the executable memory mappings with the appropriate
+// loaded base address set for non-JIT code.
+//
+// The reason why we need to find the loaded base address is that ELF executables
+// aren't typically loaded in one large executable section, but split in several
+// mappings. For example, the .rodata section, as well as .eh_frame might go in
+// sections without executable permissions, as they aren't needed.
+func ListExecutableMappings(rawMappings []*procfs.ProcMap) ExecutableMappings {
+	result := make([]*ExecutableMapping, 0, executableMappingCount(rawMappings))
+	firstSeen := false
+	for idx, rawMapping := range rawMappings {
+		if rawMapping.Perms.Execute {
+			var loadAddr uint64
+			// We need the load base address for stack unwinding with DWARF
+			// information. We don't know of any runtimes that emit said unwind
+			// information for JITed code, so we set it to zero.
+			if rawMappings[idx].Pathname != "" {
+				for revIdx := idx; revIdx >= 0; revIdx-- {
+					if rawMappings[revIdx].Pathname != rawMappings[idx].Pathname {
+						break
+					}
+					loadAddr = uint64(rawMappings[revIdx].StartAddr)
+				}
+			}
+
+			result = append(result, &ExecutableMapping{
+				LoadAddr:   loadAddr,
+				StartAddr:  uint64(rawMapping.StartAddr),
+				EndAddr:    uint64(rawMapping.EndAddr),
+				Executable: rawMapping.Pathname,
+				mainExec:   !firstSeen,
+			})
+
+			firstSeen = true
+		}
+	}
+
+	return result
+}

--- a/pkg/stack/unwind/maps_test.go
+++ b/pkg/stack/unwind/maps_test.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/prometheus/procfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptyMappingsWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, ExecutableMappings{}, result)
+}
+
+func TestMappingsWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "./my_executable"}}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, ExecutableMappings{
+		{StartAddr: 0x0, EndAddr: 0x100, Executable: "./my_executable", mainExec: true},
+	}, result)
+	require.False(t, result[0].IsSpecial())
+}
+
+func TestMappingsWithSplitSectionsWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Read: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x100, EndAddr: 0x200, Perms: &procfs.ProcMapPermissions{Write: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x200, EndAddr: 0x300, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x300, EndAddr: 0x400, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "libc"},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, &ExecutableMapping{LoadAddr: 0x0, StartAddr: 0x200, EndAddr: 0x300, Executable: "./my_executable", mainExec: true}, result[0])
+}
+
+func TestMappingsWithJittedSectionsWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Read: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x100, EndAddr: 0x200, Perms: &procfs.ProcMapPermissions{Write: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x200, EndAddr: 0x300, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: ""},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, &ExecutableMapping{LoadAddr: 0x0, StartAddr: 0x200, EndAddr: 0x300, Executable: "", mainExec: true}, result[0])
+}
+
+func TestMappingsJitSectionDetectionWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x100, EndAddr: 0x200, Perms: &procfs.ProcMapPermissions{Execute: true}},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.True(t, result.HasJitted())
+}
+
+func TestMappingsIsNotFileBackedWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x100, EndAddr: 0x200, Perms: &procfs.ProcMapPermissions{Execute: true}},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.False(t, result[0].IsNotFileBacked())
+	require.True(t, result[1].IsNotFileBacked())
+}
+
+func TestMappingJitDetectionWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x100, EndAddr: 0x200, Perms: &procfs.ProcMapPermissions{Execute: true}},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, 2, len(result))
+	require.False(t, result[0].IsJitted())
+	require.True(t, result[1].IsJitted())
+}
+
+func TestMappingSpecialSectionDetectionWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "[vdso]"},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, 1, len(result))
+	require.True(t, result[0].IsSpecial())
+}
+
+func TestExecutableMappingCountWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{}
+	require.Equal(t, uint(0), executableMappingCount(rawMaps))
+
+	rawMaps = []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Read: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x100, EndAddr: 0x200, Perms: &procfs.ProcMapPermissions{Write: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x200, EndAddr: 0x300, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "./my_executable"},
+		{StartAddr: 0x300, EndAddr: 0x400, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "libc"},
+	}
+
+	require.Equal(t, uint(2), executableMappingCount(rawMaps))
+}
+
+// Not to be run normally, but helpful to find behavior that
+// might not be covered by unittests.
+func TestAllProcesses(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("This test requires root")
+	}
+
+	procs, err := procfs.AllProcs()
+	require.NoError(t, err)
+
+	for _, proc := range procs {
+		mappings, err := proc.ProcMaps()
+		if !errors.Is(err, os.ErrNotExist) {
+			require.NoError(t, err)
+		}
+		if err == nil {
+			_ = ListExecutableMappings(mappings)
+		}
+	}
+}


### PR DESCRIPTION
Add helpers to retrieve the information we need for native stack unwinding from process memory mappings.

This is the first step towards moving away from monolithic unwind tables to improve performance and the code: https://github.com/parca-dev/parca-agent/issues/1052.

Eventually, we might consolidate all these `proc/maps` helpers under the same package but can keep them in unwind right now as this is something we will only use here for the time being.

## Test Plan

Added unittests

```
$ sudo /usr/local/go/bin/go test -v github.com/parca-dev/parca-agent/pkg/stack/unwind
[...]
--- PASS: TestBuildUnwindTable (0.00s)
PASS
ok      github.com/parca-dev/parca-agent/pkg/stack/unwind       0.040s
```

(running under sudo to also ensure no panics/weird behaviours with all the processes of my box, in CI, these don't run as they could be flaky and not easy to repro)

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>