### PR TITLE
Fail if the CPU is big endian

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -50,6 +51,7 @@ import (
 
 	"github.com/parca-dev/parca-agent/pkg/agent"
 	"github.com/parca-dev/parca-agent/pkg/buildinfo"
+	"github.com/parca-dev/parca-agent/pkg/byteorder"
 	"github.com/parca-dev/parca-agent/pkg/config"
 	"github.com/parca-dev/parca-agent/pkg/debuginfo"
 	"github.com/parca-dev/parca-agent/pkg/discovery"
@@ -162,6 +164,11 @@ func main() {
 
 	if flags.ExperimentalEnableDWARFUnwinding && runtime.GOARCH == "arm64" {
 		level.Error(logger).Log("msg", "DWARF-unwinder support for ARM64 is currently in progress. See https://github.com/parca-dev/parca-agent/issues/1209")
+		os.Exit(1)
+	}
+
+	if byteorder.GetHostByteOrder() == binary.BigEndian {
+		level.Error(logger).Log("msg", "big endian CPUs are not supported")
 		os.Exit(1)
 	}
 

--- a/pkg/byteorder/byteorder.go
+++ b/pkg/byteorder/byteorder.go
@@ -15,24 +15,11 @@ package byteorder
 
 import (
 	"encoding/binary"
-	"sync"
 	"unsafe"
 )
 
-var (
-	byteOrder binary.ByteOrder
-	once      sync.Once
-)
-
-// GetHostByteOrder returns the current byte-order.
+// GetHostByteOrder returns the endianness of the CPU.
 func GetHostByteOrder() binary.ByteOrder {
-	once.Do(func() {
-		byteOrder = determineHostByteOrder()
-	})
-	return byteOrder
-}
-
-func determineHostByteOrder() binary.ByteOrder {
 	var i int32 = 0x01020304
 	u := unsafe.Pointer(&i)
 	pb := (*byte)(u)


### PR DESCRIPTION
As both arm64 and x86_64 are little endian. While some arm64 processors support changing the their endianness, most implementations chose little endian.

Later on, we can change all the `binary.Write`s to have the endianness hardcoded.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>