### PR TITLE
unwinding/native: Ignore jitdump sections

### DIFF
--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -506,8 +506,11 @@ func (m *bpfMaps) addUnwindTableForProcess(pid int) error {
 	mappingInfoMemory.PutUint64(uint64(len(executableMappings)))
 
 	for _, executableMapping := range executableMappings {
+		if executableMapping.IsJitDump() {
+			continue
+		}
 		if err := m.setUnwindTableForMapping(&mappingInfoMemory, pid, executableMapping); err != nil {
-			return fmt.Errorf("setUnwindTableForMapping failed: %w", err)
+			return fmt.Errorf("setUnwindTableForMapping for executable %s starting at 0x%x failed: %w", executableMapping.Executable, executableMapping.StartAddr, err)
 		}
 	}
 

--- a/pkg/stack/unwind/maps.go
+++ b/pkg/stack/unwind/maps.go
@@ -16,6 +16,7 @@ package unwind
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/prometheus/procfs"
 )
@@ -46,6 +47,13 @@ func (pm *ExecutableMapping) IsMainObject() bool {
 // called to make it r+w only.
 func (pm *ExecutableMapping) IsJitted() bool {
 	return pm.Executable == ""
+}
+
+// IsJitDump returns whether the mapping looks like a jitdump[0] file.
+//
+// [0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jitdump-specification.txt
+func (pm *ExecutableMapping) IsJitDump() bool {
+	return strings.Contains(pm.Executable, "jit") && strings.HasSuffix(pm.Executable, ".dump")
 }
 
 // IsNotFileBacked returns whether the mapping is not backed by a

--- a/pkg/stack/unwind/maps_test.go
+++ b/pkg/stack/unwind/maps_test.go
@@ -98,6 +98,15 @@ func TestMappingSpecialSectionDetectionWorks(t *testing.T) {
 	require.True(t, result[0].IsSpecial())
 }
 
+func TestMappingJitDumpDetectionWorks(t *testing.T) {
+	rawMaps := []*procfs.ProcMap{
+		{StartAddr: 0x0, EndAddr: 0x100, Perms: &procfs.ProcMapPermissions{Execute: true}, Pathname: "/jit-4.dump"},
+	}
+	result := ListExecutableMappings(rawMaps)
+	require.Equal(t, 1, len(result))
+	require.True(t, result[0].IsJitDump())
+}
+
 func TestExecutableMappingCountWorks(t *testing.T) {
 	rawMaps := []*procfs.ProcMap{}
 	require.Equal(t, uint(0), executableMappingCount(rawMaps))


### PR DESCRIPTION
Reported by an user after seeing a bunch of errors in their production cluster such as:

```
elf.Open failed: bad magic number '[68 84 105 74]' in record at byte 0x0"
```

They graciously provided the mappings for this process, and this one stood out:

```
7f6c903cc000-7f6c903cd000 r-xp 00000000 08:01 403978                     /tmp/jit-11.dump
```

This commit also adds extra context to the logs to make it easier to debug these issues in the future.