### PR TITLE
unwinder/native: Export metrics

### DIFF
--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -52,6 +52,7 @@ const (
 	unwindTablesMapName     = "unwind_tables"
 	processInfoMapName      = "process_info"
 	programsMapName         = "programs"
+	perCPUStatsMapName      = "percpu_stats"
 
 	// With the current compact rows, the max items we can store in the kernels
 	// we have tested is 262k per map, which we rounded it down to 250k.
@@ -107,6 +108,19 @@ const (
 	minRoundsBeforeRedoingUnwindTables = 5
 	maxCachedProcesses                 = 10_0000
 )
+
+// Must be in sync with the BPF program.
+type unwinderStats struct {
+	Total                  uint64
+	SuccessDwarf           uint64
+	ErrorTruncated         uint64
+	ErrorUnsupExpression   uint64
+	ErrorFramePointerRule  uint64
+	ErrorShouldNeverHappen uint64
+	ErrorCatchall          uint64
+	ErrorPcNotCovered      uint64
+	ErrorUnsupportedJit    uint64
+}
 
 const (
 	mappingTypeJitted  = 1


### PR DESCRIPTION
The unwinder stats that we have been logging using BPF's printing facilities have been very useful during the development of the DWARF-based unwinder. It has surfaced areas of improvement and bugs.

This commit exports the counters via Prometheus so our users and ourselves can track how the native unwinder is doing.

In this commit, there are some other changes:
- Grouped the statistics to a single struct to be able to read the whole struct at once;
- Before, the JIT samples that we are dropping weren't accounted properly if the first frame was already JIT'ed;

Note that these metrics will always be inherently racy and the sum of success + failure might be slightly different than the total sample count. For more context, check out the comment in `metrics.go`.

Notes
=====

Just to reiterate for those of you following at home, we are working on improving the JIT support. Any samples that we don't know if it's correct it's dropped, never producing wrong results.

Test Plan
=========

```
[javierhonduco@fedora parca-agent]$ curl --silent http://localhost:7071/metrics | grep native_unwinder | grep -v "#"
parca_agent_native_unwinder_error_total{reason="catchall"} 0
parca_agent_native_unwinder_error_total{reason="frame_pointer_rule"} 0
parca_agent_native_unwinder_error_total{reason="pc_not_covered"} 0
parca_agent_native_unwinder_error_total{reason="should_never_happen"} 1
parca_agent_native_unwinder_error_total{reason="truncated"} 0
parca_agent_native_unwinder_error_total{reason="unsup_expression"} 0
parca_agent_native_unwinder_error_total{reason="unsupported_jit"} 3652
parca_agent_native_unwinder_samples_total{unwinder="dwarf"} 7466
parca_agent_native_unwinder_success_total{unwinder="dwarf"} 3805
```