### PR TITLE
bpf: Remove comment warning on helpers

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -4,10 +4,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright 2022 The Parca Authors
-//
-// NOTICE: When modifying this code, check
-// https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md for the
-// features supported by which kernels.
 
 #include "../common.h"
 #include "../vmlinux.h"


### PR DESCRIPTION
We have kernel tests that will ensure that we don't add helpers that cause regressions.

Additionally, there are many other sources of BPF loading issues, beyond helper usage, such as using of global variables, etc