### PR TITLE
bpf: Increase total stats after we've showed them

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -328,10 +328,10 @@ static void unwind_print_stats() {
 static void bump_samples() {
   u32 *c = bpf_map_lookup_elem(&percpu_stats, &UNWIND_SAMPLES_COUNT);
   if (c != NULL) {
-    *c += 1;
     if (*c % 50 == 0) {
       unwind_print_stats();
     }
+    *c += 1;
   }
 }
 


### PR DESCRIPTION
To avoid the +1 in the total counter

Test Plan
========

**before**

```
        mariadbd-22886   [010] d.h2.  3212.361146: bpf_trace_printk: [[ stats for cpu 10 ]]
        mariadbd-22886   [010] d.h2.  3212.361153: bpf_trace_printk:    success=251
        mariadbd-22886   [010] d.h2.  3212.361155: bpf_trace_printk:    unsup_expression=0
        mariadbd-22886   [010] d.h2.  3212.361158: bpf_trace_printk:    unsup_frame=0
        mariadbd-22886   [010] d.h2.  3212.361160: bpf_trace_printk:    truncated=0
        mariadbd-22886   [010] d.h2.  3212.361162: bpf_trace_printk:    catchall=0
        mariadbd-22886   [010] d.h2.  3212.361164: bpf_trace_printk:    never=0
        mariadbd-22886   [010] d.h2.  3212.361166: bpf_trace_printk:    unknown_jit=0
        mariadbd-22886   [010] d.h2.  3212.361168: bpf_trace_printk:    total_counter=250
```

**after**

```
        mariadbd-22886   [010] d.h2.  3212.361146: bpf_trace_printk: [[ stats for cpu 10 ]]
        mariadbd-22886   [010] d.h2.  3212.361153: bpf_trace_printk:    success=250
        mariadbd-22886   [010] d.h2.  3212.361155: bpf_trace_printk:    unsup_expression=0
        mariadbd-22886   [010] d.h2.  3212.361158: bpf_trace_printk:    unsup_frame=0
        mariadbd-22886   [010] d.h2.  3212.361160: bpf_trace_printk:    truncated=0
        mariadbd-22886   [010] d.h2.  3212.361162: bpf_trace_printk:    catchall=0
        mariadbd-22886   [010] d.h2.  3212.361164: bpf_trace_printk:    never=0
        mariadbd-22886   [010] d.h2.  3212.361166: bpf_trace_printk:    unknown_jit=0
        mariadbd-22886   [010] d.h2.  3212.361168: bpf_trace_printk:    total_counter=250
```