### PR TITLE
profiler: Improve normalization errors handling

### DIFF
--- a/pkg/profiler/cpu/metrics.go
+++ b/pkg/profiler/cpu/metrics.go
@@ -23,10 +23,11 @@ import (
 )
 
 type metrics struct {
-	obtainAttempts    *prometheus.CounterVec
-	obtainMapAttempts *prometheus.CounterVec
-	obtainDuration    prometheus.Histogram
-	symbolizeDuration prometheus.Histogram
+	obtainAttempts        *prometheus.CounterVec
+	obtainMapAttempts     *prometheus.CounterVec
+	normalizationAttempts *prometheus.CounterVec
+	obtainDuration        prometheus.Histogram
+	symbolizeDuration     prometheus.Histogram
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -62,6 +63,14 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 				ConstLabels:                 map[string]string{"type": "cpu"},
 				NativeHistogramBucketFactor: 1.1,
 			},
+		),
+		normalizationAttempts: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name:        "parca_agent_profiler_normalization_attempts_total",
+				Help:        "Total number of attempts normalizing frame addresses.",
+				ConstLabels: map[string]string{"type": "cpu"},
+			},
+			[]string{"status"},
 		),
 	}
 }


### PR DESCRIPTION
- Add prometheus metrics for sucess and errors;
- Skip stacks that contain frames that failed to normalize;

Test Plan
=========

```
$ curl --silent http://localhost:7071/metrics | grep parca_agent_profiler_normalization_attempts_total
parca_agent_profiler_normalization_attempts_total{status="error",type="cpu"} 3
parca_agent_profiler_normalization_attempts_total{status="success",type="cpu"} 2028
```

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/959128/226381431-42712849-a52c-4e78-8197-f6851995507a.png">