### PR TITLE
pkg/metadata: Add PodHosts provider to provide pod_ip and pod

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -388,6 +388,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			metadata.Compiler(),
 			metadata.Process(),
 			metadata.System(),
+			metadata.PodHosts(),
 		},
 		cfg.RelabelConfigs,
 		flags.ProfilingDuration, // Cache durations are calculated from profiling duration.

--- a/pkg/metadata/pod_hosts.go
+++ b/pkg/metadata/pod_hosts.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metadata
 
 import (
@@ -11,9 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-var (
-	hostname string
-)
+var hostname string
 
 func init() {
 	local, err := getExternalIpAndHost(1)
@@ -24,7 +35,7 @@ func init() {
 }
 
 // PodHosts provide host ip in default
-// and will provide pod_ip and pod if pid is a pod
+// and will provide pod_ip and pod if pid is a pod.
 func PodHosts() Provider {
 	return &StatelessProvider{"hosts", func(pid int) (model.LabelSet, error) {
 		e, err := getExternalIpAndHost(pid)

--- a/pkg/metadata/pod_hosts.go
+++ b/pkg/metadata/pod_hosts.go
@@ -1,0 +1,83 @@
+package metadata
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/prometheus/common/model"
+)
+
+var (
+	hostname string
+)
+
+func init() {
+	local, err := getExternalIpAndHost(1)
+	if err != nil {
+		panic(err)
+	}
+	hostname = local.hostname
+}
+
+// PodHosts provide host ip in default
+// and will provide pod_ip and pod if pid is a pod
+func PodHosts() Provider {
+	return &StatelessProvider{"hosts", func(pid int) (model.LabelSet, error) {
+		e, err := getExternalIpAndHost(pid)
+		if err != nil {
+			return nil, err
+		}
+		if hostname != e.hostname {
+			// pod
+			return model.LabelSet{
+				"pod_ip": model.LabelValue(e.ip),
+				"pod":    model.LabelValue(e.hostname),
+			}, nil
+		}
+		return nil, nil
+	}}
+}
+
+type hostEntry struct {
+	ip       string
+	hostname string
+}
+
+func getExternalIpAndHost(pid int) (*hostEntry, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/root/etc/hosts", pid))
+	if err != nil {
+		return nil, err
+	}
+	hostEntrys, err := parseHosts(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	if len(hostEntrys) == 0 {
+		return nil, fmt.Errorf("read hosts file result nil, raw:%s", string(data))
+	}
+	return &hostEntrys[len(hostEntrys)-1], nil
+}
+
+func parseHosts(r io.Reader) ([]hostEntry, error) {
+	var res []hostEntry
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := string(s.Bytes())
+		fileds := strings.Fields(line)
+		if len(fileds) < 2 || fileds[0] == "#" {
+			continue
+		}
+		res = append(res, hostEntry{
+			ip:       fileds[0],
+			hostname: fileds[1],
+		})
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/pkg/metadata/pod_hosts_test.go
+++ b/pkg/metadata/pod_hosts_test.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metadata
 
 import (

--- a/pkg/metadata/pod_hosts_test.go
+++ b/pkg/metadata/pod_hosts_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHost(t *testing.T) {
@@ -31,7 +31,7 @@ func TestHost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, []hostEntry{
+	require.Equal(t, []hostEntry{
 		{
 			ip:       "127.0.0.1",
 			hostname: "localhost",

--- a/pkg/metadata/pod_hosts_test.go
+++ b/pkg/metadata/pod_hosts_test.go
@@ -1,0 +1,31 @@
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHost(t *testing.T) {
+	testData := `
+# Kubernetes-managed hosts file.
+127.0.0.1       localhost
+
+10.14.218.32    parca-agent-25q5t
+`
+	result, err := parseHosts(strings.NewReader(testData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, []hostEntry{
+		{
+			ip:       "127.0.0.1",
+			hostname: "localhost",
+		},
+		{
+			ip:       "10.14.218.32",
+			hostname: "parca-agent-25q5t",
+		},
+	}, result)
+}


### PR DESCRIPTION
it is not always ok to let parca-agent query k8s directly to connect pid and pod。

so we should provide pid's pod name if possible.