### PR TITLE
bpf: Make logging opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Flags:
   -h, --help                       Show context-sensitive help.
       --log-level="info"           Log level.
       --http-address=":7071"       Address to bind HTTP server to.
-      --node="hostname"
-                                   The name of the node that the process is
+      --node="hostname"           The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Flags:
   -h, --help                       Show context-sensitive help.
       --log-level="info"           Log level.
       --http-address=":7071"       Address to bind HTTP server to.
-      --node="hostname"           The name of the node that the process is
+      --node="hostname"
+                                   The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.
@@ -118,6 +119,7 @@ Flags:
                                    Poll procfs to generate the unwind
                                    information instead of generating them on
                                    demand.
+      --verbose-bpf-logging        Enable verbose BPF logging.
 ```
 
 ## Roadmap

--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -80,7 +80,8 @@ enum stack_walking_method {
 };
 
 struct unwinder_config_t {
-  bool debug;
+  bool filter_processes;
+  bool verbose_logging;
 };
 
 const volatile struct unwinder_config_t unwinder_config = {};
@@ -115,6 +116,13 @@ typedef u64 stack_trace_type[MAX_STACK_DEPTH];
 #define STACK_COLLISION(err) (err == -EEXIST)
 // Tried to read a kernel stack from a non-kernel context.
 #define IN_USERSPACE(err) (err == -EFAULT)
+
+#define LOG(fmt, ...)                                                                                                                                          \
+  ({                                                                                                                                                           \
+    if (unwinder_config.verbose_logging) {                                                                                                                     \
+      bpf_printk(fmt, ##__VA_ARGS__);                                                                                                                          \
+    }                                                                                                                                                          \
+  })
 
 /*============================= INTERNAL STRUCTS ============================*/
 
@@ -242,10 +250,10 @@ struct {
 } programs SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-    __uint(key_size, sizeof(u32));
-    __uint(value_size, sizeof(u32));
-    __uint(max_entries, 8192);
+  __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+  __uint(key_size, sizeof(u32));
+  __uint(value_size, sizeof(u32));
+  __uint(max_entries, 8192);
 } events SEC(".maps");
 
 /*=========================== HELPER FUNCTIONS ==============================*/
@@ -299,16 +307,17 @@ static void unwind_print_stats() {
     return;
   }
 
+  // Do not use the LOG macro, always print the stats.
   bpf_printk("[[ stats for cpu %d ]]", (int)bpf_get_smp_processor_id());
-  bpf_printk("success=%lu", *success_counter);
-  bpf_printk("unsup_expression=%lu", *unsup_expression);
-  bpf_printk("truncated=%lu", *truncated_counter);
-  bpf_printk("catchall=%lu", *catchall_count);
-  bpf_printk("never=%lu", *never);
-  bpf_printk("unknown_jit=%lu", *unknown_jit);
-
-  bpf_printk("total_counter=%lu", *total_counter);
-  bpf_printk("(not_covered=%lu)", *not_covered_count);
+  bpf_printk("\tsuccess=%lu", *success_counter);
+  bpf_printk("\tunsup_expression=%lu", *unsup_expression);
+  bpf_printk("\ttruncated=%lu", *truncated_counter);
+  bpf_printk("\tcatchall=%lu", *catchall_count);
+  bpf_printk("\tnever=%lu", *never);
+  bpf_printk("\tunknown_jit=%lu", *unknown_jit);
+  bpf_printk("\ttotal_counter=%lu", *total_counter);
+  bpf_printk("\t(not_covered=%lu)", *not_covered_count);
+  bpf_printk("");
 }
 
 static void bump_samples() {
@@ -332,7 +341,7 @@ static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *k
 
   err = bpf_map_update_elem(map, key, init, BPF_NOEXIST);
   if (err && !STACK_COLLISION(err)) {
-    bpf_printk("[error] bpf_map_lookup_or_try_init with ret: %d", err);
+    LOG("[error] bpf_map_lookup_or_try_init with ret: %d", err);
     return 0;
   }
 
@@ -350,7 +359,7 @@ static u64 find_offset_for_pc(stack_unwind_table_t *table, u64 pc, u64 left, u64
     // TODO(javierhonduco): ensure that this condition is right as we use
     // unsigned values...
     if (left >= right) {
-      bpf_printk("\t.done");
+      LOG("\t.done");
       return found;
     }
 
@@ -358,13 +367,13 @@ static u64 find_offset_for_pc(stack_unwind_table_t *table, u64 pc, u64 left, u64
 
     // Appease the verifier.
     if (mid < 0 || mid >= MAX_UNWIND_TABLE_SIZE) {
-      bpf_printk("\t.should never happen, mid: %lu, max: %lu", mid, MAX_UNWIND_TABLE_SIZE);
+      LOG("\t.should never happen, mid: %lu, max: %lu", mid, MAX_UNWIND_TABLE_SIZE);
       BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
       return BINARY_SEARCH_SHOULD_NEVER_HAPPEN;
     }
 
     // Debug logs.
-    // bpf_printk("\t-> fetched PC %llx, target PC %llx (iteration %d/%d, mid: %d, left:%d, right:%d)", table->rows[mid].pc, pc, i, MAX_BINARY_SEARCH_DEPTH,
+    // LOG("\t-> fetched PC %llx, target PC %llx (iteration %d/%d, mid: %d, left:%d, right:%d)", table->rows[mid].pc, pc, i, MAX_BINARY_SEARCH_DEPTH,
     // mid, left, right);
     if (table->rows[mid].pc <= pc) {
       found = mid;
@@ -374,7 +383,7 @@ static u64 find_offset_for_pc(stack_unwind_table_t *table, u64 pc, u64 left, u64
     }
 
     // Debug logs.
-    // bpf_printk("\t<- fetched PC %llx, target PC %llx (iteration %d/%d, mid:
+    // LOG("\t<- fetched PC %llx, target PC %llx (iteration %d/%d, mid:
     // --, left:%d, right:%d)", ctx->table->rows[mid].pc, ctx->pc, index,
     // MAX_BINARY_SEARCH_DEPTH, ctx->left, ctx->right);
   }
@@ -420,7 +429,7 @@ static __always_inline enum find_unwind_table_return find_unwind_table(shard_inf
   process_info_t *proc_info = bpf_map_lookup_elem(&process_info, &pid);
   // Appease the verifier.
   if (proc_info == NULL) {
-    bpf_printk("[error] should never happen");
+    LOG("[error] should never happen");
     return FIND_UNWIND_MAPPING_SHOULD_NEVER_HAPPEN;
   }
 
@@ -432,13 +441,13 @@ static __always_inline enum find_unwind_table_return find_unwind_table(shard_inf
   // Find the mapping.
   for (int i = 0; i < MAX_MAPPINGS_PER_PROCESS; i++) {
     if (i > proc_info->len) {
-      bpf_printk("[info] mapping not found, i (%d) > proc_info->len (%d) pc: %llx", i, proc_info->len, pc);
+      LOG("[info] mapping not found, i (%d) > proc_info->len (%d) pc: %llx", i, proc_info->len, pc);
       return FIND_UNWIND_MAPPING_EXHAUSTED_SEARCH;
     }
 
     // Appease the verifier.
     if (i < 0 || i > MAX_MAPPINGS_PER_PROCESS) {
-      bpf_printk("[error] should never happen, verifier");
+      LOG("[error] should never happen, verifier");
       return FIND_UNWIND_MAPPING_SHOULD_NEVER_HAPPEN;
     }
 
@@ -462,17 +471,17 @@ static __always_inline enum find_unwind_table_return find_unwind_table(shard_inf
       return FIND_UNWIND_SPECIAL;
     }
   } else {
-    bpf_printk("[warn] :((( no mapping for ip=%llx", pc);
+    LOG("[warn] :((( no mapping for ip=%llx", pc);
     return FIND_UNWIND_MAPPING_NOT_FOUND;
   }
 
-  bpf_printk("~about to check shards found=%d", found);
-  bpf_printk("~checking shards now");
+  LOG("~about to check shards found=%d", found);
+  LOG("~checking shards now");
 
   // Find the shard where this unwind table lives.
   stack_unwind_table_shards_t *shards = bpf_map_lookup_elem(&unwind_shards, &executable_id);
   if (shards == NULL) {
-    bpf_printk("[info] shards is null for executable %llu", executable_id);
+    LOG("[info] shards is null for executable %llu", executable_id);
     return FIND_UNWIND_SHARD_NOT_FOUND;
   }
 
@@ -483,13 +492,13 @@ static __always_inline enum find_unwind_table_return find_unwind_table(shard_inf
       break;
     }
     if (shards->shards[i].low_pc <= adjusted_pc && adjusted_pc <= shards->shards[i].high_pc) {
-      bpf_printk("[info] found shard");
+      LOG("[info] found shard");
       *shard_info = &shards->shards[i];
       return FIND_UNWIND_SUCCESS;
     }
   }
 
-  bpf_printk("[error] could not find shard");
+  LOG("[error] could not find shard");
   return FIND_UNWIND_SHARD_NOT_FOUND;
 }
 
@@ -511,7 +520,7 @@ static __always_inline bool is_kthread() {
   void *mm;
   int err = bpf_probe_read_kernel(&mm, 8, &task->mm);
   if (err) {
-    bpf_printk("[warn] bpf_probe_read_kernel failed with %d", err);
+    LOG("[warn] bpf_probe_read_kernel failed with %d", err);
     return false;
   }
 
@@ -539,7 +548,7 @@ static __always_inline bool retrieve_task_registers(u64 *ip, u64 *sp, u64 *bp) {
 
   err = bpf_probe_read_kernel(&stack, 8, &task->stack);
   if (err) {
-    bpf_printk("[warn] bpf_probe_read_kernel failed with %d", err);
+    LOG("[warn] bpf_probe_read_kernel failed with %d", err);
     return false;
   }
 
@@ -548,19 +557,19 @@ static __always_inline bool retrieve_task_registers(u64 *ip, u64 *sp, u64 *bp) {
 
   err = bpf_probe_read_kernel((void *)ip, 8, &regs->ip);
   if (err) {
-    bpf_printk("bpf_probe_read_kernel failed err %d", err);
+    LOG("bpf_probe_read_kernel failed err %d", err);
     return false;
   }
 
   err = bpf_probe_read_kernel((void *)sp, 8, &regs->sp);
   if (err) {
-    bpf_printk("bpf_probe_read_kernel failed err %d", err);
+    LOG("bpf_probe_read_kernel failed err %d", err);
     return false;
   }
 
   err = bpf_probe_read_kernel((void *)bp, 8, &regs->bp);
   if (err) {
-    bpf_printk("bpf_probe_read_kernel failed err %d", err);
+    LOG("bpf_probe_read_kernel failed err %d", err);
     return false;
   }
 
@@ -579,7 +588,7 @@ static __always_inline bool has_fp(u64 current_fp) {
   for (int i = 0; i < MAX_STACK_DEPTH; i++) {
     int err = bpf_probe_read_user(&next_fp, 8, (void *)current_fp);
     if (err < 0) {
-      // bpf_printk("[debug] fp read failed with %d", err);
+      // LOG("[debug] fp read failed with %d", err);
       return false;
     }
     // Some cpp binaries, such as testdata/out/basic-cpp
@@ -588,13 +597,13 @@ static __always_inline bool has_fp(u64 current_fp) {
     // generate unwind tables for these rather than have a
     // special case.
     if (next_fp == 0) {
-      // bpf_printk("[debug] fp success");
+      // LOG("[debug] fp success");
       return true;
     }
     current_fp = next_fp;
   }
 
-  bpf_printk("[debug] fp not enough frames");
+  LOG("[debug] fp not enough frames");
   return false;
 }
 
@@ -617,13 +626,13 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx, u64 pid_t
 
   if (method == STACK_WALKING_METHOD_DWARF) {
     int stack_hash = MurmurHash2((u32 *)unwind_state->stack.addresses, MAX_STACK_DEPTH * sizeof(u64) / sizeof(u32), 0);
-    bpf_printk("stack hash %d", stack_hash);
+    LOG("stack hash %d", stack_hash);
     stack_key.user_stack_id_dwarf = stack_hash;
 
     // Insert stack.
     int err = bpf_map_update_elem(&dwarf_stack_traces, &stack_hash, &unwind_state->stack, BPF_ANY);
     if (err != 0) {
-      bpf_printk("[error] bpf_map_update_elem with ret: %d", err);
+      LOG("[error] bpf_map_update_elem with ret: %d", err);
     }
   } else if (method == STACK_WALKING_METHOD_FP) {
     int stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
@@ -632,7 +641,7 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx, u64 pid_t
     // truncated due to a limit on the rbp traversals or because frame
     // pointers aren't present.
     if (stack_id < 0) {
-      bpf_printk("[warn] bpf_get_stackid user failed with %d", stack_id);
+      LOG("[warn] bpf_get_stackid user failed with %d", stack_id);
       return;
     }
     stack_key.user_stack_id = stack_id;
@@ -641,7 +650,7 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx, u64 pid_t
   // Get kernel stack.
   int kernel_stack_id = bpf_get_stackid(ctx, &stack_traces, 0);
   if (kernel_stack_id < 0 && !IN_USERSPACE(kernel_stack_id)) {
-    bpf_printk("[warn] bpf_get_stackid kernel failed with %d", kernel_stack_id);
+    LOG("[warn] bpf_get_stackid kernel failed with %d", kernel_stack_id);
     return;
   }
   stack_key.kernel_stack_id = kernel_stack_id;
@@ -664,26 +673,26 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
 
   unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero);
   if (unwind_state == NULL) {
-    bpf_printk("unwind_state is NULL, should not happen");
+    LOG("unwind_state is NULL, should not happen");
     return 1;
   }
 
   for (int i = 0; i < MAX_STACK_DEPTH_PER_PROGRAM; i++) {
-    bpf_printk("## frame: %d", unwind_state->stack.len);
+    LOG("## frame: %d", unwind_state->stack.len);
 
-    bpf_printk("\tcurrent pc: %llx", unwind_state->ip);
-    bpf_printk("\tcurrent sp: %llx", unwind_state->sp);
-    bpf_printk("\tcurrent bp: %llx", unwind_state->bp);
+    LOG("\tcurrent pc: %llx", unwind_state->ip);
+    LOG("\tcurrent sp: %llx", unwind_state->sp);
+    LOG("\tcurrent bp: %llx", unwind_state->bp);
 
     u64 offset = 0;
     shard_info_t *shard = NULL;
     enum find_unwind_table_return unwind_table_result = find_unwind_table(&shard, user_pid, unwind_state->ip, &offset);
 
     if (unwind_table_result == FIND_UNWIND_JITTED) {
-      bpf_printk("JIT section, stopping");
+      LOG("JIT section, stopping");
       return 1;
     } else if (unwind_table_result == FIND_UNWIND_SPECIAL) {
-      bpf_printk("special section, stopping");
+      LOG("special section, stopping");
       return 1;
     } else if (shard == NULL) {
       // improve
@@ -693,28 +702,28 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
 
     stack_unwind_table_t *unwind_table = bpf_map_lookup_elem(&unwind_tables, &shard->shard_index);
     if (unwind_table == NULL) {
-      bpf_printk("unwind table is null :( for shard %llu", shard->shard_index);
+      LOG("unwind table is null :( for shard %llu", shard->shard_index);
       return 0;
     }
 
-    bpf_printk("le offset: %llx", offset);
+    LOG("le offset: %llx", offset);
     u64 left = shard->low_index;
     u64 right = shard->high_index;
-    bpf_printk("========== left %llu right %llu", left, right);
+    LOG("========== left %llu right %llu", left, right);
 
     u64 table_idx = find_offset_for_pc(unwind_table, unwind_state->ip - offset, left, right);
 
     if (table_idx == BINARY_SEARCH_DEFAULT || table_idx == BINARY_SEARCH_SHOULD_NEVER_HAPPEN || table_idx == BINARY_SEARCH_EXHAUSTED_ITERATIONS) {
-      bpf_printk("[error] binary search failed with %llx", table_idx);
+      LOG("[error] binary search failed with %llx", table_idx);
       return 1;
     }
 
-    bpf_printk("\t=> table_index: %d", table_idx);
-    bpf_printk("\t=> adjusted pc: %llx", unwind_state->ip - offset);
+    LOG("\t=> table_index: %d", table_idx);
+    LOG("\t=> adjusted pc: %llx", unwind_state->ip - offset);
 
     // Appease the verifier.
     if (table_idx < 0 || table_idx >= MAX_UNWIND_TABLE_SIZE) {
-      bpf_printk("\t[error] this should never happen");
+      LOG("\t[error] this should never happen");
       BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
       return 1;
     }
@@ -724,16 +733,16 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
     u8 found_rbp_type = unwind_table->rows[table_idx].rbp_type;
     s16 found_cfa_offset = unwind_table->rows[table_idx].cfa_offset;
     s16 found_rbp_offset = unwind_table->rows[table_idx].rbp_offset;
-    bpf_printk("\tcfa type: %d, offset: %d (row pc: %llx)", found_cfa_type, found_cfa_offset, found_pc);
+    LOG("\tcfa type: %d, offset: %d (row pc: %llx)", found_cfa_type, found_cfa_offset, found_pc);
 
     if (found_cfa_type == CFA_TYPE_END_OF_FDE_MARKER) {
-      bpf_printk("[info] PC %llx not contained in the unwind info, found marker", unwind_state->ip);
+      LOG("[info] PC %llx not contained in the unwind info, found marker", unwind_state->ip);
       reached_bottom_of_stack = true;
       break;
     }
 
     if (found_rbp_type == RBP_TYPE_UNDEFINED_RETURN_ADDRESS) {
-      bpf_printk("[info] null return address, end of stack", unwind_state->ip);
+      LOG("[info] null return address, end of stack", unwind_state->ip);
       reached_bottom_of_stack = true;
       break;
     }
@@ -748,7 +757,7 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
     }
 
     if (found_rbp_type == RBP_TYPE_REGISTER || found_rbp_type == RBP_TYPE_EXPRESSION) {
-      bpf_printk("\t[error] frame pointer is %d (register or exp), bailing out", found_rbp_type);
+      LOG("\t[error] frame pointer is %d (register or exp), bailing out", found_rbp_type);
       BUMP_UNWIND_CATCHALL_ERROR();
       return 1;
     }
@@ -760,12 +769,12 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
       previous_rsp = unwind_state->sp + found_cfa_offset;
     } else if (found_cfa_type == CFA_TYPE_EXPRESSION) {
       if (found_cfa_offset == DWARF_EXPRESSION_UNKNOWN) {
-        bpf_printk("[warn] CFA is an unsupported expression, bailing out");
+        LOG("[warn] CFA is an unsupported expression, bailing out");
         BUMP_UNWIND_UNSUPPORTED_EXPRESSION();
         return 1;
       }
 
-      bpf_printk("CFA expression found with id %d", found_cfa_offset);
+      LOG("CFA expression found with id %d", found_cfa_offset);
 
       u64 threshold = 0;
       if (found_cfa_offset == DWARF_EXPRESSION_PLT1) {
@@ -781,7 +790,7 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
 
       previous_rsp = unwind_state->sp + 8 + ((((unwind_state->ip & 15) >= threshold)) << 3);
     } else {
-      bpf_printk("\t[warn] register %d not valid (expected $rbp or $rsp)", found_cfa_type);
+      LOG("\t[warn] register %d not valid (expected $rbp or $rsp)", found_cfa_type);
       BUMP_UNWIND_CATCHALL_ERROR();
       return 1;
     }
@@ -789,7 +798,7 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
     // is within the stack. This check could be quite brittle though, so if we
     // add it, it would be best to add it only during development.
     if (previous_rsp == 0) {
-      bpf_printk("[error] previous_rsp should not be zero.");
+      LOG("[error] previous_rsp should not be zero.");
       BUMP_UNWIND_CATCHALL_ERROR();
       return 1;
     }
@@ -805,17 +814,17 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
       int user_pid = pid_tgid;
       process_info_t *proc_info = bpf_map_lookup_elem(&process_info, &user_pid);
       if (proc_info == NULL) {
-        bpf_printk("[error] should never happen");
+        LOG("[error] should never happen");
         return 1;
       }
 
       if (proc_info->is_jit_compiler) {
-        bpf_printk("[info] rip=0, Section not added, yet");
+        LOG("[info] rip=0, Section not added, yet");
         BUMP_UNWIND_JIT_ERRORS();
         return 1;
       }
 
-      bpf_printk("[error] previous_rip should not be zero. This can mean that the read failed, ret=%d while reading @ %llx.", err, previous_rip_addr);
+      LOG("[error] previous_rip should not be zero. This can mean that the read failed, ret=%d while reading @ %llx.", err, previous_rip_addr);
       BUMP_UNWIND_CATCHALL_ERROR();
       return 1;
     }
@@ -826,24 +835,24 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
       previous_rbp = unwind_state->bp;
     } else {
       u64 previous_rbp_addr = previous_rsp + found_rbp_offset;
-      bpf_printk("\t(bp_offset: %d, bp value stored at %llx)", found_rbp_offset, previous_rbp_addr);
+      LOG("\t(bp_offset: %d, bp value stored at %llx)", found_rbp_offset, previous_rbp_addr);
       int ret = bpf_probe_read_user(&previous_rbp, 8, (void *)(previous_rbp_addr));
       if (ret != 0) {
-        bpf_printk("[error] previous_rbp should not be zero. This can mean "
-                   "that the read has failed %d.",
-                   ret);
+        LOG("[error] previous_rbp should not be zero. This can mean "
+            "that the read has failed %d.",
+            ret);
         BUMP_UNWIND_CATCHALL_ERROR();
         return 1;
       }
     }
 
-    bpf_printk("\tprevious ip: %llx (@ %llx)", previous_rip, previous_rip_addr);
-    bpf_printk("\tprevious sp: %llx", previous_rsp);
+    LOG("\tprevious ip: %llx (@ %llx)", previous_rip, previous_rip_addr);
+    LOG("\tprevious sp: %llx", previous_rsp);
     // Set rsp and rip registers
     unwind_state->ip = previous_rip;
     unwind_state->sp = previous_rsp;
     // Set rbp
-    bpf_printk("\tprevious bp: %llx", previous_rbp);
+    LOG("\tprevious bp: %llx", previous_rbp);
     unwind_state->bp = previous_rbp;
 
     // Frame finished! :)
@@ -862,29 +871,29 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
     //
     // https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf
     if (unwind_state->bp == 0) {
-      bpf_printk("======= reached main! =======");
+      LOG("======= reached main! =======");
       add_stack(ctx, pid_tgid, STACK_WALKING_METHOD_DWARF, unwind_state);
       BUMP_UNWIND_SUCCESS();
     } else {
       int user_pid = pid_tgid;
       process_info_t *proc_info = bpf_map_lookup_elem(&process_info, &user_pid);
       if (proc_info == NULL) {
-        bpf_printk("[error] should never happen");
+        LOG("[error] should never happen");
         return 1;
       }
 
       if (proc_info->is_jit_compiler) {
-        bpf_printk("[info] Section not added, yet");
+        LOG("[info] Section not added, yet");
         BUMP_UNWIND_JIT_ERRORS();
         return 1;
       }
 
-      bpf_printk("[error] Could not find unwind table and rbp != 0 (%llx) bug?", unwind_state->bp);
+      LOG("[error] Could not find unwind table and rbp != 0 (%llx) bug?", unwind_state->bp);
       BUMP_UNWIND_SHOULD_NEVER_HAPPEN_ERROR();
     }
     return 0;
   } else if (unwind_state->stack.len < MAX_STACK_DEPTH && unwind_state->tail_calls < MAX_TAIL_CALLS) {
-    bpf_printk("Continuing walking the stack in a tail call, current tail %d", unwind_state->tail_calls);
+    LOG("Continuing walking the stack in a tail call, current tail %d", unwind_state->tail_calls);
     unwind_state->tail_calls++;
     bpf_tail_call(ctx, &programs, 0);
   }
@@ -938,9 +947,9 @@ static __always_inline int walk_user_stacktrace(struct bpf_perf_event_data *ctx)
 
   bump_samples();
 
-  bpf_printk("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-  bpf_printk("traversing stack using .eh_frame information!!");
-  bpf_printk("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+  LOG("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+  LOG("traversing stack using .eh_frame information!!");
+  LOG("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 
   bpf_tail_call(ctx, &programs, 0);
   return 0;
@@ -960,9 +969,9 @@ int profile_cpu(struct bpf_perf_event_data *ctx) {
     return 0;
   }
 
-  if (unwinder_config.debug) {
+  if (unwinder_config.filter_processes) {
     // This can be very noisy
-    // bpf_printk("debug mode enabled, make sure you specified process name");
+    // LOG("debug mode enabled, make sure you specified process name");
     if (!is_debug_enabled_for_pid(user_tgid)) {
       return 0;
     }
@@ -985,12 +994,12 @@ int profile_cpu(struct bpf_perf_event_data *ctx) {
     shard_info_t *shard = NULL;
     find_unwind_table(&shard, user_pid, unwind_state->ip, NULL);
     if (shard == NULL) {
-      bpf_printk("[warn] IP not covered. JIT / bug? IP %llx)", unwind_state->ip);
+      LOG("[warn] IP not covered. JIT / bug? IP %llx)", unwind_state->ip);
       BUMP_UNWIND_PC_NOT_COVERED_ERROR();
       return 0;
     }
 
-    bpf_printk("pid %d tgid %d", user_pid, user_tgid);
+    LOG("pid %d tgid %d", user_pid, user_tgid);
     walk_user_stacktrace(ctx);
     return 0;
   }
@@ -998,7 +1007,7 @@ int profile_cpu(struct bpf_perf_event_data *ctx) {
   // Debugging.
   char comm[20];
   bpf_get_current_comm(comm, 20);
-  bpf_printk("[todo] no fp, no unwind info for comm: %s ctx IP: %llx user IP: %llx", comm, ctx->regs.ip, unwind_state->ip);
+  LOG("[todo] no fp, no unwind info for comm: %s ctx IP: %llx user IP: %llx", comm, ctx->regs.ip, unwind_state->ip);
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &user_pid, sizeof(int));
 
   return 0;

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -134,6 +134,7 @@ type flags struct {
 	// Native unwinding flags.
 	DisableDWARFUnwinding    bool `kong:"help='Do not unwind using .eh_frame information.'"`
 	DWARFUnwindingUsePolling bool `kong:"help='Poll procfs to generate the unwind information instead of generating them on demand.'"`
+	VerboseBpfLogging        bool `kong:"help='Enable verbose BPF logging.'"`
 }
 
 var _ Profiler = &profiler.NoopProfiler{}
@@ -456,6 +457,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			flags.DebugProcessNames,
 			flags.DisableDWARFUnwinding,
 			flags.DWARFUnwindingUsePolling,
+			flags.VerboseBpfLogging,
 			bpfProgramLoaded,
 		),
 	}

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -35,7 +35,7 @@ func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	logger := logger.NewLogger("debug", logger.LogFormatLogfmt, "parca-cpu-test")
 
 	memLock := uint64(1200 * 1024 * 1024) // ~1.2GiB
-	m, _, err := loadBpfProgram(logger, true, memLock)
+	m, _, err := loadBpfProgram(logger, true, true, memLock)
 	require.NoError(t, err)
 
 	return m, err


### PR DESCRIPTION
The current logging is very comprehensive and helpful during debugging but it's a waste of cycles to always log in production. Besides efficiency, logging so much is a bit antisocial too, as engineers using BPF logging facilities in other applications or debug tools will get flooded with Parca's logs.

Additionally, while some additional branches might not have a big perf hit, modern kernels will completely remove the branch that test whether debug is enabled or not.

Test Plan
=========

With
```
--verbose-bpf-logging
```

logs are shown, without it, just the stats:

```
             irb-11693   [002] d.h2.  4845.737945: bpf_trace_printk: [[ stats for cpu 2 ]]
             irb-11693   [002] d.h2.  4845.737947: bpf_trace_printk:    success=130
             irb-11693   [002] d.h2.  4845.737947: bpf_trace_printk:    unsup_expression=0
             irb-11693   [002] d.h2.  4845.737947: bpf_trace_printk:    truncated=0
             irb-11693   [002] d.h2.  4845.737948: bpf_trace_printk:    catchall=0
             irb-11693   [002] d.h2.  4845.737948: bpf_trace_printk:    never=0
             irb-11693   [002] d.h2.  4845.737948: bpf_trace_printk:    unknown_jit=20
             irb-11693   [002] d.h2.  4845.737948: bpf_trace_printk:    total_counter=250
             irb-11693   [002] d.h2.  4845.737949: bpf_trace_printk:    (not_covered=164)
```