### PR TITLE
.eh_frame: Enable DWARF-based unwinder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,63 +56,68 @@ Flags:
 Usage: parca-agent
 
 Flags:
-  -h, --help                      Show context-sensitive help.
-      --log-level="info"          Log level.
-      --http-address=":7071"      Address to bind HTTP server to.
+  -h, --help                       Show context-sensitive help.
+      --log-level="info"           Log level.
+      --http-address=":7071"       Address to bind HTTP server to.
       --node="hostname"           The name of the node that the process is
-                                  running on. If on Kubernetes, this must match
-                                  the Kubernetes node name.
-      --config-path=""            Path to config file.
-      --memlock-rlimit=0          The value for the maximum number of bytes of
-                                  memory that may be locked into RAM. It is used
-                                  to ensure the agent can lock memory for eBPF
-                                  maps. 0 means no limit.
-      --profiling-duration=10s    The agent profiling duration to use. Leave
-                                  this empty to use the defaults.
+                                   running on. If on Kubernetes, this must match
+                                   the Kubernetes node name.
+      --config-path=""             Path to config file.
+      --memlock-rlimit=0           The value for the maximum number of bytes
+                                   of memory that may be locked into RAM. It is
+                                   used to ensure the agent can lock memory for
+                                   eBPF maps. 0 means no limit.
+      --profiling-duration=10s     The agent profiling duration to use. Leave
+                                   this empty to use the defaults.
       --profiling-cpu-sampling-frequency=19
-                                  The frequency at which profiling data is
-                                  collected, e.g., 19 samples per second.
+                                   The frequency at which profiling data is
+                                   collected, e.g., 19 samples per second.
       --metadata-external-labels=KEY=VALUE;...
-                                  Label(s) to attach to all profiles.
+                                   Label(s) to attach to all profiles.
       --metadata-container-runtime-socket-path=STRING
-                                  The filesystem path to the container runtimes
-                                  socket. Leave this empty to use the defaults.
+                                   The filesystem path to the container runtimes
+                                   socket. Leave this empty to use the defaults.
       --local-store-directory=STRING
-                                  The local directory to store the profiling
-                                  data.
+                                   The local directory to store the profiling
+                                   data.
       --remote-store-address=STRING
-                                  gRPC address to send profiles and symbols to.
+                                   gRPC address to send profiles and symbols to.
       --remote-store-bearer-token=STRING
-                                  Bearer token to authenticate with store.
+                                   Bearer token to authenticate with store.
       --remote-store-bearer-token-file=STRING
-                                  File to read bearer token from to authenticate
-                                  with store.
-      --remote-store-insecure     Send gRPC requests via plaintext instead of
-                                  TLS.
+                                   File to read bearer token from to
+                                   authenticate with store.
+      --remote-store-insecure      Send gRPC requests via plaintext instead of
+                                   TLS.
       --remote-store-insecure-skip-verify
-                                  Skip TLS certificate verification.
+                                   Skip TLS certificate verification.
       --remote-store-debuginfo-upload-disable
-                                  Disable debuginfo collection and upload.
+                                   Disable debuginfo collection and upload.
       --remote-store-batch-write-interval=10s
-                                  Interval between batch remote client writes.
-                                  Leave this empty to use the default value of
-                                  10s.
+                                   Interval between batch remote client writes.
+                                   Leave this empty to use the default value of
+                                   10s.
       --debuginfo-directories=/usr/lib/debug,...
-                                  Ordered list of local directories to
-                                  search for debuginfo files. Defaults to
-                                  /usr/lib/debug.
+                                   Ordered list of local directories to
+                                   search for debuginfo files. Defaults to
+                                   /usr/lib/debug.
       --debuginfo-temp-dir="/tmp"
-                                  The local directory path to store the interim
-                                  debuginfo files.
-      --debuginfo-strip           Only upload information needed for
-                                  symbolization. If false the exact binary the
-                                  agent sees will be uploaded unmodified.
+                                   The local directory path to store the interim
+                                   debuginfo files.
+      --debuginfo-strip            Only upload information needed for
+                                   symbolization. If false the exact binary the
+                                   agent sees will be uploaded unmodified.
       --debuginfo-upload-cache-duration=5m
-                                  The duration to cache debuginfo upload exists
-                                  checks for.
+                                   The duration to cache debuginfo upload exists
+                                   checks for.
       --debuginfo-upload-timeout-duration=2m
-                                  The timeout duration to cancel upload
-                                  requests.
+                                   The timeout duration to cancel upload
+                                   requests.
+      --disable-dwarf-unwinding    Do not unwind using .eh_frame information.
+      --dwarf-unwinding-use-polling
+                                   Poll procfs to generate the unwind
+                                   information instead of generating them on
+                                   demand.
 ```
 
 ## Roadmap


### PR DESCRIPTION
This commit:

- enables DWARF-unwinding by default, adding a flag to opt-out `--disable-dwarf-unwinding`;
- adds on-demand unwind table generation using the information provided by the BPF program when it can't unwind the stack using FPs and the unwind information isn't found;
- adds a new flag, `--dwarf-unwinding-use-polling` to produce the unwind tables ahead of time, if desired;

Notes
=====

I expect the CPU usage to be slightly lower thanks to not generating unwind info ahead of times for processes that perhaps will use no CPU.

Some stacks fail due to not following the ABI. This needs more investigation but seems related to the way Go grows goroutines stacks. This might cause many events to produce unwind tables to be sent, but this should not be a problem as the Go binary detection is cached as well as the unwind table generation. This code path should use very little CPU.

That being said, will take a look at profiles in Prod and Demo to ensure performance is within what we expect.

Test Plan
=========

Ran for 2h on my machine without issues or errors in the BPF logs. 

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/959128/220631439-54129523-b75a-4afc-9224-6c3f134a16cc.png">
