### PR TITLE
.eh_frame: Add initial frame pointer detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/pprof v0.0.0-20230111200839-76d1ae5aea2b
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-version v1.6.0
 	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
 	github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19
 	github.com/klauspost/compress v1.15.14

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/stack/unwind/executable.go
+++ b/pkg/stack/unwind/executable.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"debug/elf"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/xyproto/ainur"
+)
+
+func HasFramePointers(executable string) (bool, error) {
+	elf, err := elf.Open(executable)
+	if err != nil {
+		return false, fmt.Errorf("failed to open ELF file for path %s: %w", executable, err)
+	}
+	defer elf.Close()
+
+	compiler := ainur.Compiler(elf)
+	// Go 1.7 [0] enabled FP for x86_64. arm64 got them enabled in 1.12 [1].
+	//
+	// Note: we don't take into account applications that use cgo yet.
+	// If the non Go bits aren't compiled with frame pointers, too,
+	// unwinding will fail. In the future might add the unwind information
+	// for these bits of executable code.
+	//
+	// [0]: https://go.dev/doc/go1.7 (released on 2016-08-15).
+	// [1]: https://go.dev/doc/go1.12 (released on 2019-02-25).
+	if strings.Contains(compiler, "Go") {
+		versionString := strings.Split(compiler, "Go ")[1]
+		have, err := version.NewVersion(versionString)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse semver %s: %w", versionString, err)
+		}
+		want, err := version.NewVersion("1.12.0")
+		if err != nil {
+			return false, fmt.Errorf("failed to parse semver %s: %w", "1.19.4", err)
+		}
+
+		return want.LessThan(have), nil
+	}
+
+	// By default, assume there frame pointers are not present.
+	return false, nil
+}

--- a/pkg/stack/unwind/executable_test.go
+++ b/pkg/stack/unwind/executable_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasFramePointersInModernGolang(t *testing.T) {
+	// This test works because we require Go > 1.18,
+	// which compiles with frame pointers by default.
+	hasFp, err := HasFramePointers("/proc/self/exe")
+	require.NoError(t, err)
+	require.True(t, hasFp)
+}
+
+func TestHasFramePointersInCApplication(t *testing.T) {
+	hasFp, err := HasFramePointers("../../../testdata/out/basic-cpp")
+	require.NoError(t, err)
+	require.False(t, hasFp)
+}


### PR DESCRIPTION
Starting with checking Go's version to see if it might have frame pointers enabled by default. Part of https://github.com/parca-dev/parca-agent/issues/1052

## Test Plan

Added tests:
```
$ go test -v github.com/parca-dev/parca-agent/pkg/stack/unwind -- TestHasFramePointers
=== RUN   TestHasFramePointersInModernGolang
--- PASS: TestHasFramePointersInModernGolang (0.00s)
=== RUN   TestHasFramePointersInCApplication
--- PASS: TestHasFramePointersInCApplication (0.00s)
=== RUN   TestBuildUnwindTable
--- PASS: TestBuildUnwindTable (0.00s)
PASS
ok      github.com/parca-dev/parca-agent/pkg/stack/unwind       0.003s
```
Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>