### PR TITLE
pkg/profiler/cpu: Ignore non-existent keys

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -762,8 +762,8 @@ func (p *CPU) obtainProfiles(ctx context.Context) ([]*profiler.Profile, error) {
 		return nil, fmt.Errorf("failed iterator: %w", it.Err())
 	}
 
-	if err := p.bpfMaps.clean(); err != nil {
-		level.Warn(p.logger).Log("msg", "failed to clean BPF maps", "err", err)
+	if err := p.bpfMaps.cleanStacks(); err != nil {
+		level.Warn(p.logger).Log("msg", "failed to clean BPF maps that store stacktraces", "err", err)
 	}
 
 	profiles := []*profiler.Profile{}


### PR DESCRIPTION
Trying to delete a key that doesn't exist fails with `ENOENT`. This might happen due to race conditions. For example, stacks keep on being written while we list and remove them.

In the future, we might want to have a better mechanism to prevent races from occurring in the first place, but let's ensure that we progress and continue removing items from the map if a key is not present.

If we don't do this, we might leave the map filled with older data, and can produce broken profiles.

This commit also moves the common listing+removing functionality to its own function

Test Plan
=========

Run the agent for >1h with DWARF unwinding and several hot processes without issues:

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/959128/217487563-0b1d64d0-2721-4f01-9d20-e7ac996e54d3.png">


Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>