### PR TITLE
env.sh: update golangci-lint to v1.51.1

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -10,7 +10,7 @@ GOFUMPT_VERSION='v0.4.0'
 go install "mvdan.cc/gofumpt@${GOFUMPT_VERSION}"
 
 # renovate: datasource=go depName=github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION='v1.51.0'
+GOLANGCI_LINT_VERSION='v1.51.1'
 go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 
 # renovate: datasource=go depName=github.com/florianl/bluebox


### PR DESCRIPTION
As the current version consumes too much memory and it's OOMing my box after trying to use more than 50GB of memory.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>