### PR TITLE
bpf: Bump max mappings per process to 250

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -41,7 +41,7 @@ _Static_assert(1 << MAX_BINARY_SEARCH_DEPTH >= MAX_UNWIND_TABLE_SIZE, "unwind ta
 // of the current shard are broken up into chunks up to `MAX_UNWIND_TABLE_SIZE`.
 #define MAX_UNWIND_TABLE_CHUNKS 30
 // Maximum memory mappings per process.
-#define MAX_MAPPINGS_PER_PROCESS 120
+#define MAX_MAPPINGS_PER_PROCESS 250
 
 // Values for dwarf expressions.
 #define DWARF_EXPRESSION_UNKNOWN 0

--- a/kerneltest/vmtest.sh
+++ b/kerneltest/vmtest.sh
@@ -91,7 +91,7 @@ run_tests() {
         # Ensure that the adaptive unwind shard mechanism
         # works in memory constrained environments.
         if [[ "$kernel" == "5.4" ]]; then
-            vm_run "$kernel" "0.4G"
+            vm_run "$kernel" "0.5G"
         else
             vm_run "$kernel" "1.5G"
         fi

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -57,7 +57,7 @@ const (
 	// we have tested is 262k per map, which we rounded it down to 250k.
 	maxUnwindShards       = 50         // How many unwind table shards we have.
 	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in the BPF program.
-	maxMappingsPerProcess = 120        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
+	maxMappingsPerProcess = 250        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
 	maxUnwindTableChunks  = 30         // Always need to be in sync with MAX_UNWIND_TABLE_CHUNKS.
 
 	/*


### PR DESCRIPTION
While the current limit is enough for most applications, there are some behemoths out there, looking at you, gnome-shell, that bring more than 150 mappings.

Let's bump the maximum mappings so we can support many other processes. This increases our memory footprint and it's something we will be looking to optimise in the future.

Note that we still perform a linear search over the array of mappings. We'll also measure the impact of switching this to other searching algorithms and decide if it's worth changing it.

Test Plan
=========

Ran the agent for 30 mins without any issue, 100% of the firefox stacks were collected https://pprof.me/9a8a8c3

```
=============
Test results:
=============
- ✅ 5.4
- ✅ 5.10
- ✅ 5.18
- ✅ 5.19
```