### PR TITLE
Discover java processes via hsperfdata

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -421,6 +421,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			metadata.Target(flags.Node, flags.MetadataExternalLabels),
 			metadata.Compiler(),
 			metadata.Process(pfs),
+			metadata.JavaProcess(logger),
 			metadata.System(),
 			metadata.PodHosts(),
 		},

--- a/pkg/hsperfdata/hsperfdata.go
+++ b/pkg/hsperfdata/hsperfdata.go
@@ -1,0 +1,150 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package hsperfdata
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/parca-dev/parca-agent/pkg/perf"
+)
+
+const hsperfdata = "/tmp/hsperfdata_*"
+
+type Cache struct {
+	pids   map[int]struct{}
+	fs     fs.FS
+	logger log.Logger
+	mu     sync.Mutex
+	nsPID  map[int]int
+	group  singleflight.Group
+}
+
+type realfs struct{}
+
+func (f *realfs) Open(name string) (fs.File, error) {
+	return os.Open(name)
+}
+
+func NewCache(logger log.Logger) *Cache {
+	return &Cache{
+		pids:   make(map[int]struct{}),
+		fs:     &realfs{},
+		logger: logger,
+		nsPID:  map[int]int{},
+	}
+}
+
+func (c *Cache) Exists(pid int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	_, ok := c.pids[pid]
+	return ok
+}
+
+// IsJavaProcess returns true if the hsperfdata file exists for a given pid.
+// It first searches in all hsperfdata user directories for the processes
+// running on host and then searches in /proc/{pid}/root/tmp for processes
+// running in containers. Note that pids are assumed to be unique regardless
+// of username.
+func (c *Cache) IsJavaProcess(pid int) (bool, error) {
+	// Check if the pid is in the cache.
+	if c.Exists(pid) {
+		return true, nil
+	}
+
+	// Use singleflight to prevent concurrent requests for the same pid
+	ch := c.group.DoChan(strconv.Itoa(pid), func() (interface{}, error) {
+		// Fast path to find the processes running on the host.
+		// List all directories that match the pattern /tmp/hsperfdata_*
+		dirs, err := filepath.Glob(hsperfdata)
+		if err != nil {
+			return false, fmt.Errorf("failed to list directories: %w", err)
+		}
+
+		// Loop over all directories and search for the hsperfdata file for the given pid
+		for _, dir := range dirs {
+			hsperfdataPath := filepath.Join(dir, strconv.Itoa(pid))
+			if path, err := c.fs.Open(hsperfdataPath); err == nil {
+				defer path.Close()
+				c.pids[pid] = struct{}{}
+				return true, nil
+			}
+		}
+
+		// Slow path for the processes running in containers.
+		// Search for the pid via nspids.
+		nsPid, found := c.nsPID[pid]
+		if !found {
+			nsPids, err := perf.FindNSPIDs(c.fs, pid)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return false, fmt.Errorf("%w when reading status", perf.ErrProcNotFound)
+				}
+				return false, err
+			}
+			// If we didn't find the pid in the root PID namespace, try to find it in the
+			// namespaces of the process. Store the namespace PID in the nsPID map to
+			// avoid searching for it again in the future.
+			// Note that the PID of the root PID namespace will always be the last element
+			// in the slice returned by perf.FindNSPIDs.
+			c.nsPID[pid] = nsPids[len(nsPids)-1]
+			nsPid = c.nsPID[pid]
+		}
+
+		// TODO(vthakkar): Check for the process mount point.
+		perfdataFiles := fmt.Sprintf("/proc/%d/root/tmp/", pid)
+
+		files, err := os.ReadDir(perfdataFiles)
+		if err != nil {
+			return false, fmt.Errorf("error reading %s: %w", perfdataFiles, err)
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				if name := f.Name(); strings.HasPrefix(name, "hsperfdata") {
+					if path, err := c.fs.Open(filepath.Join(perfdataFiles, name, strconv.Itoa(nsPid))); err == nil {
+						defer path.Close()
+						c.pids[pid] = struct{}{}
+						return true, nil
+					}
+				}
+			}
+		}
+		return false, nil
+	})
+
+	result := <-ch
+	if result.Err != nil {
+		return false, result.Err
+	}
+
+	val, ok := result.Val.(bool)
+	if !ok {
+		return false, fmt.Errorf("failed to convert the result to bool")
+	}
+
+	return val, nil
+}

--- a/pkg/metadata/java_process.go
+++ b/pkg/metadata/java_process.go
@@ -1,0 +1,43 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+
+	"github.com/parca-dev/parca-agent/pkg/hsperfdata"
+)
+
+func JavaProcess(logger log.Logger) Provider {
+	return &StatelessProvider{"java process", func(pid int) (model.LabelSet, error) {
+		cache := hsperfdata.NewCache(logger)
+
+		java, err := cache.IsJavaProcess(pid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine if PID %d belongs to a java process: %w", pid, err)
+		}
+
+		if !java {
+			return nil, nil
+		}
+
+		return model.LabelSet{
+			"java": model.LabelValue(fmt.Sprintf("%t", java)),
+		}, nil
+	}}
+}

--- a/pkg/perf/perf.go
+++ b/pkg/perf/perf.go
@@ -166,7 +166,7 @@ func (p *cache) MapForPID(pid int) (*Map, error) {
 
 	nsPid, found := p.nsPID[pid]
 	if !found {
-		nsPids, err := findNSPIDs(p.fs, pid)
+		nsPids, err := FindNSPIDs(p.fs, pid)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("%w when reading status", ErrProcNotFound)
@@ -222,7 +222,7 @@ func (p *cache) MapForPID(pid int) (*Map, error) {
 	return &m, nil
 }
 
-func findNSPIDs(fs fs.FS, pid int) ([]int, error) {
+func FindNSPIDs(fs fs.FS, pid int) ([]int, error) {
 	f, err := fs.Open(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		return nil, err

--- a/pkg/perf/perf_test.go
+++ b/pkg/perf/perf_test.go
@@ -76,7 +76,7 @@ func TestFindNSPid(t *testing.T) {
 		"/proc/25803/status": mustReadFile("testdata/proc-status"),
 	})
 
-	pid, err := findNSPIDs(fs, 25803)
+	pid, err := FindNSPIDs(fs, 25803)
 	require.NoError(t, err)
 
 	require.Equal(t, []int{25803, 1}, pid)


### PR DESCRIPTION
Fixes: #1306 

Java Hotspot VM provides telemetry data through jvmstat performace counters and publishes it through a memory-mapped file in a temp directory /tmp/hsperfdata_{user}/{pid}. Currently, in parca-agent there is no way to determine if a certain process is a Java process. So above naming convention will help us to find running Java processes in the system as well as add it as a metadata.

Proposed PR does the following things:
- For the given pid it searches in the global /tmp/ directory first to check in case process is being run on a host
- If not then it searches for the associated NSPid to find the hsperfdata file associated with the pid
- It also adds a new metadata label 'java', see #1366 for more details 

Output from `jps`:
![Screenshot from 2023-02-27 06-24-56](https://user-images.githubusercontent.com/7105009/221480891-55efb947-7772-4455-9d3e-981d0dfbc753.png)

Parca-agent output for the process running on host:
![Screenshot from 2023-02-27 05-05-18](https://user-images.githubusercontent.com/7105009/221481090-f3267609-18e5-433b-8be3-c84538b806db.png)

Parca-agent output for the process running in the container:
![Screenshot from 2023-02-28 08-28-38](https://user-images.githubusercontent.com/7105009/221785526-d39a4760-d0ac-4f5f-812a-5a2fd7188365.png)


P.S. Applications for testing - https://github.com/v-thakkar/Java-testing

