### PR TITLE
*: Populate process mappings on-demand

### DIFF
--- a/pkg/process/maps_test.go
+++ b/pkg/process/maps_test.go
@@ -66,7 +66,6 @@ func TestMapping(t *testing.T) {
 	m := &Mapping{
 		cache:       testCache(),
 		pidMappings: map[int][]*profile.Mapping{},
-		pids:        []int{},
 	}
 	mapping, err := m.PIDAddrMapping(2043862, 0x45e427)
 	require.NoError(t, err)

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -127,6 +127,11 @@ const (
 	mappingTypeSpecial = 2
 )
 
+const (
+	RequestUnwindInformation = 1 << 62
+	RequestProcessMappings   = 1 << 63
+)
+
 var (
 	errMissing                   = errors.New("missing stack trace")
 	errUnwindFailed              = errors.New("stack ID is 0, probably stack unwinding failed")

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -56,7 +56,7 @@ type Symbolizer interface {
 }
 
 type Normalizer interface {
-	Normalize(pid int, m *profile.Mapping, addr uint64) uint64
+	Normalize(pid int, m *profile.Mapping, addr uint64) (uint64, error)
 }
 
 type ObjectFileCache interface {


### PR DESCRIPTION
This commit starts the work on increasing the chances of success when profiling short-lived processes.

Among other things:
- populate the mappings cache on-demand to be able to normalize and find the build ids for processes that exit before we collect this information;
- we will now drop samples that contained frames that failed to normalize;
- reduced the unwind info batch deadline from 250 to 150 ms to increase the chance of profiling short-lived processes;

This commit doesn't tackle:
- symbolisation of short-lived processes. See comment in cpu.go;
- DWARF-based unwinding for processes that run for less than 150ms;
- improvements to how the mappings are cached;
- single stray frames that require more investigation;
- configurable batch deadlines;
- adding an eviction strategy for the different caches;

Test Plan
=========

Ran for 2h without issues.

**short-lived process: git**
```
$ while true; do git --no-pager log; done
```
<img width="1963" alt="image" src="https://user-images.githubusercontent.com/959128/225324349-2c1ca213-3ea1-4756-93ba-10719e8be34d.png">

**all processes but git**
<img width="1963" alt="image" src="https://user-images.githubusercontent.com/959128/225324581-2a6aa98c-e116-4a0e-b86a-ebf4fe96fb90.png">

