### PR TITLE
.eh_frame: Adaptively size unwind info shard count

### DIFF
--- a/kerneltest/vmtest.sh
+++ b/kerneltest/vmtest.sh
@@ -88,7 +88,13 @@ run_tests() {
 
     for kernel in "${kernel_versions[@]}"; do
         use_kernel "$kernel"
-        vm_run "$kernel" "1.5G"
+        # Ensure that the adaptive unwind shard mechanism
+        # works in memory constrained environments.
+        if [[ "$kernel" == "5.4" ]]; then
+            vm_run "$kernel" "0.4G"
+        else
+            vm_run "$kernel" "1.5G"
+        fi
     done
 
     failed_tests=0

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -22,8 +22,7 @@ import (
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/parca-dev/parca-agent/pkg/byteorder"
-	"github.com/parca-dev/parca-agent/pkg/profiler"
+	"github.com/parca-dev/parca-agent/pkg/logger"
 )
 
 // The intent of these tests is to ensure that libbpfgo behaves the
@@ -33,29 +32,12 @@ import (
 // BPF program.
 func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	t.Helper()
+	logger := logger.NewLogger("debug", logger.LogFormatLogfmt, "parca-cpu-test")
 
-	m, err := bpf.NewModuleFromBufferArgs(bpf.NewModuleArgs{
-		BPFObjBuff: bpfObj,
-		BPFObjName: "parca",
-	})
+	m, _, err := loadBpfProgram(logger, true)
 	require.NoError(t, err)
 
-	memLock := uint64(1200 * 1024 * 1024) // ~1.2GiB
-	_, err = profiler.BumpMemlock(memLock, memLock)
-	require.NoError(t, err)
-
-	bpfMaps, err := initializeMaps(nil, m, byteorder.GetHostByteOrder())
-	require.NoError(t, err)
-
-	// Enable DWARF unwinding so the unwind tables are created with a
-	// more representative size.
-	bpfMaps.adjustMapSizes(true)
-	require.NoError(t, err)
-
-	err = m.BPFLoadObject()
-	require.NoError(t, err)
-
-	return m, nil
+	return m, err
 }
 
 func TestDeleteNonExistentKeyReturnsEnoent(t *testing.T) {


### PR DESCRIPTION
Right now we request 50 unwind shards which account for ~200MB of kernel memory. Some systems might not have so much memory if they are running in constrained environments.

Rather than trying to figure out how much memory we have at our disposal, which is quite complicated to do, let's try to load some amount of shards and if that fails, try again with half the size.

Test Plan
=========
Now the kernel tests for 5.4 run with 1/3 of the memory, exercising this
code path.

```
[            ] stderr: level=debug name=parca-cpu-test ts=2023-02-21T10:53:55.189470094Z caller=cpu.go:238 msg="actual memory locked rlimit" cur="1.3 GB" max="1.3 GB"
[            ] stderr: level=info name=parca-cpu-test ts=2023-02-21T10:53:55.235053489Z caller=cpu.go:246 msg="Attempting to create unwind shards" count=50
[            ] stderr: libbpf: Error in bpf_create_map_xattr(dwarf_stack_traces):Cannot allocate memory(-12). Retrying without BTF.
[            ] stderr: libbpf: map 'dwarf_stack_traces': failed to create: Cannot allocate memory(-12)
[            ] stderr: libbpf: failed to load object 'parca'
[            ] stderr: level=debug name=parca-cpu-test ts=2023-02-21T10:53:55.440799147Z caller=cpu.go:238 msg="actual memory locked rlimit" cur="1.3 GB" max="1.3 GB"
[            ] stderr: level=info name=parca-cpu-test ts=2023-02-21T10:53:55.470910312Z caller=cpu.go:246 msg="Attempting to create unwind shards" count=25
```

```
=============
Test results:
=============
- ✅ 5.4
- ✅ 5.10
- ✅ 5.18
- ✅ 5.19
```
