### PR TITLE
Frame pointer detection caching

### DIFF
--- a/pkg/stack/unwind/executable.go
+++ b/pkg/stack/unwind/executable.go
@@ -16,12 +16,84 @@ package unwind
 
 import (
 	"debug/elf"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"syscall"
 
+	burrow "github.com/goburrow/cache"
 	"github.com/hashicorp/go-version"
 	"github.com/xyproto/ainur"
 )
+
+type FramePointerCache struct {
+	cache burrow.Cache
+}
+
+// The inode value can be recycled (this behavior is filesystem specific)
+// and it's only guaranteed to be unique within each filesystem. By adding
+// the change time, which gets updated every time the file or its medatadata
+// are modified + the inode we significantly reduce the chances of collisions.
+//
+// Replacing the file in-place might result in the same inode being used, but
+// the change time will most likely be different.
+type framePointerCacheKey struct {
+	inode        uint64
+	creationTime syscall.Timespec
+}
+
+func (fpc *FramePointerCache) cacheKey(executable string) (framePointerCacheKey, error) {
+	fileinfo, err := os.Stat(executable)
+	if err != nil {
+		return framePointerCacheKey{}, err
+	}
+
+	stat, ok := fileinfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return framePointerCacheKey{}, errors.New("fileinfo didn't have stat_t")
+	}
+
+	return framePointerCacheKey{
+		inode:        stat.Ino,
+		creationTime: stat.Ctim,
+	}, nil
+}
+
+func (fpc *FramePointerCache) HasFramePointers(executable string) (bool, error) {
+	cacheKey, err := fpc.cacheKey(executable)
+	if err != nil {
+		return false, err
+	}
+
+	val, found := fpc.cache.GetIfPresent(cacheKey)
+	if found {
+		cachedHasFramePointers, ok := val.(bool)
+		if !ok {
+			panic("Non-bool found in frame pointer cache. This should never happen.")
+		}
+
+		return cachedHasFramePointers, nil
+	}
+
+	hasFramePointers, err := HasFramePointers(executable)
+	if err != nil {
+		return false, err
+	}
+
+	fpc.cache.Put(cacheKey, hasFramePointers)
+	return hasFramePointers, nil
+}
+
+func NewHasFramePointersCache() FramePointerCache {
+	return FramePointerCache{
+		// 8 bytes for the hash + 3 * 8 bytes for the actual key (inode: uint64
+		// syscall.Timespec: 2x int64) + size of value (bool: 1x byte)
+		// => 33 bytes
+		// => 33 bytes * 10_000 entries = 0.330 KB (excluding metadata from the map).
+		cache: burrow.New(burrow.WithMaximumSize(10_000)),
+	}
+}
 
 func HasFramePointers(executable string) (bool, error) {
 	elf, err := elf.Open(executable)

--- a/pkg/stack/unwind/executable_test.go
+++ b/pkg/stack/unwind/executable_test.go
@@ -33,3 +33,32 @@ func TestHasFramePointersInCApplication(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, hasFp)
 }
+
+func TestHasFramePointersCache(t *testing.T) {
+	fpCache := NewHasFramePointersCache()
+
+	// Ensure that the cached results are correct.
+	{
+		hasFp, err := fpCache.HasFramePointers("../../../testdata/out/basic-cpp")
+		require.NoError(t, err)
+		require.False(t, hasFp)
+	}
+
+	{
+		hasFp, err := fpCache.HasFramePointers("../../../testdata/out/basic-cpp")
+		require.NoError(t, err)
+		require.False(t, hasFp)
+	}
+
+	{
+		hasFp, err := fpCache.HasFramePointers("/proc/self/exe")
+		require.NoError(t, err)
+		require.True(t, hasFp)
+	}
+
+	{
+		hasFp, err := fpCache.HasFramePointers("/proc/self/exe")
+		require.NoError(t, err)
+		require.True(t, hasFp)
+	}
+}


### PR DESCRIPTION
As of right now it uses 50% of CPU cycles in Demo. We only saw it there as
it seems that the disks we use there are very slow.

Test Plan
=========
Ran the agent for a while with zero issues. Let's push this change to
the Demo environment and ensure that we are getting the performance wins
we expect.

Running locally:

<img width="1796" alt="image" src="https://user-images.githubusercontent.com/959128/216950348-f2046c1b-fd45-4a43-9f7a-11e841c3df5f.png">


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>