### PR TITLE
Fix panic due to low rlimit value

### DIFF
--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -34,7 +34,8 @@ func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	t.Helper()
 	logger := logger.NewLogger("debug", logger.LogFormatLogfmt, "parca-cpu-test")
 
-	m, _, err := loadBpfProgram(logger, true)
+	memLock := uint64(1200 * 1024 * 1024) // ~1.2GiB
+	m, _, err := loadBpfProgram(logger, true, memLock)
 	require.NoError(t, err)
 
 	return m, err


### PR DESCRIPTION
As I didn't pass the right value in https://github.com/parca-dev/parca-agent/commit/8e9f580a79f4cfdabc74688b10ed259bf88b4a81

```
level=error name=parca-agent ts=2023-02-21T16:49:00.909431559Z caller=cpu.go:267 msg="Could not create unwind info shards"
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x19896fd]

goroutine 133 [running]:
github.com/aquasecurity/libbpfgo.(*Module).Close(0x0)
        github.com/aquasecurity/libbpfgo@v0.4.5-libbpf-1.0.1/libbpfgo.go:411 +0x1d
panic({0x1ce3ce0, 0x3128b10})
        runtime/panic.go:890 +0x262
github.com/aquasecurity/libbpfgo.(*Module).GetProgram.func1(0x1fbb29c?, 0xb?)
        github.com/aquasecurity/libbpfgo@v0.4.5-libbpf-1.0.1/libbpfgo.go:1073 +0x19
github.com/aquasecurity/libbpfgo.(*Module).GetProgram(0x0, {0x1fbb29c, 0xb})
        github.com/aquasecurity/libbpfgo@v0.4.5-libbpf-1.0.1/libbpfgo.go:1073 +0x4a
github.com/parca-dev/parca-agent/pkg/profiler/cpu.(*CPU).Run(0xc0003ca2c0, {0x22a87b8, 0xc0005c8180})
        github.com/parca-dev/parca-agent/pkg/profiler/cpu/cpu.go:339 +0x7ef
```

Test Plan
=========

+ we should run this in Demo
```
=============
Test results:
=============
- ✅ 5.4
- ✅ 5.10
- ✅ 5.18
- ✅ 5.19
```