### PR TITLE
internal/dwarf/frame: Make FrameDescriptionEntries sortable

### DIFF
--- a/internal/dwarf/frame/entries.go
+++ b/internal/dwarf/frame/entries.go
@@ -57,6 +57,10 @@ func (fde *FrameDescriptionEntry) Translate(delta uint64) {
 
 type FrameDescriptionEntries []*FrameDescriptionEntry
 
+func (t FrameDescriptionEntries) Len() int           { return len(t) }
+func (t FrameDescriptionEntries) Less(i, j int) bool { return t[i].begin < t[j].begin }
+func (t FrameDescriptionEntries) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+
 func newFrameIndex() FrameDescriptionEntries {
 	return make(FrameDescriptionEntries, 0, 1000)
 }


### PR DESCRIPTION
Needed by the per executable section unwind tables work (https://github.com/parca-dev/parca-agent/issues/1052), as it's good a good idea to sort the FDEs when generating the full unwind table, so we reduce sorting from `O(total_unwind_rows)` to `O(fdes)`, the latter being always (significantly) smaller.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>