### PR TITLE
chore: migrate to `nix develop`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ kerneltest/cpu.test
 kerneltest/initramfs.cpio
 kerneltest/logs/vm_log_*.txt
 kerneltest/kernels/linux-*.bz
+
+# direnv / Nix
+.direnv
+.envrc
+result*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,7 @@ repos:
     rev: v0.19.2-pre2
     hooks:
       - id: jsonnet-format
+  - repo: https://github.com/nix-community/nixpkgs-fmt
+    rev: v1.3.0
+    hooks:
+      - id: nixpkgs-fmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ $ sudo apt-get install make zlib1g pkg-config libclang-11-dev llvm-11-dev libbpf
 ```
 
 Alternatively, [Nix](https://nixos.org/download.html#download-nix) can be used to avoid installing system packages,
-simply run `nix-shell` (or `nix-shell shell.nix`) to load the dependencies. Docker and VirtualBox are required to be installed as system packages.
+simply run `nix-shell` or `nix develop` to load the dependencies. Docker and VirtualBox are required to be installed as system packages.
 
 # Getting Started
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677676435,
+        "narHash": "sha256-6FxdcmQr5JeZqsQvfinIMr0XcTyTuR7EXX0H3ANShpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a08d6979dd7c82c4cef0dcc6ac45ab16051c1169",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "eBPF based always-on profiler auto-discovering targets in Kubernetes and systemd, zero code changes or restarts needed!";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      pkgs-x86_64-linux = { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
+      pkgs-aarch64-linux = { pkgs = nixpkgs.legacyPackages.aarch64-linux; };
+
+      devShell = { pkgs }: import ./nix/devshell.nix { inherit pkgs; };
+    in
+    {
+      devShells.aarch64-linux.default = devShell pkgs-aarch64-linux;
+      devShells.x86_64-linux.default = devShell pkgs-x86_64-linux;
+    };
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,37 @@
+{ pkgs }:
+
+let
+  goTools = pkgs.callPackage (import ./go-tools.nix) { };
+in
+(pkgs.mkShell.override {
+  inherit (pkgs.llvmPackages_14) stdenv;
+}) rec {
+  name = "parca-agent-devshell";
+
+  packages = with pkgs; [
+    bpftools
+    docker-machine-kvm2
+    elfutils.dev
+    glibc.dev
+    glibc.static
+    go-jsonnet
+    goTools.bluebox
+    goTools.embedmd
+    go_1_20
+    gofumpt
+    gojsontoyaml
+    # Build with Go 1.20
+    # https://github.com/golangci/golangci-lint/issues/3565
+    (golangci-lint.override {
+      buildGoModule = buildGo120Module;
+    })
+    jsonnet-bundler
+    kubectl
+    llvm_14
+    minikube
+    pkg-config
+    pre-commit
+    tilt
+    zlib.static
+  ];
+}

--- a/nix/go-tools.nix
+++ b/nix/go-tools.nix
@@ -1,0 +1,67 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+{
+  bluebox = buildGoModule rec {
+    pname = "bluebox";
+    version = "0.0.1";
+
+    src = fetchFromGitHub {
+      owner = "florianl";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-h7NhJ/V0FaMX7F6OG+FJB4h3nSXUE/4ZYeUwoBZo0C0=";
+    };
+
+    vendorSha256 = "sha256-dSYu5Sb6hBTnNE4PXHQK6oGQasCrSu4l7KqhYJxTNDQ=";
+
+    CGO_ENABLED = 0;
+
+    ldflags = [ "-X main.version=${version}" ];
+
+    meta = with lib; {
+      description = "bluebox is intended to fast build a low overhead environment to be able to run tests against Linux kernel APIs like netlink or ebpf";
+      homepage = "https://github.com/florianl/bluebox";
+      license = licenses.mit;
+    };
+  };
+
+  embedmd = buildGoModule rec {
+    pname = "embedmd";
+    # v2 is actually broken, import from main points to v1
+    version = "1.0.0";
+
+    src = fetchFromGitHub {
+      owner = "campoy";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-hfMI2d3iRe74nUQ9ydgXUshStk9LFWXkJL1/7ZsEX6g=";
+    };
+
+    vendorSha256 = "sha256-0rVwjFULl9mrce6eMSueuybPJmuLIZr1alG4AwOD+OU=";
+
+    CGO_ENABLED = 0;
+
+    ldflags = [ "-X main.version=${version}" ];
+
+    # Patches may be a cleaner choice, but substituteInPlace keeps things self-contained
+    preCheck = ''
+      # Replace embedmd excetable path
+      substituteInPlace ./integration_test.go \
+        --replace embedmd "$GOPATH/bin/embedmd"
+
+      # Fix expected error message in TestProcess/embedding_code_from_a_bad_URL
+      substituteInPlace ./embedmd/embedmd_test.go \
+        --replace 'parse https://fakeurl.com\\main.go:' 'parse \"https://fakeurl.com\\\\main.go\":'
+
+      # Replace HTTP URLs, tests run offline.
+      substituteInPlace ./sample/docs.md ./sample/result.md \
+        --replace 'https://raw.githubusercontent.com/campoy/embedmd/master/sample/' './'
+    '';
+
+    meta = with lib; {
+      description = "embed code into markdown and keep everything in sync";
+      homepage = "https://github.com/campoy/embedmd";
+      license = licenses.asl20;
+    };
+  };
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["github>parca-dev/.github"],
   "reviewers": ["team:agent-maintainers"],
   "rangeStrategy": "pin",
+  "nix": { "enabled": true },
   "packageRules": [
     {
       "description": "Group parca packages",

--- a/shell.nix
+++ b/shell.nix
@@ -1,25 +1,10 @@
-{ pkgs ? import <nixpkgs> { } }:
-
-pkgs.mkShell rec {
-  name = "parca-agent";
-
-  packages = with pkgs; [
-    clang_11
-    elfutils.dev
-    gnumake
-    go_1_19
-    kubectl
-    llvmPackages_14.llvm
-    minikube
-    docker-machine-kvm2
-    pkg-config
-    zlib.static
-  ] ++ (lib.optional stdenv.isLinux [ glibc.dev glibc.static ]);
-
-  shellHook = ''
-    export PATH="''${PROJECT_ROOT}/bin:''${PATH}"
-  '';
-
-  PROJECT_ROOT = builtins.toString ./.;
-  GOBIN = "${PROJECT_ROOT}/bin";
-}
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
This uses the experimental `nix develop` command with Nix Flakes, this way we can use the unstable channel to get the latest packages and lock its revision with ease (Renovate has support for Nix Flakes). I made the list of packages more exhaustive as well.

`nix-shell` is still usable for now thanks to the [flake-compat](https://github.com/edolstra/flake-compat) module.