### PR TITLE
build: Upgrade LLVM from 11 to 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
-          version: "11"
+          version: "14"
 
       - name: clang version
         run:  |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
-          version: "11"
+          version: "14"
 
       - name: Install libbpf dependencies
         run: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
-          version: "11"
+          version: "14"
 
       - name: Install libbpf dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
-          version: "11"
+          version: "14"
 
       - name: Install libbpf dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
-          version: "11"
+          version: "14"
 
       - name: Install libbpf dependencies
         run: |

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
-          version: "11"
+          version: "14"
 
       - name: Install libbpf dependencies
         run: |


### PR DESCRIPTION
LLVM 11 is ancient, let's upgrade to 14. Additionally, this fixes the problem that https://github.com/parca-dev/parca-agent/pull/1357 was trying to fix. I suggest we land both because the code is a bit cleaner and it would be good to use a more modern compiler 😄 