### PR TITLE
bpf: Use our logger for libbpf logs

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -227,6 +227,12 @@ func loadBpfProgram(logger log.Logger, debugEnabled, verboseBpfLogging bool, mem
 	maxLoadAttempts := 10
 	unwindShards := uint32(maxUnwindShards)
 
+	bpf.SetLoggerCbs(bpf.Callbacks{
+		Log: func(_ int, msg string) {
+			level.Debug(logger).Log("msg", msg)
+		},
+	})
+
 	// Adaptive unwind shard count sizing.
 	for i := 0; i < maxLoadAttempts; i++ {
 		m, err = bpf.NewModuleFromBufferArgs(bpf.NewModuleArgs{


### PR DESCRIPTION
libbpfgo changed [[0]] the way it handles libbpf logs and right now they are being printed by default. This commit reroutes these logs as debug logs in our logging facilities

[0]: https://github.com/aquasecurity/libbpfgo/commit/fde1f6e5ba094d1bceb68b3e6ab038832a44bd8b