### PR TITLE
bpf: Increase the number unique stacks

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -27,7 +27,7 @@
 #define MAX_STACK_DEPTH 127
 _Static_assert(MAX_TAIL_CALLS *MAX_STACK_DEPTH_PER_PROGRAM >= MAX_STACK_DEPTH, "Not enough iterations to traverse the whole stack");
 // Number of unique stacks.
-#define MAX_STACK_TRACES_ENTRIES 1024
+#define MAX_STACK_TRACES_ENTRIES 64000
 // Number of items in the stack counts aggregation map.
 #define MAX_STACK_COUNTS_ENTRIES 10240
 // Maximum number of processes we are willing to track.


### PR DESCRIPTION
Right now, the current value is ~1k. We will have collisions very quickly. With 500 elements alone, we'll have a probability of almost 1 of a hash collision (see [0]), so let's bump it to 64k.

[0] : https://preshing.com/20110504/hash-collision-probabilities

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>