### PR TITLE
build: Compile libbpf with frame pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,7 @@ CGO_LDFLAGS_DYN = -L$(abspath $(LIBBPF_DIR)) -fuse-ld=ld -lelf -lz -lbpf
 # CGO_FFLAGS ?=
 
 # libbpf build flags:
-# CFLAGS = -g -O2 -Wall -fpie
-CFLAGS ?= -g -O2 -Werror -Wall -std=gnu89 -fpic # default CFLAGS
+CFLAGS ?= -g -O2 -Werror -Wall -std=gnu89 -fpic -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
 LDFLAGS ?= -fuse-ld=ld
 
 # sanitizer config:


### PR DESCRIPTION
Test Plan
=========

```
$ make libbpf
$ ar x dist/libbpf/amd64/libbpf.a
$ gdb linker.o
```
**Before**

```
Dump of assembler code for function bpf_linker__new:
   0x00000000000000fa <+10>:	sub    $0x28,%rsp
   0x00000000000000fe <+14>:	mov    %rdi,%rbp
   0x0000000000000101 <+17>:	test   %rsi,%rsi
```

**After**

```
Dump of assembler code for function bpf_linker__new:
   0x00000000000000f0 <+0>:	push   %rbp
   0x00000000000000f1 <+1>:	mov    %rsp,%rbp
```