### PR TITLE
Add compact tables snapshot tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ $(OUT_BIN_EH_FRAME): go/deps
 
 write-dwarf-unwind-tables: build
 	make -C testdata validate EH_FRAME_BIN=../dist/eh-frame
+	make -C testdata validate-compact EH_FRAME_BIN=../dist/eh-frame
 
 test-dwarf-unwind-tables: write-dwarf-unwind-tables
 	$(CMD_GIT) diff --exit-code testdata/

--- a/cmd/eh-frame/main.go
+++ b/cmd/eh-frame/main.go
@@ -26,6 +26,7 @@ import (
 
 type flags struct {
 	Executable string `kong:"help='The executable to print the .eh_unwind tables for.'"`
+	Compact    bool   `kong:"help='Whether to use the compact format.'"`
 }
 
 // This tool exists for debugging .eh_frame unwinding and its intended for Parca Agent's
@@ -45,7 +46,7 @@ func main() {
 	}
 
 	ptb := unwind.NewUnwindTableBuilder(logger)
-	err := ptb.PrintTable(os.Stdout, executablePath)
+	err := ptb.PrintTable(os.Stdout, executablePath, flags.Compact)
 	if err != nil {
 		// nolint
 		fmt.Println("failed with:", err)


### PR DESCRIPTION
Add compact tables snapshot tests to ensure that we don't accidentally break them.

part of https://github.com/parca-dev/parca-agent/issues/1052

## Test Plan

```
$ make write-dwarf-unwind-tables
$ git diff
$
```

I've spot checked the table, and also ensured that the entries # matched:

```bash
$ wc -l testdata/{compact_,}tables/* | sort | tail -n +2 | awk -F' ' '{ count[$1]++ } END {for (el in count) print el, count[el]}'
14 2
23 2
49 2
53 2
18894 2
20620 2
28476 2
56693 2
71031 2
468837 2
```