### PR TITLE
.eh_frame: Handle undefined rip

### DIFF
--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -31,13 +31,14 @@ const (
 	cfaTypeEndFdeMarker
 )
 
-type BpfRbpType uint16
+type bpfRbpType uint16
 
 const (
-	RbpRuleOffsetUnchanged BpfRbpType = iota
-	RbpRuleOffset
-	RbpRuleRegister
+	rbpRuleOffsetUnchanged bpfRbpType = iota
+	rbpRuleOffset
+	rbpRuleRegister
 	rbpTypeExpression
+	rbpTypeUndefinedReturnAddress
 )
 
 // CompactUnwindTableRows encodes unwind information using 2x 64 bit words.
@@ -134,10 +135,10 @@ func rowToCompactRow(row *UnwindTableRow) (CompactUnwindTableRow, error) {
 	// Frame pointer.
 	switch row.RBP.Rule {
 	case frame.RuleOffset:
-		rbpType = uint8(RbpRuleOffset)
+		rbpType = uint8(rbpRuleOffset)
 		rbpOffset = int16(row.RBP.Offset)
 	case frame.RuleRegister:
-		rbpType = uint8(RbpRuleRegister)
+		rbpType = uint8(rbpRuleRegister)
 	case frame.RuleExpression:
 		rbpType = uint8(rbpTypeExpression)
 	case frame.RuleUndefined:
@@ -146,6 +147,11 @@ func rowToCompactRow(row *UnwindTableRow) (CompactUnwindTableRow, error) {
 	case frame.RuleValOffset:
 	case frame.RuleValExpression:
 	case frame.RuleCFA:
+	}
+
+	// Return address.
+	if row.RA.Rule == frame.RuleUndefined {
+		rbpType = uint8(rbpTypeUndefinedReturnAddress)
 	}
 
 	return CompactUnwindTableRow{


### PR DESCRIPTION
We know we've reached the bottom of the stack when:
- we don't have unwind information && `$rbp==0`;
- we have unwind information, but the saved return address is undefined;

This commit adds the second case. The special value is encoded in the frame register to save some space as the field for return address (__reserved_do_not_use) is not needed in x86 and can be removed altogether.

Test Plan
=========
Profiled MySQL without issues. Before, it was failing to detect the end of frame condition as we didn't handle this case.