### PR TITLE
Do not enable pprof profiling until BPF program is loaded

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -103,6 +103,9 @@ type CPU struct {
 
 	debugProcessNames    []string
 	enableDWARFUnwinding bool
+
+	// Notify that the BPF program was loaded.
+	bpfProgramLoaded chan bool
 }
 
 func NewCPUProfiler(
@@ -119,6 +122,7 @@ func NewCPUProfiler(
 	memlockRlimit uint64,
 	debugProcessNames []string,
 	enableDWARFUnwinding bool,
+	bpfProgramLoaded chan bool,
 ) *CPU {
 	return &CPU{
 		logger: logger,
@@ -146,6 +150,8 @@ func NewCPUProfiler(
 
 		debugProcessNames:    debugProcessNames,
 		enableDWARFUnwinding: enableDWARFUnwinding,
+
+		bpfProgramLoaded: bpfProgramLoaded,
 	}
 }
 
@@ -247,6 +253,8 @@ func (p *CPU) Run(ctx context.Context) error {
 	if err := m.BPFLoadObject(); err != nil {
 		return fmt.Errorf("load bpf object: %w", err)
 	}
+
+	p.bpfProgramLoaded <- true
 
 	// Get bpf metrics
 	agentProc, err := procfs.Self() // pid of parca-agent


### PR DESCRIPTION
Set the pprof profile handler only once we have loaded our BPF program to avoid SIGPROFs [1] while we are loading it which results in increased loading time in the best scenario, and failure to start the Agent in the worst case.

Loading our program takes a little bit, mostly due to the verification process, and if any signals are received during that time, the kernel will abort the loading process [2] and return with -EAGAIN. Libbpf will retry up to 5 times [3], and then return the error.

1: https://github.com/golang/go/blob/2ab0e04681332c88e1bfb5fe5a72d35c1c5aae8a/src/runtime/proc.go#L4658
2: https://github.com/torvalds/linux/blob/master/kernel/bpf/verifier.c#L13793-L13794
3: https://github.com/libbpf/libbpf/blob/d73ecc91e1f9a2f2782e00f010a5a0d6abec09a4/src/bpf.h#L68-L69

Test Plan
=========

```bash
$ while true; do curl http://127.0.0.1:7071/debug/pprof/profile; done
```

No sigprofs are delivered until the BPF program is loaded (notice there are multiple BPF programs loaded by libbpf to calibrate different features):

```dtrace
# can be run with bpftrace ./file
uprobe:/proc/<PARCA_AGENT_PID>/exe:sys_bpf_prog_load { 
  @loaded=1;
  printf("BPF LOAD CALLED\n");
} 

tracepoint:signal:signal_deliver 
/comm == "parca-agent-deb" && args->sig == 27/ {  # SIGPROF
  printf("sigprof. loaded: %d (might have already been loaded)\n", @loaded); # for this to work has to be run as soon as parca agent is executed, otherwise we might miss the probe. Running it under GDB with a breakpoint in main and continuing from there does the trick
}
```

```
Attaching 2 probes...
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
BPF LOAD CALLED
sigprof. loaded: 1 (might have already been loaded)
sigprof. loaded: 1 (might have already been loaded)
sigprof. loaded: 1 (might have already been loaded)
sigprof. loaded: 1 (might have already been loaded)
sigprof. loaded: 1 (might have already been loaded)
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>