### PR TITLE
pkg/discovery: systemd discoverer with less allocs

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -364,7 +364,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				flags.Node,
 				flags.MetadataContainerRuntimeSocketPath,
 			),
-			discovery.NewSystemdConfig(),
+			discovery.NewSystemd2Config(),
 		}
 		discoveryManager = discovery.NewManager(logger, reg)
 		if err := discoveryManager.ApplyConfig(ctx, map[string]discovery.Configs{"all": configs}); err != nil {

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -364,7 +364,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				flags.Node,
 				flags.MetadataContainerRuntimeSocketPath,
 			),
-			discovery.NewSystemd2Config(),
+			discovery.NewSystemdConfig(),
 		}
 		discoveryManager = discovery.NewManager(logger, reg)
 		if err := discoveryManager.ApplyConfig(ctx, map[string]discovery.Configs{"all": configs}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cilium/ebpf v0.10.0
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
-	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/docker v20.10.23+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fsnotify/fsnotify v1.6.0
@@ -22,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
 	github.com/klauspost/compress v1.16.0
-	github.com/marselester/systemd v0.0.0-20230310181427-d65a642104a7
+	github.com/marselester/systemd v0.0.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/oklog/run v1.1.0
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1.0.20230201033851-7301c345492a
@@ -87,7 +86,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
-	github.com/godbus/dbus/v5 v5.1.1-0.20221223143132-c1a76c14e486 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
 	github.com/klauspost/compress v1.16.0
+	github.com/marselester/systemd v0.0.0-20230310181427-d65a642104a7
 	github.com/minio/highwayhash v1.0.2
 	github.com/oklog/run v1.1.0
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1.0.20230201033851-7301c345492a

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkE
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosiner/argv v0.1.0/go.mod h1:EusR6TucWKX+zFgtdUsKT2Cvg45K5rtpCcWz4hK06d8=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -182,9 +180,6 @@ github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRi
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goburrow/cache v0.1.4 h1:As4KzO3hgmzPlnaMniZU9+VmoNYseUhuELbxy9mRBfw=
 github.com/goburrow/cache v0.1.4/go.mod h1:cDFesZDnIlrHoNlMYqqMpCRawuXulgx+y7mXU8HZ+/c=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/godbus/dbus/v5 v5.1.1-0.20221223143132-c1a76c14e486 h1:Ong/oLaBsq0b+/tjpflWZMqhjs7zQpYv4qqRZz7WsRM=
-github.com/godbus/dbus/v5 v5.1.1-0.20221223143132-c1a76c14e486/go.mod h1:fXoNnqaUvdKqjJmMGeiBgmRphUg+kO0MT4AhPOP6+Qg=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -341,8 +336,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/marselester/systemd v0.0.0-20230310181427-d65a642104a7 h1:ip7D1DMNahWLbIri9hW8jvsnGudG6tWyMOs5vMQwgRU=
-github.com/marselester/systemd v0.0.0-20230310181427-d65a642104a7/go.mod h1:GqNcIL3xE2CpD82h1IEMirLWMRLm6KXHLRCsJg1SpxQ=
+github.com/marselester/systemd v0.0.2 h1:Tuft90dvKtvhBIfqAj4Odwm5BBCMhtQIlN4o4vZa0eY=
+github.com/marselester/systemd v0.0.2/go.mod h1:GqNcIL3xE2CpD82h1IEMirLWMRLm6KXHLRCsJg1SpxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -628,7 +623,6 @@ golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/marselester/systemd v0.0.0-20230310181427-d65a642104a7 h1:ip7D1DMNahWLbIri9hW8jvsnGudG6tWyMOs5vMQwgRU=
+github.com/marselester/systemd v0.0.0-20230310181427-d65a642104a7/go.mod h1:GqNcIL3xE2CpD82h1IEMirLWMRLm6KXHLRCsJg1SpxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=

--- a/pkg/discovery/systemd.go
+++ b/pkg/discovery/systemd.go
@@ -22,6 +22,7 @@ import (
 	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	systemd2 "github.com/marselester/systemd"
 	"github.com/prometheus/common/model"
 )
 
@@ -106,4 +107,126 @@ func (c *SystemdDiscoverer) Run(ctx context.Context, up chan<- []*Group) error {
 			return ctx.Err()
 		}
 	}
+}
+
+type Systemd2Config struct{}
+
+func NewSystemd2Config() *Systemd2Config {
+	return &Systemd2Config{}
+}
+
+func (c *Systemd2Config) Name() string {
+	return "systemd2"
+}
+
+func (c *Systemd2Config) NewDiscoverer(d DiscovererOptions) (Discoverer, error) {
+	return &Systemd2Discoverer{
+		logger: d.Logger,
+		prev:   make(map[string]systemd2.Unit),
+	}, nil
+}
+
+type Systemd2Discoverer struct {
+	logger log.Logger
+	prev   map[string]systemd2.Unit
+}
+
+func (d *Systemd2Discoverer) Run(ctx context.Context, up chan<- []*Group) error {
+	c, err := systemd2.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to systemd D-Bus API, %w", err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			level.Warn(d.logger).Log("msg", "failed to close systemd", "err", err)
+		}
+	}()
+
+	for {
+		select {
+		case <-time.After(5 * time.Second):
+			update, err := d.updatedUnits(c)
+			if err != nil {
+				level.Warn(d.logger).Log("msg", "failed to get units from systemd D-Bus API", "err", err)
+				continue
+			}
+			if len(update) == 0 {
+				continue
+			}
+
+			groups := make([]*Group, 0, len(update))
+			for unitName, unit := range update {
+				if unit.Name == "" || unit.SubState != "running" {
+					groups = append(groups, &Group{Source: unitName})
+					continue
+				}
+
+				pid, err := c.MainPID(unitName)
+				if err != nil {
+					level.Warn(d.logger).Log("msg", "failed to get MainPID from systemd D-Bus API", "err", err, "unit", unitName)
+					continue
+				}
+
+				groups = append(groups, &Group{
+					Targets: []model.LabelSet{{}},
+					Labels: model.LabelSet{
+						model.LabelName("systemd_unit"): model.LabelValue(unitName),
+					},
+					Source:   unitName,
+					EntryPID: int(pid),
+				})
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case up <- groups:
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// updatedUnits is like SubscribeUnitsCustom
+// from github.com/coreos/go-systemd/v22/dbus,
+// i.e., it returns systemd units if there were any changes detected.
+func (d *Systemd2Discoverer) updatedUnits(c *systemd2.Client) (map[string]systemd2.Unit, error) {
+	cur := make(map[string]systemd2.Unit)
+	err := c.ListUnits(systemd2.IsService, func(u *systemd2.Unit) {
+		// Must copy a unit,
+		// otherwise it will be modified on the next function call.
+		cur[u.Name] = *u
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect all new and changed units.
+	changed := make(map[string]systemd2.Unit)
+	for name, unit := range cur {
+		prevUnit, ok := d.prev[name]
+		// Is it a new unit or
+		// the existing one but with an updated substate?
+		if !ok || prevUnit.SubState != unit.SubState {
+			changed[name] = unit
+		}
+
+		delete(d.prev, name)
+	}
+
+	// Add all deleted units.
+	for name := range d.prev {
+		changed[name] = systemd2.Unit{}
+	}
+
+	d.prev = cur
+
+	// No changes.
+	if len(changed) == 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	return changed, nil
 }

--- a/pkg/discovery/systemd.go
+++ b/pkg/discovery/systemd.go
@@ -16,28 +16,22 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	systemd2 "github.com/marselester/systemd"
+	systemd "github.com/marselester/systemd"
 	"github.com/prometheus/common/model"
 )
 
 type SystemdConfig struct{}
 
-type SystemdDiscoverer struct {
-	logger log.Logger
+func NewSystemdConfig() *SystemdConfig {
+	return &SystemdConfig{}
 }
 
 func (c *SystemdConfig) Name() string {
 	return "systemd"
-}
-
-func NewSystemdConfig() *SystemdConfig {
-	return &SystemdConfig{}
 }
 
 func (c *SystemdConfig) NewDiscoverer(d DiscovererOptions) (Discoverer, error) {
@@ -46,93 +40,13 @@ func (c *SystemdConfig) NewDiscoverer(d DiscovererOptions) (Discoverer, error) {
 	}, nil
 }
 
-func (c *SystemdDiscoverer) Run(ctx context.Context, up chan<- []*Group) error {
-	conn, err := systemd.NewWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to connect to systemd D-Bus API, %w", err)
-	}
-	defer conn.Close()
-
-	isSubStateChanged := func(u1, u2 *systemd.UnitStatus) bool {
-		return u1.SubState != u2.SubState
-	}
-
-	isNotService := func(name string) bool {
-		return !strings.HasSuffix(name, ".service")
-	}
-
-	updateCh, errCh := conn.SubscribeUnitsCustom(5*time.Second, 0, isSubStateChanged, isNotService)
-
-	for {
-		select {
-		case update := <-updateCh:
-			var groups []*Group
-
-			for unit, status := range update {
-				if status == nil || status.SubState != "running" {
-					groups = append(groups, &Group{Source: unit})
-					continue
-				}
-
-				mainPIDProperty, err := conn.GetServicePropertyContext(ctx, unit, "MainPID")
-				if err != nil {
-					level.Warn(c.logger).Log("msg", "failed to get MainPID property for service", "err", err, "unit", unit)
-					continue
-				}
-
-				pid, ok := mainPIDProperty.Value.Value().(uint32)
-				if !ok {
-					level.Warn(c.logger).Log("msg", "failed to assert type of PID", "unit", unit)
-					continue
-				}
-
-				groups = append(groups, &Group{
-					Targets: []model.LabelSet{{}},
-					Labels: model.LabelSet{
-						model.LabelName("systemd_unit"): model.LabelValue(unit),
-					},
-					Source:   unit,
-					EntryPID: int(pid),
-				})
-			}
-
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case up <- groups:
-			}
-		case err := <-errCh:
-			level.Warn(c.logger).Log("msg", "received error from systemd D-Bus API", "err", err)
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-type Systemd2Config struct{}
-
-func NewSystemd2Config() *Systemd2Config {
-	return &Systemd2Config{}
-}
-
-func (c *Systemd2Config) Name() string {
-	return "systemd2"
-}
-
-func (c *Systemd2Config) NewDiscoverer(d DiscovererOptions) (Discoverer, error) {
-	return &Systemd2Discoverer{
-		logger: d.Logger,
-		prev:   make(map[string]systemd2.Unit),
-	}, nil
-}
-
-type Systemd2Discoverer struct {
+type SystemdDiscoverer struct {
 	logger log.Logger
-	prev   map[string]systemd2.Unit
+	units  map[string]systemd.Unit
 }
 
-func (d *Systemd2Discoverer) Run(ctx context.Context, up chan<- []*Group) error {
-	c, err := systemd2.New()
+func (d *SystemdDiscoverer) Run(ctx context.Context, up chan<- []*Group) error {
+	c, err := systemd.New()
 	if err != nil {
 		return fmt.Errorf("failed to connect to systemd D-Bus API, %w", err)
 	}
@@ -145,7 +59,7 @@ func (d *Systemd2Discoverer) Run(ctx context.Context, up chan<- []*Group) error 
 	for {
 		select {
 		case <-time.After(5 * time.Second):
-			update, err := d.updatedUnits(c)
+			update, err := d.unitsUpdate(c)
 			if err != nil {
 				level.Warn(d.logger).Log("msg", "failed to get units from systemd D-Bus API", "err", err)
 				continue
@@ -189,44 +103,42 @@ func (d *Systemd2Discoverer) Run(ctx context.Context, up chan<- []*Group) error 
 	}
 }
 
-// updatedUnits is like SubscribeUnitsCustom
-// from github.com/coreos/go-systemd/v22/dbus,
-// i.e., it returns systemd units if there were any changes detected.
-func (d *Systemd2Discoverer) updatedUnits(c *systemd2.Client) (map[string]systemd2.Unit, error) {
-	cur := make(map[string]systemd2.Unit)
-	err := c.ListUnits(systemd2.IsService, func(u *systemd2.Unit) {
+// unitsUpdate returns systemd units if there were any changes detected.
+func (d *SystemdDiscoverer) unitsUpdate(c *systemd.Client) (map[string]systemd.Unit, error) {
+	recent := make(map[string]systemd.Unit)
+	err := c.ListUnits(systemd.IsService, func(u *systemd.Unit) {
 		// Must copy a unit,
 		// otherwise it will be modified on the next function call.
-		cur[u.Name] = *u
+		recent[u.Name] = *u
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Collect all new and changed units.
-	changed := make(map[string]systemd2.Unit)
-	for name, unit := range cur {
-		prevUnit, ok := d.prev[name]
+	// Collect new and changed units.
+	update := make(map[string]systemd.Unit)
+	for unitName, unit := range recent {
+		seenUnit, ok := d.units[unitName]
 		// Is it a new unit or
 		// the existing one but with an updated substate?
-		if !ok || prevUnit.SubState != unit.SubState {
-			changed[name] = unit
+		if !ok || seenUnit.SubState != unit.SubState {
+			update[unitName] = unit
 		}
 
-		delete(d.prev, name)
+		delete(d.units, unitName)
 	}
 
-	// Add all deleted units.
-	for name := range d.prev {
-		changed[name] = systemd2.Unit{}
+	// Indicate that units were deleted.
+	for unitName := range d.units {
+		update[unitName] = systemd.Unit{}
 	}
 
-	d.prev = cur
+	d.units = recent
 
 	// No changes.
-	if len(changed) == 0 {
+	if len(update) == 0 {
 		return nil, nil //nolint:nilnil
 	}
 
-	return changed, nil
+	return update, nil
 }


### PR DESCRIPTION
Hi! I would like to share some of the results I got with https://github.com/marselester/systemd. ~~There are still things I need to finish though...~~

The current version of `discovery.SystemdDiscoverer` makes use of 1.1 MB/op and 32,332 allocs/op to get a list of systemd services along with their PIDs. That accounts for 40% of CPU cycles in the agent, excluding the GC time, see https://pprof.me/e711789. The proposed change gets 13.96 KB/op and 30 allocs/op.

```
BenchmarkSystemd-2    	       1	1001314916 ns/op	 1163552 B/op	   32332 allocs/op
BenchmarkSystemd2-2   	       1	1003780290 ns/op	   14304 B/op	      30 allocs/op
```

I ran the benchmarks as follows:

- temporarily removed `pkg/discovery/kubernetes.go` or else tests won't run `github.com/parca-dev/parca-agent/pkg/cgroup: build constraints exclude all Go files in /vagrant/parca-agent/pkg/cgroup`
- placed the benchmarks into `pkg/discovery/systemd_test.go`
- `sudo go test -run=^$ -bench=. -benchmem .`

<details>

```go
// The benchmarks are not pretty, but at least they give a rough idea.

func BenchmarkSystemd(b *testing.B) {
	ctx := context.Background()
	conf := NewSystemdConfig()
	d, err := conf.NewDiscoverer(DiscovererOptions{})
	if err != nil {
		b.Fatal(err)
	}

	up := make(chan<- []*Group)
	ctx, cancel := context.WithTimeout(ctx, time.Second)
	b.Cleanup(cancel)

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if err = d.Run(ctx, up); err != nil && err != context.DeadlineExceeded {
			b.Fatal(err)
		}
	}
}

func BenchmarkSystemd2(b *testing.B) {
	ctx := context.Background()
	conf := NewSystemd2Config()
	d, err := conf.NewDiscoverer(DiscovererOptions{})
	if err != nil {
		b.Fatal(err)
	}

	up := make(chan<- []*Group)
	ctx, cancel := context.WithTimeout(ctx, time.Second)
	b.Cleanup(cancel)

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if err = d.Run(ctx, up); err != nil && err != context.DeadlineExceeded {
			b.Fatal(err)
		}
	}
}
```

</details>

I've added `fmt.Printf` to see whether the current implementation and a new one show the same services/PIDs.
I also tried to stop and start a cron service to make sure that was picked up in the updates.
The output matches.

It would be cool if you guys could have a look and give it a go in a safe environment.

```sh
$ make && sudo ./dist/parca-agent 2>&1 | grep --invert-match 'libbpf'
systemd-timesyncd.service 459
user@1000.service 1468
systemd-networkd.service 607
unattended-upgrades.service 748
systemd-logind.service 675
dbus.service 663
systemd-journald.service 364
systemd-udevd.service 405
irqbalance.service 668
snapd.service 673
udisks2.service 676
cron.service 36684
polkit.service 32180
systemd-resolved.service 609
packagekit.service 15442
multipathd.service 402
networkd-dispatcher.service 669
getty@tty1.service 686
serial-getty@ttyS0.service 683
ModemManager.service 32184
ssh.service 711
rsyslog.service 671
```