### PR TITLE
Unify compact unwind tables code

### DIFF
--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -1,0 +1,168 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"fmt"
+
+	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
+)
+
+type BpfCfaType uint16
+
+const (
+	//nolint: deadcode,varcheck
+	cfaTypeUndefined BpfCfaType = iota
+	cfaTypeRbp
+	cfaTypeRsp
+	cfaTypeExpression
+)
+
+type BpfRbpType uint16
+
+const (
+	RbpRuleOffsetUnchanged BpfRbpType = iota
+	RbpRuleOffset
+	RbpRuleRegister
+	rbpTypeExpression
+)
+
+// CompactUnwindTableRows encodes unwind information using 2x 64 bit words.
+type CompactUnwindTableRow struct {
+	pc                uint64
+	_reservedDoNotUse uint16
+	cfaType           uint8
+	rbpType           uint8
+	cfaOffset         int16
+	rbpOffset         int16
+}
+
+func (cutr *CompactUnwindTableRow) Pc() uint64 {
+	return cutr.pc
+}
+
+func (cutr *CompactUnwindTableRow) ReservedDoNotUse() uint16 {
+	return cutr._reservedDoNotUse
+}
+
+func (cutr *CompactUnwindTableRow) CfaType() uint8 {
+	return cutr.cfaType
+}
+
+func (cutr *CompactUnwindTableRow) RbpType() uint8 {
+	return cutr.rbpType
+}
+
+func (cutr *CompactUnwindTableRow) CfaOffset() int16 {
+	return cutr.cfaOffset
+}
+
+func (cutr *CompactUnwindTableRow) RbpOffset() int16 {
+	return cutr.rbpOffset
+}
+
+type CompactUnwindTable []CompactUnwindTableRow
+
+func (t CompactUnwindTable) Len() int           { return len(t) }
+func (t CompactUnwindTable) Less(i, j int) bool { return t[i].pc < t[j].pc }
+func (t CompactUnwindTable) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+
+// BuildCompactUnwindTable produces a compact unwind table for the given
+// frame description entries.
+func BuildCompactUnwindTable(fdes frame.FrameDescriptionEntries) (CompactUnwindTable, error) {
+	table := make(CompactUnwindTable, 0, 4*len(fdes)) // heuristic: we expect each function to have ~4 unwind entries.
+	for _, fde := range fdes {
+		frameContext := frame.ExecuteDwarfProgram(fde, nil)
+		for insCtx := frameContext.Next(); frameContext.HasNext(); insCtx = frameContext.Next() {
+			row := unwindTableRow(insCtx)
+			compactRow, err := rowToCompactRow(row)
+			if err != nil {
+				return CompactUnwindTable{}, err
+			}
+			table = append(table, compactRow)
+		}
+	}
+	return table, nil
+}
+
+// rowToCompactRow converts an unwind row to a compact row.
+func rowToCompactRow(row *UnwindTableRow) (CompactUnwindTableRow, error) {
+	var cfaType uint8
+	var rbpType uint8
+	var cfaOffset int16
+	var rbpOffset int16
+
+	// CFA.
+	//nolint:exhaustive
+	switch row.CFA.Rule {
+	case frame.RuleCFA:
+		if row.CFA.Reg == frame.X86_64FramePointer {
+			cfaType = uint8(cfaTypeRbp)
+		} else if row.CFA.Reg == frame.X86_64StackPointer {
+			cfaType = uint8(cfaTypeRsp)
+		}
+		cfaOffset = int16(row.CFA.Offset)
+	case frame.RuleExpression:
+		cfaType = uint8(cfaTypeExpression)
+		cfaOffset = int16(ExpressionIdentifier(row.CFA.Expression))
+	default:
+		return CompactUnwindTableRow{}, fmt.Errorf("CFA rule is not valid: %d", row.CFA.Rule)
+	}
+
+	// Frame pointer.
+	switch row.RBP.Rule {
+	case frame.RuleOffset:
+		rbpType = uint8(RbpRuleOffset)
+		rbpOffset = int16(row.RBP.Offset)
+	case frame.RuleRegister:
+		rbpType = uint8(RbpRuleRegister)
+	case frame.RuleExpression:
+		rbpType = uint8(rbpTypeExpression)
+	case frame.RuleUndefined:
+	case frame.RuleUnknown:
+	case frame.RuleSameVal:
+	case frame.RuleValOffset:
+	case frame.RuleValExpression:
+	case frame.RuleCFA:
+	}
+
+	return CompactUnwindTableRow{
+		pc:                row.Loc,
+		_reservedDoNotUse: 0,
+		cfaType:           cfaType,
+		rbpType:           rbpType,
+		cfaOffset:         cfaOffset,
+		rbpOffset:         rbpOffset,
+	}, nil
+}
+
+// CompactUnwindTableRepresentation converts an unwind table to its compact table
+// representation.
+func CompactUnwindTableRepresentation(unwindTable UnwindTable) (CompactUnwindTable, error) {
+	compactTable := make(CompactUnwindTable, 0, len(unwindTable))
+
+	for i := range unwindTable {
+		row := unwindTable[i]
+
+		compactRow, err := rowToCompactRow(&row)
+		if err != nil {
+			return CompactUnwindTable{}, err
+		}
+
+		compactTable = append(compactTable, compactRow)
+	}
+
+	return compactTable, nil
+}

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -1,0 +1,194 @@
+// Copyright 2022 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unwind
+
+import (
+	"testing"
+
+	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompactUnwindTable(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   UnwindTableRow
+		want    CompactUnwindTableRow
+		wantErr bool
+	}{
+		{
+			name: "CFA with Offset on x86_64 stack pointer",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.X86_64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           2,
+				rbpType:           0,
+				cfaOffset:         8,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name: "CFA with Offset on x86_64 frame pointer",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.X86_64FramePointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           1,
+				rbpType:           0,
+				cfaOffset:         8,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name: "CFA known expression PLT 1",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleExpression, Expression: Plt1[:]},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           3,
+				rbpType:           0,
+				cfaOffset:         1,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name: "CFA known expression PLT 2",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleExpression, Expression: Plt2[:]},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           3,
+				rbpType:           0,
+				cfaOffset:         2,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name: "CFA not known expression",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleExpression, Expression: []byte{'l', 'o', 'l'}},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           3,
+				rbpType:           0,
+				cfaOffset:         0,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name: "RBP offset",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.X86_64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleOffset, Offset: 64},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           2,
+				rbpType:           1,
+				cfaOffset:         8,
+				rbpOffset:         64,
+			},
+		},
+		{
+			name: "RBP register",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.X86_64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleRegister, Reg: 0xBAD},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           2,
+				rbpType:           2,
+				cfaOffset:         8,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name: "RBP expression",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.X86_64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleExpression, Expression: Plt1[:]},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:                123,
+				_reservedDoNotUse: 0,
+				cfaType:           2,
+				rbpType:           3,
+				cfaOffset:         8,
+				rbpOffset:         0,
+			},
+		},
+		{
+			name:    "Invalid CFA rule returns error",
+			input:   UnwindTableRow{},
+			want:    CompactUnwindTableRow{},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			have, err := CompactUnwindTableRepresentation(UnwindTable{test.input})
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, CompactUnwindTable{test.want}, have)
+			}
+		})
+	}
+}

--- a/pkg/stack/unwind/dwarf_expression.go
+++ b/pkg/stack/unwind/dwarf_expression.go
@@ -28,8 +28,8 @@ const (
 
 // DWARF expressions that we recognize.
 
-// plt1 is equivalent to: sp + 8 + ((((ip & 15) >= 11)) << 3.
-var plt1 = [...]byte{
+// Plt1 is equivalent to: sp + 8 + ((((ip & 15) >= 11)) << 3.
+var Plt1 = [...]byte{
 	frame.DW_OP_breg7,
 	frame.DW_OP_const1u,
 	frame.DW_OP_breg16,
@@ -42,8 +42,8 @@ var plt1 = [...]byte{
 	frame.DW_OP_plus,
 }
 
-// plt2 is quivalent to: sp + 8 + ((((ip & 15) >= 10)) << 3.
-var plt2 = [...]byte{
+// Plt2 is quivalent to: sp + 8 + ((((ip & 15) >= 10)) << 3.
+var Plt2 = [...]byte{
 	frame.DW_OP_breg7,
 	frame.DW_OP_const1u,
 	frame.DW_OP_breg16,
@@ -80,11 +80,11 @@ func ExpressionIdentifier(expression []byte) DwarfExpressionID {
 		cleanedExpression = append(cleanedExpression, opcode)
 	}
 
-	if equalBytes(plt1[:], cleanedExpression) {
+	if equalBytes(Plt1[:], cleanedExpression) {
 		return ExpressionPlt1
 	}
 
-	if equalBytes(plt2[:], cleanedExpression) {
+	if equalBytes(Plt2[:], cleanedExpression) {
 		return ExpressionPlt2
 	}
 


### PR DESCRIPTION
Before, the code to convert from the initial DWARF unwind information rows to the compact representation we use for BPF was duplicated and not well-tested. This commit:

- cleans the code
- adds comprehensive unit tests
- prepares the ground for snapshot tests in forthcoming PR (https://github.com/parca-dev/testdata/pull/10)

The current code to convert to compact unwind tables will be cleaned up in another PR

Part of https://github.com/parca-dev/parca-agent/issues/1052, https://github.com/parca-dev/parca-agent/issues/874

## Test Plan

Added unit-tests (will add snapshot tests in another PR)

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>