### PR TITLE
Improve performance of BPF map buffer writes

### DIFF
--- a/pkg/profiler/buffer.go
+++ b/pkg/profiler/buffer.go
@@ -1,0 +1,69 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package profiler
+
+import "encoding/binary"
+
+type EfficientBuffer []byte
+
+// Slice returns a slice re-sliced from the original EfficientBuffer.
+// This is useful to efficiently write byte by byte, for example, when
+// setting BPF maps without incurring in extra allocations in the writing
+// methods, or changing the capacity of the underlying memory buffer.
+//
+// Callers are responsible to ensure that there is enough capacity left
+// for the passed size.
+func (eb *EfficientBuffer) Slice(size int) EfficientBuffer {
+	newSize := len(*eb) + size
+	subSlice := (*eb)[len(*eb):newSize]
+	// Extend its length.
+	*eb = (*eb)[:newSize]
+	return subSlice
+}
+
+// PutUint64 writes the passed uint64 in little
+// endian and advances the current slice.
+func (eb *EfficientBuffer) PutUint64(v uint64) {
+	binary.LittleEndian.PutUint64((*eb)[:8], v)
+	*eb = (*eb)[8:]
+}
+
+// PutUint32 writes the passed uint32 in little
+// endian and advances the current slice.
+func (eb *EfficientBuffer) PutUint32(v uint32) {
+	binary.LittleEndian.PutUint32((*eb)[:4], v)
+	*eb = (*eb)[4:]
+}
+
+// PutUint16 writes the passed uint16 in little
+// endian and advances the current slice.
+func (eb *EfficientBuffer) PutUint16(v uint16) {
+	binary.LittleEndian.PutUint16((*eb)[:2], v)
+	*eb = (*eb)[2:]
+}
+
+// PutInt16 writes the passed int16 in little
+// endian and advances the current slice.
+func (eb *EfficientBuffer) PutInt16(v int16) {
+	binary.LittleEndian.PutUint16((*eb)[:2], uint16(v))
+	*eb = (*eb)[2:]
+}
+
+// PutUint8 writes the passed uint8 in little
+// endian and advances the current slice.
+func (eb *EfficientBuffer) PutUint8(v uint8) {
+	(*eb)[0] = v
+	*eb = (*eb)[1:]
+}

--- a/pkg/profiler/buffer_test.go
+++ b/pkg/profiler/buffer_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package profiler
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEfficientBufferInvariants(t *testing.T) {
+	buf := make(EfficientBuffer, 0, 1000)
+	subSlice := buf.Slice(10)
+	require.Equal(t, 10, len(buf))
+	require.Equal(t, 1000, cap(buf))
+
+	require.Equal(t, 10, len(subSlice))
+	require.Equal(t, 1000, cap(subSlice))
+}
+
+func TestEfficientBufferInvariants2(t *testing.T) {
+	buf := make(EfficientBuffer, 0, 1000)
+	subSlice := buf.Slice(10)
+	subSlice.PutUint8(1)
+
+	require.Equal(t, 10, len(buf))
+	require.Equal(t, 1000, cap(buf))
+
+	require.Equal(t, 9, len(subSlice))
+	require.Equal(t, 999, cap(subSlice))
+}
+
+func TestEfficientBufferInvariant3(t *testing.T) {
+	buf := make(EfficientBuffer, 0, 1000)
+	subSlice := buf.Slice(10)
+	subSlice.PutUint8(1)
+	subSlice.PutUint8(1)
+
+	require.Equal(t, 10, len(buf))
+	require.Equal(t, 1000, cap(buf))
+
+	require.Equal(t, 8, len(subSlice))
+	require.Equal(t, 998, cap(subSlice))
+}
+
+func TestEfficientBufferAgainstBinaryWrite(t *testing.T) {
+	buf := make(EfficientBuffer, 0, 1000)
+	subSlice := buf.Slice(1000)
+	subSlice.PutUint8(111)
+	subSlice.PutUint16(222)
+	subSlice.PutUint32(333)
+	subSlice.PutUint64(444)
+
+	buf2 := bytes.NewBuffer(make([]byte, 0, 1000))
+	binary.Write(buf2, binary.LittleEndian, uint8(111))
+	binary.Write(buf2, binary.LittleEndian, uint16(222))
+	binary.Write(buf2, binary.LittleEndian, uint32(333))
+	binary.Write(buf2, binary.LittleEndian, uint64(444))
+
+	require.Equal(t, buf2.Bytes()[:15], []byte(buf[:15]))
+}
+
+func BenchmarkEfficientBufferSliceWrite(b *testing.B) {
+	b.ReportAllocs()
+
+	buf := make(EfficientBuffer, 0, b.N*8)
+	subSlice := buf.Slice(b.N * 8)
+	number := uint64(111)
+	for n := 0; n < b.N; n++ {
+		subSlice.PutUint64(number)
+	}
+}
+
+func BenchmarkBinaryWrite(b *testing.B) {
+	b.ReportAllocs()
+
+	buf := bytes.NewBuffer(make([]byte, 0, b.N*8))
+	number := uint64(111)
+	for n := 0; n < b.N; n++ {
+		binary.Write(buf, binary.LittleEndian, number)
+	}
+}


### PR DESCRIPTION
Using `binary.Write` to write to memory buffers we use to update BPF maps is not only using quite a bit of CPU cycles but also incurs quite a bit of small allocations. In particular, [every single write performs an allocation](https://github.com/golang/go/blob/02d8ebda8398342516a24a3e8435d527ed156cab/src/encoding/binary/binary.go#L345).

This commit reduces allocations to 0 and CPU cycles by ~14x by writing to the buffer without performing any allocations. We do this with a new type, defined over a byte slice, which directly writes to the buffer using the lower-level `binary` APIs.

This also introduces two other advantages:
- The underlying array backing the slice will never grow in case of bugs. We want the buffers to be static and of exactly the size we expect in BPF.
- We can zero the buffers more efficiently. We need to do this to ensure that there is no stale information in the buffers we reuse.

This new type has to be used with care as we expect the `Slice` method to request a size equal or smaller to the available capacity.

Test Plan
=========

Added unit tests, ran locally for a while with no issues and `binary.Write` barely showing up in the profiles. The new methods don't take much CPU either.

```
$ go test -v ./pkg/profiler/ -bench=. -count=30 > bench.txt
```

```
$ benchstat bench.txt
name                          time/op
EfficientBufferSliceWrite-12  2.18ns ± 4%
BinaryWrite-12                31.3ns ±26%

name                          alloc/op
EfficientBufferSliceWrite-12   8.00B ± 0%
BinaryWrite-12                 16.0B ± 0%

name                          allocs/op
EfficientBufferSliceWrite-12    0.00
BinaryWrite-12                  1.00 ± 0%
```


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>