### PR TITLE
bpf: Do not reuse kernel stack hash

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -498,7 +498,7 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx, u64 pid_t
   stack_key.tgid = user_tgid;
 
   // Get kernel stack.
-  int kernel_stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_REUSE_STACKID);
+  int kernel_stack_id = bpf_get_stackid(ctx, &stack_traces, 0);
   if (kernel_stack_id >= 0) {
     stack_key.kernel_stack_id = kernel_stack_id;
   }


### PR DESCRIPTION
When using `BPF_F_REUSE_STACKID` if a different stack hashes to the same hash, the old stack will be replaced with a new one. If a collision like that happens, we will get the wrong stack when finding the right kernel stack for its hash.

Right now we only have up to `MAX_STACK_TRACES_ENTRIES=1024` unique stacks, which is makes hash collitions incredibly common. This will be changed in a forthcoming commit.

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>