### PR TITLE
.eh_frame: unwind table per executable

### DIFF
--- a/bpf/.clang-format
+++ b/bpf/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: LLVM
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+ColumnLimit: 160

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -11,7 +11,7 @@ format: c/fmt
 
 .PHONY: c/fmt
 c/fmt:
-	clang-format -i --style=LLVM $(BPF_SRC) $(BPF_HEADERS)
+	clang-format -i --style=file $(BPF_SRC) $(BPF_HEADERS)
 
 .PHONY: format-check
 format-check:

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/rzajac/flexbuf v0.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/xyproto/ainur v1.3.0
+	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.4.0
 	google.golang.org/grpc v1.52.0
@@ -140,7 +141,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect
 	golang.org/x/term v0.3.0 // indirect

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"runtime"
 	"strings"
@@ -36,7 +37,6 @@ import (
 	"github.com/google/pprof/profile"
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/goburrow/cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
@@ -82,9 +82,8 @@ type CPU struct {
 	debuginfoManager profiler.DebugInfoManager
 	labelsManager    profiler.LabelsManager
 
-	psMapCache         profiler.ProcessMapCache
-	objFileCache       profiler.ObjectFileCache
-	unwindTableBuilder *unwind.UnwindTableBuilder
+	psMapCache   profiler.ProcessMapCache
+	objFileCache profiler.ObjectFileCache
 
 	metrics *metrics
 
@@ -131,9 +130,8 @@ func NewCPUProfiler(
 		processMappings:  process.NewMapping(psMapCache),
 
 		// Shared caches between all profilers.
-		psMapCache:         psMapCache,
-		objFileCache:       objFileCache,
-		unwindTableBuilder: unwind.NewUnwindTableBuilder(logger),
+		psMapCache:   psMapCache,
+		objFileCache: objFileCache,
 
 		profilingDuration:          profilingDuration,
 		profilingSamplingFrequency: profilingSamplingFrequency,
@@ -189,6 +187,10 @@ func bpfCheck() error {
 	return result.ErrorOrNil()
 }
 
+func (p *CPU) debugProcesses() bool {
+	return len(p.debugProcessNames) > 0
+}
+
 func (p *CPU) Run(ctx context.Context) error {
 	level.Debug(p.logger).Log("msg", "starting cpu profiler")
 
@@ -214,7 +216,7 @@ func (p *CPU) Run(ctx context.Context) error {
 	level.Debug(p.logger).Log("msg", "actual memory locked rlimit", "cur", profiler.HumanizeRLimit(rLimit.Cur), "max", profiler.HumanizeRLimit(rLimit.Max))
 
 	var matchers []*regexp.Regexp
-	if len(p.debugProcessNames) > 0 {
+	if p.debugProcesses() {
 		level.Info(p.logger).Log("msg", "process names specified, debugging processes", "matchers", strings.Join(p.debugProcessNames, ", "))
 		for _, exp := range p.debugProcessNames {
 			regex, err := regexp.Compile(exp)
@@ -226,7 +228,7 @@ func (p *CPU) Run(ctx context.Context) error {
 	}
 
 	// Make sure it's called before BPFObjLoad.
-	p.bpfMaps, err = initializeMaps(m, p.byteOrder)
+	p.bpfMaps, err = initializeMaps(p.logger, m, p.byteOrder)
 	if err != nil {
 		return fmt.Errorf("failed to initialize eBPF maps: %w", err)
 	}
@@ -315,16 +317,14 @@ func (p *CPU) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create maps: %w", err)
 	}
 
-	if debugEnabled {
-		pfs, err := procfs.NewDefaultFS()
-		if err != nil {
-			return fmt.Errorf("failed to create procfs: %w", err)
-		}
-
-		level.Debug(p.logger).Log("msg", "debug process matchers found, starting process watcher")
-		// Update the debug pids map.
-		go p.watchProcesses(ctx, pfs, matchers)
+	pfs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return fmt.Errorf("failed to create procfs: %w", err)
 	}
+
+	level.Debug(p.logger).Log("msg", "debug process matchers found, starting process watcher")
+	// Update the debug pids map.
+	go p.watchProcesses(ctx, pfs, matchers)
 
 	ticker := time.NewTicker(p.profilingDuration)
 	defer ticker.Stop()
@@ -407,75 +407,96 @@ func (p *CPU) watchProcesses(ctx context.Context, pfs procfs.FS, matchers []*reg
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
-	unwindTableCache := cache.New(cache.WithExpireAfterWrite(20 * time.Minute))
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 		}
-
-		procs, err := pfs.AllProcs()
+		allProcs, err := pfs.AllProcs()
 		if err != nil {
 			level.Error(p.logger).Log("msg", "failed to list processes", "err", err)
-			continue
+			return
 		}
 
 		pids := []int{}
-		for _, proc := range procs {
-			comm, err := proc.Comm()
-			if err != nil {
-				level.Error(p.logger).Log("msg", "failed to get process name", "err", err)
-				continue
-			}
 
-			if comm == "" {
-				continue
-			}
+		// Filter processes if needed.
+		if p.debugProcesses() {
+			for _, proc := range allProcs {
+				comm, err := proc.Comm()
+				if err != nil {
+					level.Error(p.logger).Log("msg", "failed to get process name", "err", err)
+					continue
+				}
 
-			for _, m := range matchers {
-				if m.MatchString(comm) {
-					level.Info(p.logger).Log("msg", "match found; debugging process", "pid", proc.PID, "comm", comm)
-					pids = append(pids, proc.PID)
+				if comm == "" {
+					continue
+				}
+
+				for _, m := range matchers {
+					if m.MatchString(comm) {
+						level.Info(p.logger).Log("msg", "match found; debugging process", "pid", proc.PID, "comm", comm)
+						pids = append(pids, proc.PID)
+					}
 				}
 			}
-		}
 
-		if len(pids) > 0 {
-			level.Debug(p.logger).Log("msg", "updating debug pids map", "pids", fmt.Sprintf("%v", pids))
-			// Only meant to be used for debugging, it is not safe to use in production.
-			if err := p.bpfMaps.setDebugPIDs(pids); err != nil {
-				level.Warn(p.logger).Log("msg", "failed to update debug pids map", "err", err)
+			if len(pids) > 0 {
+				level.Debug(p.logger).Log("msg", "updating debug pids map", "pids", fmt.Sprintf("%v", pids))
+				// Only meant to be used for debugging, it is not safe to use in production.
+				if err := p.bpfMaps.setDebugPIDs(pids); err != nil {
+					level.Error(p.logger).Log("msg", "failed to update debug pids map", "err", err)
+				}
+			} else {
+				level.Debug(p.logger).Log("msg", "no processes matched the provided regex")
+				if err := p.bpfMaps.setDebugPIDs(nil); err != nil {
+					level.Error(p.logger).Log("msg", "failed to update debug pids map", "err", err)
+				}
 			}
 		} else {
-			level.Debug(p.logger).Log("msg", "no processes matched the provided regex")
-			if err := p.bpfMaps.setDebugPIDs(nil); err != nil {
-				level.Warn(p.logger).Log("msg", "failed to update debug pids map", "err", err)
+			for _, proc := range allProcs {
+				pids = append(pids, proc.PID)
 			}
-			continue
 		}
 
-		// Can only be enabled when a debug process name is specified.
 		if p.enableDWARFUnwinding {
+			level.Info(p.logger).Log("msg", "about to call addUnwindTableForProcess")
+
 			// Update unwind tables for the given pids.
 			for _, pid := range pids {
-				if _, exists := unwindTableCache.GetIfPresent(pid); exists {
+				executable := fmt.Sprintf("/proc/%d/exe", pid)
+				hasFramePointers, err := unwind.HasFramePointers(executable)
+				if err != nil {
+					// It might not exist as reading procfs is racy.
+					if !errors.Is(err, os.ErrNotExist) {
+						level.Error(p.logger).Log("msg", "frame pointer detection failed", "executable", executable, "err", err)
+						continue
+					}
+				}
+
+				if hasFramePointers {
 					continue
 				}
+
 				level.Info(p.logger).Log("msg", "adding unwind tables", "pid", pid)
 
-				pt, err := p.unwindTableBuilder.UnwindTableForPid(pid)
+				err = p.bpfMaps.addUnwindTableForProcess(pid)
 				if err != nil {
-					level.Warn(p.logger).Log("msg", "failed to build unwind table", "pid", pid, "err", err)
+					if errors.Is(err, os.ErrNotExist) {
+						level.Debug(p.logger).Log("msg", "failed to add unwind table due to a procfs race", "pid", pid, "err", err)
+					} else {
+						level.Error(p.logger).Log("msg", "failed to add unwind table", "pid", pid, "err", err)
+					}
 					continue
 				}
+			}
 
-				if err := p.bpfMaps.setUnwindTable(pid, pt); err != nil {
-					level.Warn(p.logger).Log("msg", "failed to update unwind tables", "pid", pid, "err", err)
-					continue
-				}
-				unwindTableCache.Put(pid, struct{}{})
+			// Must be called after all the calls to `addUnwindTableForProcess`, as it's possible
+			// that the current in-flight shard hasn't been written to the BPF map, yet.
+			err := p.bpfMaps.PersistUnwindTable()
+			if err != nil {
+				level.Error(p.logger).Log("msg", "PersistUnwindTable failed", "err", err)
 			}
 		}
 	}

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -44,7 +44,7 @@ func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	_, err = profiler.BumpMemlock(memLock, memLock)
 	require.NoError(t, err)
 
-	bpfMaps, err := initializeMaps(m, byteorder.GetHostByteOrder())
+	bpfMaps, err := initializeMaps(nil, m, byteorder.GetHostByteOrder())
 	require.NoError(t, err)
 
 	// Enable DWARF unwinding so the unwind tables are created with a

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -18,57 +18,73 @@ import "C"
 
 import (
 	"bytes"
+	"debug/elf"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
+	"path"
+	"sort"
+	"syscall"
 	"unsafe"
 
-	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
-	"github.com/parca-dev/parca-agent/pkg/stack/unwind"
-
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	burrow "github.com/goburrow/cache"
+	"github.com/prometheus/procfs"
+	"golang.org/x/exp/constraints"
+
+	"github.com/parca-dev/parca-agent/pkg/buildid"
+	"github.com/parca-dev/parca-agent/pkg/executable"
+	"github.com/parca-dev/parca-agent/pkg/stack/unwind"
 )
 
 const (
 	debugPIDsMapName        = "debug_pids"
 	stackCountsMapName      = "stack_counts"
 	stackTracesMapName      = "stack_traces"
+	unwindShardsMapName     = "unwind_shards"
 	dwarfStackTracesMapName = "dwarf_stack_traces"
 	unwindTablesMapName     = "unwind_tables"
+	processInfoMapName      = "process_info"
 	programsMapName         = "programs"
 
-	// With the current row structure, the max items we can store is 262k per map.
-	unwindTableMaxEntries = 100
+	// With the current compact rows, the max items we can store in the kernels
+	// we have tested is 262k per map, which we rounded it down to 250k.
+	unwindTableMaxEntries = 50         // How many unwind table shards we have.
 	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in the BPF program.
-	unwindTableShardCount = 6          // Always needs to be sync with MAX_SHARDS in the BPF program.
-	maxUnwindSize         = maxUnwindTableSize * unwindTableShardCount
-)
+	maxMappingsPerProcess = 120        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
+	/*
+		TODO: once we generate the bindings automatically, remove this.
 
-type BpfCfaType uint16
+		typedef struct mapping {
+			u64 load_address;
+			u64 begin;
+			u64 end;
+			u64 executable_id;
+			u64 type;
+		} mapping_t;
 
-const (
-	CfaRegisterUndefined BpfCfaType = iota
-	CfaRegisterRbp
-	CfaRegisterRsp
-	CfaRegisterExpression
-)
-
-type BpfRbpType uint16
-
-const (
-	RbpRuleOffsetUnchanged BpfRbpType = iota
-	RbpRuleOffset
-	RbpRuleRegister
-	RbpRegisterExpression
+		typedef struct {
+			u64 is_jit_compiler;
+			u64 len;
+			mapping_t mappings[MAX_MAPPINGS_PER_PROCESS];
+		} process_info_t;
+	*/
+	procInfoSizeBytes = 8 + 8 + (maxMappingsPerProcess * 8 * 5)
 )
 
 var (
-	errMissing       = errors.New("missing stack trace")
-	errUnwindFailed  = errors.New("stack ID is 0, probably stack unwinding failed")
-	errUnrecoverable = errors.New("unrecoverable error")
+	errMissing                   = errors.New("missing stack trace")
+	errUnwindFailed              = errors.New("stack ID is 0, probably stack unwinding failed")
+	errUnrecoverable             = errors.New("unrecoverable error")
+	errTooManyExecutableMappings = errors.New("too many executable mappings")
 )
 
 type bpfMaps struct {
+	logger log.Logger
+
 	module    *bpf.Module
 	byteOrder binary.ByteOrder
 
@@ -77,19 +93,58 @@ type bpfMaps struct {
 	stackCounts      *bpf.BPFMap
 	stackTraces      *bpf.BPFMap
 	dwarfStackTraces *bpf.BPFMap
+	processInfo      *bpf.BPFMap
 
+	unwindShards *bpf.BPFMap
 	unwindTables *bpf.BPFMap
 	programs     *bpf.BPFMap
+
+	// unwind stuff 🔬
+	processCache burrow.Cache
+	procInfoBuf  *bytes.Buffer
+
+	buildIDMapping map[string]uint64
+	//	globalView []{shard_id:, [all the ranges it contains]}
+	// which shard we are on
+	shardIndex    uint64
+	executableID  uint64
+	unwindInfoBuf *bytes.Buffer
+	// Account where we are within a shard
+	lowIndex  uint64
+	highIndex uint64
+	// Other stats
+	totalEntries       uint64
+	uniqueMappings     uint64
+	referencedMappings uint64
 }
 
-func initializeMaps(m *bpf.Module, byteOrder binary.ByteOrder) (*bpfMaps, error) {
+func min[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func initializeMaps(logger log.Logger, m *bpf.Module, byteOrder binary.ByteOrder) (*bpfMaps, error) {
 	if m == nil {
 		return nil, fmt.Errorf("nil module")
 	}
 
+	procInfoArray := make([]byte, 0, procInfoSizeBytes)
+	unwindInfoArray := make([]byte, 0, maxUnwindTableSize*unsafe.Sizeof(unwind.CompactUnwindTableRow{}))
+
 	maps := &bpfMaps{
-		module:    m,
-		byteOrder: byteOrder,
+		logger:         log.With(logger, "component", "maps"),
+		module:         m,
+		byteOrder:      byteOrder,
+		processCache:   burrow.New(),
+		procInfoBuf:    bytes.NewBuffer(procInfoArray),
+		unwindInfoBuf:  bytes.NewBuffer(unwindInfoArray),
+		buildIDMapping: make(map[string]uint64),
+	}
+
+	if err := maps.resetInFlightBuffer(); err != nil {
+		level.Error(logger).Log("msg", "resetInFlightBuffer failed", "err", err)
 	}
 
 	return maps, nil
@@ -132,6 +187,11 @@ func (m *bpfMaps) create() error {
 		return fmt.Errorf("get stack traces map: %w", err)
 	}
 
+	unwindShards, err := m.module.GetMap(unwindShardsMapName)
+	if err != nil {
+		return fmt.Errorf("get unwind shards map: %w", err)
+	}
+
 	unwindTables, err := m.module.GetMap(unwindTablesMapName)
 	if err != nil {
 		return fmt.Errorf("get unwind tables map: %w", err)
@@ -142,11 +202,19 @@ func (m *bpfMaps) create() error {
 		return fmt.Errorf("get dwarf stack traces map: %w", err)
 	}
 
+	processInfo, err := m.module.GetMap(processInfoMapName)
+	if err != nil {
+		return fmt.Errorf("get process info map: %w", err)
+	}
+
 	m.debugPIDs = debugPIDs
 	m.stackCounts = stackCounts
 	m.stackTraces = stackTraces
+	m.unwindShards = unwindShards
 	m.unwindTables = unwindTables
 	m.dwarfStackTraces = dwarfStackTraces
+	m.processInfo = processInfo
+
 	return nil
 }
 
@@ -223,6 +291,7 @@ func (m *bpfMaps) readUserStackWithDwarf(userStackID int32, stack *combinedStack
 	}
 
 	userStack := stack[:stackDepth]
+
 	for i, addr := range dwarfStack.Addrs {
 		if i >= stackDepth || i >= int(dwarfStack.Len) || addr == 0 {
 			break
@@ -265,192 +334,699 @@ func (m *bpfMaps) clean() error {
 	// can only delete the "previous" item once we've already iterated to
 	// the next.
 
-	it := m.stackTraces.Iterator()
-	var prev []byte = nil
-	for it.Next() {
+	// stackTraces
+	{
+		it := m.stackTraces.Iterator()
+		var prev []byte = nil
+		for it.Next() {
+			if prev != nil {
+				err := m.stackTraces.DeleteKey(unsafe.Pointer(&prev[0]))
+				if err != nil {
+					return fmt.Errorf("failed to delete stack trace: %w", err)
+				}
+			}
+
+			key := it.Key()
+			prev = make([]byte, len(key))
+			copy(prev, key)
+		}
 		if prev != nil {
 			err := m.stackTraces.DeleteKey(unsafe.Pointer(&prev[0]))
 			if err != nil {
 				return fmt.Errorf("failed to delete stack trace: %w", err)
 			}
 		}
-
-		key := it.Key()
-		prev = make([]byte, len(key))
-		copy(prev, key)
 	}
-	if prev != nil {
-		err := m.stackTraces.DeleteKey(unsafe.Pointer(&prev[0]))
-		if err != nil {
-			return fmt.Errorf("failed to delete stack trace: %w", err)
+
+	// dwarfStackTraces
+	{
+		it := m.dwarfStackTraces.Iterator()
+		var prev []byte = nil
+		for it.Next() {
+			if prev != nil {
+				err := m.dwarfStackTraces.DeleteKey(unsafe.Pointer(&prev[0]))
+				if err != nil {
+					return fmt.Errorf("failed to delete dwarf stack trace: %w", err)
+				}
+			}
+
+			key := it.Key()
+			prev = make([]byte, len(key))
+			copy(prev, key)
+		}
+		if prev != nil {
+			err := m.dwarfStackTraces.DeleteKey(unsafe.Pointer(&prev[0]))
+			if err != nil {
+				return fmt.Errorf("failed to delete dwarf tack trace: %w", err)
+			}
 		}
 	}
 
-	it = m.stackCounts.Iterator()
-	prev = nil
-	for it.Next() {
+	// stackCounts
+	{
+		it := m.stackCounts.Iterator()
+		var prev []byte = nil
+		for it.Next() {
+			if prev != nil {
+				err := m.stackCounts.DeleteKey(unsafe.Pointer(&prev[0]))
+				if err != nil {
+					return fmt.Errorf("failed to delete count: %w", err)
+				}
+			}
+
+			key := it.Key()
+			prev = make([]byte, len(key))
+			copy(prev, key)
+		}
 		if prev != nil {
 			err := m.stackCounts.DeleteKey(unsafe.Pointer(&prev[0]))
 			if err != nil {
 				return fmt.Errorf("failed to delete count: %w", err)
 			}
 		}
-
-		key := it.Key()
-		prev = make([]byte, len(key))
-		copy(prev, key)
-	}
-	if prev != nil {
-		err := m.stackCounts.DeleteKey(unsafe.Pointer(&prev[0]))
-		if err != nil {
-			return fmt.Errorf("failed to delete count: %w", err)
-		}
 	}
 
 	return nil
 }
 
-// setUnwindTable updates the unwind tables with the given unwind table.
-func (m *bpfMaps) setUnwindTable(pid int, ut unwind.UnwindTable) error {
-	buf := new(bytes.Buffer)
+func (m *bpfMaps) cleanProcessInfo() error {
+	// BPF iterators need the previous value to iterate to the next, so we
+	// can only delete the "previous" item once we've already iterated to
+	// the next.
 
-	if len(ut) >= maxUnwindSize {
-		return fmt.Errorf("maximum unwind table size reached. Table size %d, but max size is %d", len(ut), maxUnwindSize)
-	}
-
-	// Range-partition the unwind table in the different shards.
-	shardIndex := 0
-	for i := 0; i < len(ut); i += maxUnwindTableSize {
-		upTo := i + maxUnwindTableSize
-		if upTo > len(ut) {
-			upTo = len(ut)
-		}
-
-		chunk := ut[i:upTo]
-
-		// Write `.low_pc`
-		if err := binary.Write(buf, m.byteOrder, chunk[0].Loc); err != nil {
-			return fmt.Errorf("write the number of rows: %w", err)
-		}
-		// Write `.high_pc`.
-		if err := binary.Write(buf, m.byteOrder, chunk[len(chunk)-1].Loc); err != nil {
-			return fmt.Errorf("write the number of rows: %w", err)
-		}
-		// Write number of rows `.table_len`.
-		if err := binary.Write(buf, m.byteOrder, uint64(len(chunk))); err != nil {
-			return fmt.Errorf("write the number of rows: %w", err)
-		}
-		// Write padding.
-		if err := binary.Write(buf, m.byteOrder, uint64(0)); err != nil {
-			return fmt.Errorf("write the number of rows: %w", err)
-		}
-		for _, row := range chunk {
-			// Right now we only support x86_64, where the return address position
-			// is specified in the ABI, so we don't write it.
-
-			// Write Program Counter (PC).
-			if err := binary.Write(buf, m.byteOrder, row.Loc); err != nil {
-				return fmt.Errorf("write the program counter: %w", err)
-			}
-
-			// Write __reserved_do_not_use.
-			if err := binary.Write(buf, m.byteOrder, uint16(0)); err != nil {
-				return fmt.Errorf("write CFA register bytes: %w", err)
-			}
-
-			var CfaRegister uint8
-			var RbpRegister uint8
-			var CfaOffset int16
-			var RbpOffset int16
-
-			// CFA.
-			switch row.CFA.Rule {
-			case frame.RuleCFA:
-				if row.CFA.Reg == frame.X86_64FramePointer {
-					CfaRegister = uint8(CfaRegisterRbp)
-				} else if row.CFA.Reg == frame.X86_64StackPointer {
-					CfaRegister = uint8(CfaRegisterRsp)
+	// processInfo
+	{
+		it := m.processInfo.Iterator()
+		var prev []byte = nil
+		for it.Next() {
+			if prev != nil {
+				err := m.processInfo.DeleteKey(unsafe.Pointer(&prev[0]))
+				if err != nil {
+					return fmt.Errorf("failed to delete stack trace: %w", err)
 				}
-				CfaOffset = int16(row.CFA.Offset)
-			case frame.RuleExpression:
-				CfaRegister = uint8(CfaRegisterExpression)
-				CfaOffset = int16(unwind.ExpressionIdentifier(row.CFA.Expression))
-
-			default:
-				return fmt.Errorf("CFA rule is not valid. This should never happen")
 			}
 
-			// Frame pointer.
-			switch row.RBP.Rule {
-			case frame.RuleUndefined:
-			case frame.RuleOffset:
-				RbpRegister = uint8(RbpRuleOffset)
-				RbpOffset = int16(row.RBP.Offset)
-			case frame.RuleRegister:
-				RbpRegister = uint8(RbpRuleRegister)
-			case frame.RuleExpression:
-				RbpRegister = uint8(RbpRegisterExpression)
-			}
-
-			// Write CFA type (.cfa_type).
-			if err := binary.Write(buf, m.byteOrder, CfaRegister); err != nil {
-				return fmt.Errorf("write CFA register bytes: %w", err)
-			}
-
-			// Write frame pointer type (.rbp_type).
-			if err := binary.Write(buf, m.byteOrder, RbpRegister); err != nil {
-				return fmt.Errorf("write CFA register bytes: %w", err)
-			}
-
-			// Write CFA offset (.cfa_offset).
-			if err := binary.Write(buf, m.byteOrder, CfaOffset); err != nil {
-				return fmt.Errorf("write CFA offset bytes: %w", err)
-			}
-
-			// Write frame pointer offset (.rbp_offset).
-			if err := binary.Write(buf, m.byteOrder, RbpOffset); err != nil {
-				return fmt.Errorf("write RBP offset bytes: %w", err)
+			key := it.Key()
+			prev = make([]byte, len(key))
+			copy(prev, key)
+		}
+		if prev != nil {
+			err := m.processInfo.DeleteKey(unsafe.Pointer(&prev[0]))
+			if err != nil {
+				return fmt.Errorf("failed to delete stack trace: %w", err)
 			}
 		}
+	}
+	return nil
+}
 
-		// Set (PID, shard ID) -> unwind table for each shard.
-		keyBuf := new(bytes.Buffer)
-		if err := binary.Write(keyBuf, m.byteOrder, int32(pid)); err != nil {
-			return fmt.Errorf("write RBP offset bytes: %w", err)
-		}
-		if err := binary.Write(keyBuf, m.byteOrder, int32(shardIndex)); err != nil {
-			return fmt.Errorf("write RBP offset bytes: %w", err)
-		}
+func (m *bpfMaps) cleanShardInfo() error {
+	// BPF iterators need the previous value to iterate to the next, so we
+	// can only delete the "previous" item once we've already iterated to
+	// the next.
 
-		if err := m.unwindTables.Update(unsafe.Pointer(&keyBuf.Bytes()[0]), unsafe.Pointer(&buf.Bytes()[0])); err != nil {
-			return fmt.Errorf("update unwind tables: %w", err)
+	// unwindShards
+	{
+		it := m.unwindShards.Iterator()
+		var prev []byte = nil
+		for it.Next() {
+			if prev != nil {
+				err := m.unwindShards.DeleteKey(unsafe.Pointer(&prev[0]))
+				if err != nil {
+					return fmt.Errorf("failed to delete stack trace: %w", err)
+				}
+			}
+
+			key := it.Key()
+			prev = make([]byte, len(key))
+			copy(prev, key)
 		}
-		shardIndex++
-		buf.Reset()
+		if prev != nil {
+			err := m.unwindShards.DeleteKey(unsafe.Pointer(&prev[0]))
+			if err != nil {
+				return fmt.Errorf("failed to delete stack trace: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (m *bpfMaps) resetProcInfoBuffer() error {
+	// Set len to zero.
+	m.procInfoBuf.Reset()
+
+	// Zero it.
+	zero := byte(0)
+	// TODO(javierhonduco): This is a waste of allocations and CPU cycles,
+	// perhaps this can be optimized.
+	for i := 0; i < procInfoSizeBytes; i++ {
+		if err := binary.Write(m.procInfoBuf, m.byteOrder, zero); err != nil {
+			return fmt.Errorf("failed write zeroes to resetProcInfoBuffer: %w", err)
+		}
 	}
 
-	// HACK(javierhonduco): remove this.
-	// Debug stuff to compare this with the BPF program's view of the world.
-	/* printRow := func(w io.Writer, pt unwind.UnwindTable, index int) {
-		cfaInfo := ""
-		switch ut[index].CFA.Rule {
-		case frame.RuleCFA:
-			cfaInfo = fmt.Sprintf("CFA Reg: %d Offset:%d", ut[index].CFA.Reg, ut[index].CFA.Offset)
-		case frame.RuleExpression:
-			cfaInfo = "CFA exp"
-		default:
-			panic("CFA rule is not valid. This should never happen.")
-		}
+	// Set len to zero.
+	m.procInfoBuf.Reset()
 
-		fmt.Fprintf(w, "\trow[%d]. Loc: %x, %s, $rbp: %d\n", index, pt[index].Loc, cfaInfo, pt[index].RBP.Offset)
+	return nil
+}
+
+// 1. Find executable sections
+// 2. For each section, generate compact table
+// 3. Add table to maps
+// 4. Add map metadata to process
+func (m *bpfMaps) addUnwindTableForProcess(pid int) error {
+	// TODO(javierhonduco): the current caching schema doesn't have any eviction policy,
+	// so memory might grow linear to the number of unique seen processes.
+	//
+	// Some other shortcomings:
+	//	- if evicting, we should add some random jitter to ensure that the unwind tables
+	// aren't built in the same short window of time causing a big resource spike.
+	//	- perhaps we could cache based on `start_at` (but parsing this file properly
+	// is challenging...).
+	//  - executable mappings can change, think `ldopen`, or JITs. We don't account for this
+	// just yet.
+	//  - PIDs can be recycled.
+	if _, exists := m.processCache.GetIfPresent(pid); exists {
+		level.Debug(m.logger).Log("msg", "process already cached", "pid", pid)
+		return nil
 	}
 
-	fmt.Fprintf(os.Stdout, "\t- Total entries %d\n\n", len(ut))
-	printRow(os.Stdout, ut, 0)
-	printRow(os.Stdout, ut, 1)
-	printRow(os.Stdout, ut, 2)
-	printRow(os.Stdout, ut, 6)
-	printRow(os.Stdout, ut, len(ut)-1) */
+	proc, err := procfs.NewProc(pid)
+	if err != nil {
+		return err
+	}
+
+	mappings, err := proc.ProcMaps()
+	if err != nil {
+		return err
+	}
+
+	executableMappings := unwind.ListExecutableMappings(mappings)
+	if err := m.resetProcInfoBuffer(); err != nil {
+		level.Error(m.logger).Log("msg", "resetProcInfoBuffer failed", "err", err)
+	}
+
+	// Important: the below *must* be called before setUnwindTable.
+	// .is_jit_compiler
+	var isJitCompiler uint64
+	if executableMappings.HasJitted() {
+		isJitCompiler = 1
+	}
+	if err := binary.Write(m.procInfoBuf, m.byteOrder, isJitCompiler); err != nil {
+		return fmt.Errorf("write proc_info .is_jit_compiler bytes: %w", err)
+	}
+
+	if len(executableMappings) >= maxMappingsPerProcess {
+		return errTooManyExecutableMappings
+	}
+
+	// .len
+	if err := binary.Write(m.procInfoBuf, m.byteOrder, uint64(len(executableMappings))); err != nil {
+		return fmt.Errorf("write proc_info .len bytes: %w", err)
+	}
+
+	for _, executableMapping := range executableMappings {
+		if err := m.setUnwindTableForMapping(pid, executableMapping, m.procInfoBuf); err != nil {
+			return fmt.Errorf("setUnwindTableForMapping failed: %w", err)
+		}
+	}
+
+	if err := m.processInfo.Update(unsafe.Pointer(&pid), unsafe.Pointer(&m.procInfoBuf.Bytes()[0])); err != nil {
+		return fmt.Errorf("update processInfo: %w", err)
+	}
+
+	m.processCache.Put(pid, struct{}{})
+	return nil
+}
+
+// generateCompactUnwindTable produces the compact unwidn table for a given
+// executable.
+func (m *bpfMaps) generateCompactUnwindTable(fullExecutablePath string, mapping *unwind.ExecutableMapping) (unwind.CompactUnwindTable, uint64, uint64, error) {
+	var minCoveredPc uint64
+	var maxCoveredPc uint64
+	var ut unwind.CompactUnwindTable
+
+	// Fetch FDEs.
+	fdes, err := unwind.ReadFDEs(fullExecutablePath)
+	if err != nil {
+		return ut, 0, 0, err
+	}
+
+	// Sort them, as this will ensure that the generated table
+	// is also sorted. Sorting fewer elements will be faster.
+	sort.Sort(fdes)
+	minCoveredPc = fdes[0].Begin()
+	maxCoveredPc = fdes[len(fdes)-1].End()
+
+	// Generate the compact unwind table.
+	ut, err = unwind.BuildCompactUnwindTable(fdes)
+	if err != nil {
+		return ut, 0, 0, err
+	}
+
+	// This should not be necessary, as per the sorting above, but
+	// just in case :).
+	sort.Sort(ut)
+
+	// Now we have a full compact unwind table that we have to split in different BPF maps.
+	level.Debug(m.logger).Log("msg", "found unwind entries", "executable", mapping.Executable, "len", len(ut), "low pc", fmt.Sprintf("%x", minCoveredPc), "high pc", fmt.Sprintf("%x", maxCoveredPc))
+
+	return ut, minCoveredPc, maxCoveredPc, nil
+}
+
+// writeUnwindTableRow writes a compact unwind table row to the provided buffer.
+//
+// Note: we are writing field by field to avoid extra allocations and CPU spent in
+// the reflection code paths in `binary.Write`.
+func (m *bpfMaps) writeUnwindTableRow(buffer *bytes.Buffer, row unwind.CompactUnwindTableRow) error {
+	// .pc
+	if err := binary.Write(buffer, m.byteOrder, row.Pc()); err != nil {
+		return fmt.Errorf("write unwind table .pc bytes: %w", err)
+	}
+
+	// .__reserved_do_not_use
+	if err := binary.Write(buffer, m.byteOrder, row.ReservedDoNotUse()); err != nil {
+		return fmt.Errorf("write unwind table __reserved_do_not_use bytes: %w", err)
+	}
+
+	// .cfa_type
+	if err := binary.Write(buffer, m.byteOrder, row.CfaType()); err != nil {
+		return fmt.Errorf("write unwind table cfa_type bytes: %w", err)
+	}
+
+	// .rbp_type
+	if err := binary.Write(buffer, m.byteOrder, row.RbpType()); err != nil {
+		return fmt.Errorf("write unwind table rbp_type bytes: %w", err)
+	}
+
+	// .cfa_offset
+	if err := binary.Write(buffer, m.byteOrder, row.CfaOffset()); err != nil {
+		return fmt.Errorf("write unwind table cfa_offset bytes: %w", err)
+	}
+
+	// .rbp_offset
+	if err := binary.Write(buffer, m.byteOrder, row.RbpOffset()); err != nil {
+		return fmt.Errorf("write unwind table rbp_offset bytes: %w", err)
+	}
+
+	return nil
+}
+
+// writeMapping writes the memory mapping information to the provided buffer.
+//
+// Note: we write field by field to avoid the expensive reflection code paths
+// when writing structs using `binary.Write`.
+func (m *bpfMaps) writeMapping(procInfoBuf *bytes.Buffer, loadAddress, startAddr, endAddr, executableID, type_ uint64) error {
+	// .load_address
+	if err := binary.Write(procInfoBuf, m.byteOrder, loadAddress); err != nil {
+		return fmt.Errorf("write mappings .load_address bytes: %w", err)
+	}
+	// .begin
+	if err := binary.Write(procInfoBuf, m.byteOrder, startAddr); err != nil {
+		return fmt.Errorf("write mappings .begin bytes: %w", err)
+	}
+	// .end
+	if err := binary.Write(procInfoBuf, m.byteOrder, endAddr); err != nil {
+		return fmt.Errorf("write mappings .end bytes: %w", err)
+	}
+	// .executable_id
+	if err := binary.Write(procInfoBuf, m.byteOrder, executableID); err != nil {
+		return fmt.Errorf("write proc info .executable_id bytes: %w", err)
+	}
+	// .type
+	if err := binary.Write(procInfoBuf, m.byteOrder, type_); err != nil {
+		return fmt.Errorf("write proc info .type bytes: %w", err)
+	}
+
+	return nil
+}
+
+// mappingID returns the internal identifier for a memory mapping.
+//
+// It will either return the already produced ID or generate a new
+// one while indicating whether it was already seen or not.
+//
+// This allows us to reuse the unwind tables for the mappings we
+// see.
+func (m *bpfMaps) mappingID(buildID string) (uint64, bool) {
+	_, alreadySeenMapping := m.buildIDMapping[buildID]
+	if alreadySeenMapping {
+		level.Debug(m.logger).Log("msg", "mapping caching, seen before", "buildID", buildID)
+		m.referencedMappings += 1
+	} else {
+		level.Debug(m.logger).Log("msg", "mapping caching, new", "buildID", buildID)
+		m.buildIDMapping[buildID] = m.executableID
+	}
+
+	return m.buildIDMapping[buildID], alreadySeenMapping
+}
+
+// resetInFlightBuffer zeroes and resets the length of the
+// in-flight shard.
+func (m *bpfMaps) resetInFlightBuffer() error {
+	// Reset first
+	m.unwindInfoBuf.Reset()
+
+	// Zero it.
+	zero := uint64(0)
+	// This is a waste of CPU (+allocs).
+	for i := 0; i < maxUnwindTableSize; i++ {
+		// .pc.
+		if err := binary.Write(m.unwindInfoBuf, m.byteOrder, zero); err != nil {
+			return fmt.Errorf("write unwindInfoBuf .pc bytes: %w", err)
+		}
+		// rest of the fields.
+		if err := binary.Write(m.unwindInfoBuf, m.byteOrder, zero); err != nil {
+			return fmt.Errorf("write unwindInfoBuf <rest> bytes: %w", err)
+		}
+	}
+
+	// Reset again.
+	m.unwindInfoBuf.Reset()
+	return nil
+}
+
+// PersistUnwindTable writes the current in-flight, writable shard
+// to the corresponding BPF map's shard.
+//
+// Note: as of now, this must be called in two situations:
+//   - In the callsite, once we are done with generating the unwind
+//     tables.
+//   - Whenever the current in-flight shard is full, before we wipe
+//     it and start reusing it.
+func (m *bpfMaps) PersistUnwindTable() error {
+	totalRows := uintptr(m.unwindInfoBuf.Len()) / unsafe.Sizeof(unwind.CompactUnwindTableRow{})
+	if totalRows > maxUnwindTableSize {
+		panic("totalRows > maxUnwindTableSize should never happen")
+	}
+	level.Debug(m.logger).Log("msg", "PersistUnwindTable called", "live unwind rows", totalRows)
+
+	if totalRows == 0 {
+		return nil
+	}
+
+	shardIndex := m.shardIndex
+
+	err := m.unwindTables.Update(unsafe.Pointer(&shardIndex), unsafe.Pointer(&m.unwindInfoBuf.Bytes()[0]))
+	if err != nil {
+		if errors.Is(err, syscall.E2BIG) {
+			if err := m.resetUnwindState(); err != nil {
+				level.Error(m.logger).Log("msg", "resetUnwindState failed", "err", err)
+				return err
+			}
+			return nil
+		}
+		return fmt.Errorf("update unwind tables: %w", err)
+	}
+
+	return nil
+}
+
+func (m *bpfMaps) resetUnwindState() error {
+	m.processCache = burrow.New()
+	m.buildIDMapping = make(map[string]uint64)
+	m.shardIndex = 0
+	m.executableID = 0
+	if err := m.resetInFlightBuffer(); err != nil {
+		level.Error(m.logger).Log("msg", "resetInFlightBuffer failed", "err", err)
+	}
+
+	m.lowIndex = 0
+	m.highIndex = 0
+	// Other stats
+	m.totalEntries = 0
+	m.uniqueMappings = 0
+	m.referencedMappings = 0
+
+	// TODO(javierhonduco): Ensure we reset everything, including:
+	// - process
+	// - shards
+	// - heap
+	// - stats
+	// etc.
+	if err := m.cleanProcessInfo(); err != nil {
+		level.Error(m.logger).Log("msg", "cleanProcessInfo failed", "err", err)
+		return err
+	}
+	if err := m.cleanShardInfo(); err != nil {
+		level.Error(m.logger).Log("msg", "cleanShardInfo failed", "err", err)
+		return err
+	}
+	if err := m.clean(); err != nil {
+		level.Error(m.logger).Log("msg", "clean failed", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+// availableEntries returns how many entries we have left
+// in the in-flight shard.
+func (m *bpfMaps) availableEntries() uint64 {
+	return maxUnwindTableSize - m.highIndex
+}
+
+// assertInvariants checks that some invariants that should
+// always be true during the execution of the program are held.
+func (m *bpfMaps) assertInvariants() {
+	if m.highIndex > maxUnwindTableSize {
+		panic("m.highIndex > 250k, this should never happen")
+	}
+	if uintptr(m.unwindInfoBuf.Len())/unsafe.Sizeof(unwind.CompactUnwindTableRow{}) >= maxUnwindTableSize {
+		panic("unwindInfoBuf has more than 250k entries")
+	}
+	if m.availableEntries() == 0 {
+		panic("no space left in the in-flight shard, this should never happen")
+	}
+}
+
+// setUnwindTableForMapping sets all the necessary metadata and unwind tables, if needed
+// to make DWARF unwinding work, such as:
+//
+//   - Continue appending information to the executable mapping information for a process.
+//   - Add mapping information.
+//   - If unwind table is already present, we are done here, otherwise, we generate the
+//     unwind table for this executable and write to the in-flight shard.
+//
+// Notes:
+// -
+// - This function is *not* safe to be called concurrently.
+func (m *bpfMaps) setUnwindTableForMapping(pid int, mapping *unwind.ExecutableMapping, procInfoBuf *bytes.Buffer) error {
+	level.Debug(m.logger).Log("msg", "setUnwindTable called", "shards", m.shardIndex, "max shards", unwindTableMaxEntries, "sum of unwind rows", m.totalEntries)
+
+	// Deal with mappings that are not filed backed. They don't have unwind
+	// information.
+	if mapping.IsNotFileBacked() {
+		var type_ uint64
+		if mapping.IsJitted() {
+			level.Debug(m.logger).Log("msg", "jit section", "pid", pid)
+			type_ = 1
+		}
+		if mapping.IsSpecial() {
+			level.Debug(m.logger).Log("msg", "special section", "pid", pid)
+			type_ = 2
+		}
+
+		err := m.writeMapping(procInfoBuf, mapping.LoadAddr, mapping.StartAddr, mapping.EndAddr, uint64(0), type_)
+		if err != nil {
+			return fmt.Errorf("writing mappings failed with %w", err)
+		}
+		return nil
+	}
+
+	// Deal with mappings that are backed by a file and might contain unwind
+	// information.
+	fullExecutablePath := path.Join("/proc/", fmt.Sprintf("%d", pid), "/root/", mapping.Executable)
+
+	elfFile, err := elf.Open(fullExecutablePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("elf.Open failed: %w", err)
+	}
+	buildID, err := buildid.BuildID(&buildid.ElfFile{File: elfFile, Path: fullExecutablePath})
+	if err != nil {
+		return fmt.Errorf("BuildID failed %s: %w", fullExecutablePath, err)
+	}
+
+	// Find the adjusted load address.
+	aslrElegible := executable.IsASLRElegibleElf(elfFile)
+
+	adjustedLoadAddress := uint64(0)
+	if mapping.IsMainObject() {
+		level.Debug(m.logger).Log("msg", "dealing with main object", "mapping", mapping)
+
+		if aslrElegible {
+			adjustedLoadAddress = mapping.LoadAddr
+		}
+	} else {
+		adjustedLoadAddress = mapping.LoadAddr
+	}
+
+	level.Debug(m.logger).Log("msg", "adding memory mappings in for executable", "executableID", m.executableID, "buildID", buildID, "executable", mapping.Executable)
+
+	// Add the memory mapping information.
+	foundexecutableID, mappingAlreadySeen := m.mappingID(buildID)
+
+	err = m.writeMapping(procInfoBuf, adjustedLoadAddress, mapping.StartAddr, mapping.EndAddr, foundexecutableID, uint64(0))
+	if err != nil {
+		return fmt.Errorf("writing mappings failed with %w", err)
+	}
+
+	// Generated and add the unwind table, if needed.
+	if !mappingAlreadySeen {
+		unwindShardsKeyBuf := new(bytes.Buffer)
+		unwindShardsValBuf := new(bytes.Buffer)
+
+		// ==================================== generate unwind table
+
+		// PERF(javierhonduco): Not reusing a buffer here yet, let's profile and decide whether this
+		// change would be worth it.
+		ut, minCoveredPc, maxCoveredPc, err := m.generateCompactUnwindTable(fullExecutablePath, mapping)
+		if err != nil {
+			if errors.Is(err, unwind.ErrNoFDEsFound) {
+				// is it ok to return here?
+				return nil
+			}
+			if errors.Is(err, unwind.ErrEhFrameSectionNotFound) {
+				// is it ok to return here?
+				return nil
+			}
+			return nil
+		}
+
+		if len(ut) == 0 {
+			return nil
+		}
+
+		threshold := min(uint64(len(ut)), m.availableEntries())
+		currentChunk := ut[:threshold]
+		restChunks := ut[threshold:]
+
+		numShards := len(ut) / maxUnwindTableSize
+		// The above numShards is correct if the unwind table we want to add
+		// snugly fits in the available space. We occupy one more shard if we
+		// don't have an empty live shard and if don't perfectly fit in the
+		// available space.
+		if m.highIndex%maxUnwindTableSize == 0 && uint64(len(ut)) > m.availableEntries() {
+			numShards++
+		}
+
+		// .len
+		if err := binary.Write(unwindShardsValBuf, m.byteOrder, uint64(numShards)); err != nil {
+			return fmt.Errorf("write shards .len bytes: %w", err)
+		}
+
+		chunkIndex := 0
+
+		for {
+			m.assertInvariants()
+
+			level.Debug(m.logger).Log("current chunk size", len(currentChunk))
+			level.Debug(m.logger).Log("rest of chunk size", len(restChunks))
+
+			m.totalEntries += uint64(len(currentChunk))
+
+			if len(currentChunk) == 0 {
+				level.Debug(m.logger).Log("msg", "done with the last chunk")
+				break
+			}
+
+			m.highIndex += uint64(len(currentChunk))
+			level.Debug(m.logger).Log("lowindex", m.lowIndex)
+			level.Debug(m.logger).Log("highIndex", m.highIndex)
+
+			// ======================== shard info ===============================
+
+			level.Debug(m.logger).Log("executableID", m.executableID, "executable", mapping.Executable, "current shard", chunkIndex)
+
+			if err := binary.Write(unwindShardsKeyBuf, m.byteOrder, m.executableID); err != nil {
+				return fmt.Errorf("write shards key bytes: %w", err)
+			}
+
+			// Dealing with the first chunk, we must add the lowest known PC.
+			minPc := currentChunk[0].Pc()
+			if chunkIndex == 0 {
+				minPc = minCoveredPc
+			}
+			// .low_pc
+			if err := binary.Write(unwindShardsValBuf, m.byteOrder, minPc); err != nil {
+				return fmt.Errorf("write shards .low_pc bytes: %w", err)
+			}
+
+			// Dealing with the last chunk, we must add the highest known PC.
+			maxPc := currentChunk[len(currentChunk)-1].Pc()
+			if chunkIndex == numShards {
+				maxPc = maxCoveredPc
+			}
+			// .high_pc
+			if err := binary.Write(unwindShardsValBuf, m.byteOrder, maxPc); err != nil {
+				return fmt.Errorf("write shards .high_pc bytes: %w", err)
+			}
+
+			// .shard_index
+			if err := binary.Write(unwindShardsValBuf, m.byteOrder, m.shardIndex); err != nil {
+				return fmt.Errorf("write shards .shard_index bytes: %w", err)
+			}
+
+			// .low_index
+			if err := binary.Write(unwindShardsValBuf, m.byteOrder, m.lowIndex); err != nil {
+				return fmt.Errorf("write shards .low_index bytes: %w", err)
+			}
+			// .high_index
+			if err := binary.Write(unwindShardsValBuf, m.byteOrder, m.highIndex); err != nil {
+				return fmt.Errorf("write shards .high_index bytes: %w", err)
+			}
+
+			m.lowIndex = m.highIndex
+
+			// ====================== Write unwind table =====================
+			for _, row := range currentChunk {
+				if err := m.writeUnwindTableRow(m.unwindInfoBuf, row); err != nil {
+					return fmt.Errorf("writing unwind table row: %w", err)
+				}
+			}
+
+			// Need a new shard?
+			if m.availableEntries() == 0 {
+				level.Info(m.logger).Log("msg", "run out of space in the 'live' shard, creating a new one")
+
+				err := m.PersistUnwindTable()
+				if err != nil {
+					return fmt.Errorf("failed to write unwind table: %w", err)
+				}
+
+				m.shardIndex++
+				if err := m.resetInFlightBuffer(); err != nil {
+					level.Error(m.logger).Log("msg", "resetInFlightBuffer failed", "err", err)
+				}
+				m.lowIndex = 0
+				m.highIndex = 0
+
+				if m.shardIndex == unwindTableMaxEntries {
+					level.Error(m.logger).Log("msg", "Not enough shards - this is not implemented but we should deal with this")
+				}
+			}
+
+			// Recalculate for next iteration
+			threshold := min(uint64(len(restChunks)), m.availableEntries())
+			currentChunk = restChunks[:threshold]
+			restChunks = restChunks[threshold:]
+
+			chunkIndex++
+		}
+
+		if err := m.unwindShards.Update(
+			unsafe.Pointer(&unwindShardsKeyBuf.Bytes()[0]),
+			unsafe.Pointer(&unwindShardsValBuf.Bytes()[0])); err != nil {
+			return fmt.Errorf("failed to update unwind shard: %w", err)
+		}
+
+		m.executableID++
+		m.uniqueMappings++
+	}
 
 	return nil
 }

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -17,20 +17,16 @@ package unwind
 import (
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
 )
 
 func TestBuildUnwindTable(t *testing.T) {
-	logger := log.NewNopLogger()
-	utb := NewUnwindTableBuilder(logger)
-
-	fdes, err := utb.readFDEs("../../../testdata/out/basic-cpp")
+	fdes, err := ReadFDEs("../../../testdata/out/basic-cpp")
 	require.NoError(t, err)
 
-	unwindTable := utb.buildUnwindTable(fdes)
+	unwindTable := BuildUnwindTable(fdes)
 	require.Equal(t, 38, len(unwindTable))
 
 	require.Equal(t, uint64(0x401020), unwindTable[0].Loc)
@@ -47,12 +43,10 @@ func benchmarkParsingDwarfUnwindInformation(b *testing.B, executable string) {
 	b.Helper()
 	b.ReportAllocs()
 
-	logger := log.NewNopLogger()
 	var rbpOffset int64
-	utb := NewUnwindTableBuilder(logger)
 
 	for n := 0; n < b.N; n++ {
-		fdes, err := utb.readFDEs(executable)
+		fdes, err := ReadFDEs(executable)
 		if err != nil {
 			panic("could not read FDEs")
 		}


### PR DESCRIPTION
This commit reworks the current DWARF-based unwinder and surrounding userspace facilities to deal with unwind tables per executable, rather than per process. It also removes the need to specify the processes names, only `--experimental-enable-dwarf-unwinding` is required.

The main benefits of this change are:

- Improved efficiency. We don't need to globally sort all the unwind entries, which in some cases resulted in a nontrivial CPU sorting millions of items. We also only produce the unwind tables for every unique executable once, and just add some metadata when a process contains a known mapping. We can completely skip the parsing of DWARF information as well as the interpretation to generate the table. This is a major win as most libraries are, well, shared, such as `libc`! :)
- Better space utilisation, as we use every single byte per shard. Before we were using a new shard for every new unwind table, without using the rest of the available space in the current shard. Most of the space was wasted before.

With this proposed approach, using ~200MB of kernel memory for the unwind table shards, we can store up to 12.5M unwind rows. Tests on my relatively busy machine showed that I only used half of the available space.

Now we have the following graph:

```
	process -> _n_ mappings -> _m_ chunks -> each stored in a shard
```

Beyond the changes above, in previous commits, the process mapping helpers got correctness improvements, while adding thorough tests and making the code simpler.

Simplifying the code and making it more correct is one of the shared goals for these changes, too.

Fixes https://github.com/parca-dev/parca-agent/issues/1052.

Additional changes
==================

Added a new clang-format configuration to allow for twice as many characters in a line to increase reliability. We all have big monitors nowadays, don't we? :D

What's not in scope
===================

- Some memory allocations are not reused, and we do them again and again, but they don't show up in profiles yet, so I haven't optimised them. Will keep an eye on these and see if this changes in production.

- Some other low-level optimisations haven't been done because they haven't been needed yet, such as improved `binary.Write`, or faster zeroing of buffers.

Future work
===========

- Continue polishing this feature;
- Properly dealing with all shards used. Right now we just clean up most of the things, but we don't ensure we give a fair chance for other processes to be profiled, too;
- More automated tests to ensure stack correctness;
- Processes with more than 120 executable mappings aren't supported yet;
- Improved metrics;
- JIT support;

Among many others!

Test plan
=========

```
$ bin/parca
```

```
$ sudo bpftool prog tracelog | tee bpf_logs.txt
```

Not unexpected errors showed up.

```
$ make && make debug/build && sudo dist/parca-agent-debug --node=test --remote-store-insecure  --remote-store-address=127.0.0.1:7070 --experimental-enable-dwarf-unwinding
```

All profiles appeared as expected with 0 reported errors.

**Python**
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/959128/215542957-f5533cf4-f0e1-4a96-a8ff-8d77a333ea14.png">

**Node.js**

<img width="1704" alt="image" src="https://user-images.githubusercontent.com/959128/215543036-419da3e7-5b04-44d7-ac95-bbcbf8ccb0a0.png">



Automated tests
===============

```
$ make test
```

```
$ make vmtest
[...
=============
Test results:
=============
- ✅ 5.4
- ✅ 5.10
- ✅ 5.18
- ✅ 5.19]
```

Both passed.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>