### PR TITLE
pkg/executable: Add ASLR check with an existent ELF object

### DIFF
--- a/pkg/executable/executable.go
+++ b/pkg/executable/executable.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 )
 
-// IsASLRElegible returns whether the elf executable could be elegible for
+// IsASLRElegibleElf returns whether the elf executable could be elegible for
 // address space layout randomization (ASLR).
 //
 // Whether to enable ASLR for a process is decided in this kernel code
@@ -28,6 +28,10 @@ import (
 // Note(javierhonduco): This check is a bit simplistic and might not work
 // for every case. We might want to check across multiple kernels. It probably
 // won't be correct for the dynamic loader itself. See link above.
+func IsASLRElegibleElf(elfFile *elf.File) bool {
+	return elfFile.FileHeader.Type == elf.ET_DYN
+}
+
 func IsASLRElegible(path string) (bool, error) {
 	elfFile, err := elf.Open(path)
 	if err != nil {
@@ -35,5 +39,5 @@ func IsASLRElegible(path string) (bool, error) {
 	}
 	defer elfFile.Close()
 
-	return elfFile.FileHeader.Type == elf.ET_DYN, nil
+	return IsASLRElegibleElf(elfFile), nil
 }


### PR DESCRIPTION
Profiling while developing unwind tables per executable showed that `elf.Open()` was a big source of memory allocations. The extra CPU cycles caused by allocations, GC pressure, and the work inside of `elf.Open` accounted for ~20% of CPU cycles in my experiments.

In the current WIP rework, we already have an ELF file handle open that we can reuse, hence the added function.

Part of this work: https://github.com/parca-dev/parca-agent/issues/1052

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>