### PR TITLE
.eh_frame: Remove testing values

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -68,7 +68,7 @@ _Static_assert(1 << MAX_BINARY_SEARCH_DEPTH >= MAX_UNWIND_TABLE_SIZE, "Unwind ta
 #define RBP_TYPE_REGISTER 2
 #define RBP_TYPE_EXPRESSION 3
 // Special values.
-#define RBP_TYPE_UNDEFINED_RETURN_ADDRESS 5
+#define RBP_TYPE_UNDEFINED_RETURN_ADDRESS 4
 
 // Binary search error codes.
 #define BINARY_SEARCH_DEFAULT 0xFAFAFAFA

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -54,7 +54,7 @@ const (
 
 	// With the current compact rows, the max items we can store in the kernels
 	// we have tested is 262k per map, which we rounded it down to 250k.
-	unwindTableMaxEntries = 10         // How many unwind table shards we have.
+	unwindTableMaxEntries = 50         // How many unwind table shards we have.
 	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in the BPF program.
 	maxMappingsPerProcess = 120        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
 	maxUnwindTableChunks  = 30         // Always need to be in sync with MAX_UNWIND_TABLE_CHUNKS.


### PR DESCRIPTION
Oops. Forgot to remove these from testing... 🙃

- the RBP_TYPE is completely wrong and that condition won't ever reach.
- the default size is wrong. This will be adaptively changed in a future PR