### PR TITLE
pkg/profiler/cpu: skip samples with errored user stacks

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -580,6 +580,7 @@ func (p *CPU) obtainProfiles(ctx context.Context) ([]*profiler.Profile, error) {
 					p.metrics.obtainMapAttempts.WithLabelValues(labelUser, labelDwarfUnwind, labelMissing).Inc()
 				}
 				p.metrics.obtainMapAttempts.WithLabelValues(labelUser, labelDwarfUnwind, labelSuccess).Inc()
+				continue
 			}
 		} else {
 			// Stacks retrieved with the kernel's included frame pointer based unwinder.
@@ -595,6 +596,7 @@ func (p *CPU) obtainProfiles(ctx context.Context) ([]*profiler.Profile, error) {
 				if errors.Is(userErr, errMissing) {
 					p.metrics.obtainMapAttempts.WithLabelValues(labelUser, labelKernelUnwind, labelMissing).Inc()
 				}
+				continue
 			}
 			p.metrics.obtainMapAttempts.WithLabelValues(labelUser, labelKernelUnwind, labelSuccess).Inc()
 		}


### PR DESCRIPTION
Long story short, profiling a hot box with lots of different processes might result in more than `MAX_STACK_COUNTS_ENTRIES` entries in the stack_counts map.

When that happens we don't store this profile, but because it might exist, we don't error.

In userspace, we attempt to read this ID, which was never written to the map, hence failing. The issue stems from that code, if there are any issues reading the user stack, with continue with the rest of the sample, when we should just drop it on the floor.

The samples would then look odd, as they would miss the user components and their mappings. Zeroes will be added on the left and some children nodes would not sum to ~100% of the parent.

Another question is whether we should use `BPF_ANY` instead of `BPF_NOEXIST`. We can leave that discussion and can go to another PR if we decide to change it.

Test Plan
=======

**before**

<img width="506" alt="image" src="https://user-images.githubusercontent.com/959128/215546096-86922340-2fdd-48ed-8cce-17593a7bf114.png">

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>