### PR TITLE
Add synthetic unwind row entry for the function end

### DIFF
--- a/cmd/eh-frame/main.go
+++ b/cmd/eh-frame/main.go
@@ -27,6 +27,7 @@ import (
 type flags struct {
 	Executable string `kong:"help='The executable to print the .eh_unwind tables for.'"`
 	Compact    bool   `kong:"help='Whether to use the compact format.'"`
+	RelativePC uint64 `kong:"help='Filter FDEs that contain this PC'"`
 }
 
 // This tool exists for debugging .eh_frame unwinding and its intended for Parca Agent's
@@ -45,8 +46,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	var pc *uint64
+
+	if flags.RelativePC != 0 {
+		pc = &flags.RelativePC
+	}
+
 	ptb := unwind.NewUnwindTableBuilder(logger)
-	err := ptb.PrintTable(os.Stdout, executablePath, flags.Compact)
+	err := ptb.PrintTable(os.Stdout, executablePath, flags.Compact, pc)
 	if err != nil {
 		// nolint
 		fmt.Println("failed with:", err)

--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -28,6 +28,7 @@ const (
 	cfaTypeRbp
 	cfaTypeRsp
 	cfaTypeExpression
+	cfaTypeEndFdeMarker
 )
 
 type BpfRbpType uint16
@@ -73,6 +74,10 @@ func (cutr *CompactUnwindTableRow) RbpOffset() int16 {
 	return cutr.rbpOffset
 }
 
+func (cutr *CompactUnwindTableRow) IsEndOfFDEMarker() bool {
+	return cutr.cfaType == uint8(cfaTypeEndFdeMarker)
+}
+
 type CompactUnwindTable []CompactUnwindTableRow
 
 func (t CompactUnwindTable) Len() int           { return len(t) }
@@ -93,6 +98,11 @@ func BuildCompactUnwindTable(fdes frame.FrameDescriptionEntries) (CompactUnwindT
 			}
 			table = append(table, compactRow)
 		}
+		// Add a synthetic row for the end of the function.
+		table = append(table, CompactUnwindTableRow{
+			pc:      fde.End(),
+			cfaType: uint8(cfaTypeEndFdeMarker),
+		})
 	}
 	return table, nil
 }

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -22,6 +22,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsEndOfFDEMarkerWorks(t *testing.T) {
+	row := CompactUnwindTableRow{}
+	require.False(t, row.IsEndOfFDEMarker())
+
+	row.cfaType = uint8(cfaTypeEndFdeMarker)
+	require.True(t, row.IsEndOfFDEMarker())
+}
+
 func TestCompactUnwindTable(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -58,7 +58,7 @@ func x64RegisterToString(reg uint64) string {
 }
 
 // PrintTable is a debugging helper that prints the unwinding table to the given io.Writer.
-func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact bool) error {
+func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact bool, pc *uint64) error {
 	fdes, err := ReadFDEs(path)
 	if err != nil {
 		return err
@@ -73,6 +73,12 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 
 	unwindContext := frame.NewContext()
 	for _, fde := range fdes {
+		if pc != nil {
+			if fde.Begin() > *pc || *pc > fde.End() {
+				continue
+			}
+		}
+
 		fmt.Fprintf(writer, "=> Function start: %x, Function end: %x\n", fde.Begin(), fde.End())
 
 		frameContext := frame.ExecuteDwarfProgram(fde, unwindContext)


### PR DESCRIPTION
Context
=======

DWARF unwind information specifies the low and high PC for every
function it covers. Within a function, it has entries for each
instruction boundary. These entries have the program counter they
start covering, but not its end.

This is not a problem for any instruction boundary except the last one,
but while we have that information when parsing the DWARF info, we never
add it anywhere in the BPF representation.

While this was not a problem for a large majority of the stacks we need
to unwind it introduce two issues:

- We know we've reached the bottom frame when a PC doesn't have unwind
  info + frame pointer == 0. Normally the bottom frame has a PC that's
not covered by the (lowest, highest) PCs that the unwind info has, but
as far as I know there's no guarantee of this. If we get the last item
of a chunk, we have no way to know if the PC we are interested in is
covered in the unwind info, or not;
- The other problem is that we currently have, related to the last point
  above, is that we have to chunk some unwind tables when they are too
large for the maximum size of a shard or for the current free space in a
shard. When this happens we might split a function in two. This causes
the same issues as above at every split point.

Proposed solution
=================

This commit adds a fake or synthetic unwind row to indicate the end of a
function. We then handle this appropriately in the unwinder.

Unfortunately we will increase the unwind table size, I expect by ~5-10% on
average, but haven't measured properly. While this is not ideal, we want to
ensure that the statistics we get from the unwinder as are correct as possible.

In the future we might remove some of these markers that aren't totally
necessary (e.g. if we can prove that there can't be any other PC in between
a pair of consecutive rows from different functions. This might be hard
to get 100% right on x86, but could be a possibility).

I was planning on slightly reducing the size of the unwind row, which
should help a bit with the recent size increase from this commit.

Other changes
=============

- Made the code that deals with chunking and shard allocation cleaner an
more correct.
- The `eh-frame` utility accepts a new argument to filter unwind info
  for a particular function that contains the given PC.

Test Plan
=========

<img width="1558" alt="image" src="https://user-images.githubusercontent.com/959128/218519427-3af48b34-9306-46ec-a0b5-ce7709d77066.png">

+ no errors on `sudo bpftool prog tracelog | grep err` 

Co-authored-by: Kemal Akkoyun <kakkoyun@users.noreply.github.com>
Co-authored-by: Javier Honduvilla Coto <javierhonduco@gmail.com>

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>
