### PR TITLE
bpf: Make unwind row size ~12% smaller

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -26,7 +26,7 @@
 #define MAX_TAIL_CALLS 10
 // Maximum number of frames.
 #define MAX_STACK_DEPTH 127
-_Static_assert(MAX_TAIL_CALLS *MAX_STACK_DEPTH_PER_PROGRAM >= MAX_STACK_DEPTH, "Not enough iterations to traverse the whole stack");
+_Static_assert(MAX_TAIL_CALLS *MAX_STACK_DEPTH_PER_PROGRAM >= MAX_STACK_DEPTH, "enough iterations to traverse the whole stack");
 // Number of unique stacks.
 #define MAX_STACK_TRACES_ENTRIES 64000
 // Number of items in the stack counts aggregation map.
@@ -39,7 +39,7 @@ _Static_assert(MAX_TAIL_CALLS *MAX_STACK_DEPTH_PER_PROGRAM >= MAX_STACK_DEPTH, "
 // Size of the unwind table.
 // 250k * sizeof(stack_unwind_row_t) = 2MB
 #define MAX_UNWIND_TABLE_SIZE 250 * 1000
-_Static_assert(1 << MAX_BINARY_SEARCH_DEPTH >= MAX_UNWIND_TABLE_SIZE, "Unwind table too small");
+_Static_assert(1 << MAX_BINARY_SEARCH_DEPTH >= MAX_UNWIND_TABLE_SIZE, "unwind table is big enough");
 
 // Unwind tables bigger than can't fit in the remaining space
 // of the current shard are broken up into chunks up to `MAX_UNWIND_TABLE_SIZE`.
@@ -180,15 +180,15 @@ typedef struct {
   stack_trace_t stack;
 } unwind_state_t;
 
-// A row in the stack unwinding table.
-typedef struct stack_unwind_row {
+// A row in the stack unwinding table for x86_64.
+typedef struct __attribute__((packed)) {
   u64 pc;
-  u16 __reserved_do_not_use;
   u8 cfa_type;
   u8 rbp_type;
   s16 cfa_offset;
   s16 rbp_offset;
 } stack_unwind_row_t;
+_Static_assert(sizeof(stack_unwind_row_t) == 14, "unwind row has the expected size");
 
 // Unwinding table representation.
 typedef struct stack_unwind_table {

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -92,8 +92,17 @@ const (
 			shard_info_t shards[MAX_UNWIND_TABLE_CHUNKS];
 		} stack_unwind_table_shards_t;
 	*/
-	unwindShardsSizeBytes              = maxUnwindTableChunks * 8 * 5
-	compactUnwindRowSizeBytes          = int(unsafe.Sizeof(unwind.CompactUnwindTableRow{}))
+	unwindShardsSizeBytes = maxUnwindTableChunks * 8 * 5
+	/*
+		typedef struct __attribute__((packed)) {
+		  u64 pc;
+		  u8 cfa_type;
+		  u8 rbp_type;
+		  s16 cfa_offset;
+		  s16 rbp_offset;
+		} stack_unwind_row_t;
+	*/
+	compactUnwindRowSizeBytes          = 14
 	minRoundsBeforeRedoingUnwindTables = 5
 	maxCachedProcesses                 = 10_0000
 )
@@ -553,8 +562,6 @@ func (m *bpfMaps) generateCompactUnwindTable(fullExecutablePath string, mapping 
 func (m *bpfMaps) writeUnwindTableRow(rowSlice *profiler.EfficientBuffer, row unwind.CompactUnwindTableRow) {
 	// .pc
 	rowSlice.PutUint64(row.Pc())
-	// .__reserved_do_not_use
-	rowSlice.PutUint16(row.ReservedDoNotUse())
 	// .cfa_type
 	rowSlice.PutUint8(row.CfaType())
 	// .rbp_type


### PR DESCRIPTION
By not writing the field that we will use in arm64 for the saved return address which is not needed in x86_64. This saves 2 bytes, going from 16 to 14 bytes.

Test Plan
=========

No errors with `--verbose-bpf-logging`
```
[javierhonduco@fedora parca]$ sudo bpftool prog tracelog  | grep err

```