### PR TITLE
unwinder/native: Discard stacks with just one frame

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -569,14 +569,20 @@ static __always_inline bool has_fp(u64 current_fp) {
       // LOG("[debug] fp read failed with %d", err);
       return false;
     }
+
     // Some cpp binaries, such as testdata/out/basic-cpp
     // seem to have rbp set to 1 in the bottom frame. This
-    // does not comply with the x86_64 ABI, we prefer to
-    // generate unwind tables for these rather than have a
-    // special case.
+    // does not comply with the x86_64 ABI.
+    //
+    // Additionally, we consider that stacks with just one
+    // frame aren't valid. This is just a heuristic, as most
+    // processes should at least have two frames.
+    //
+    // For both cases above, we prefer to unwind using the
+    // DWARF-derived unwind information.
     if (next_fp == 0) {
       // LOG("[debug] fp success");
-      return true;
+      return i > 0;
     }
     current_fp = next_fp;
   }


### PR DESCRIPTION
We've seen a lot of single frame stacks that aren't corresponding to any
bottom frame such as `_start`, `__libc_start_main_impl`, `start_thread`,
or `runtime.goexit`, in the case of Go.

After some debugging, it looks like some applications compiled without
frame pointers have zero as their frame pointer, tripping our checks.
While this is completely valid, and perhaps a better check would be to
stop walking the stack once we've reached its end, most of the instances
for this problem show as a single frame. Theoretically it could be any
number of frames until finding `rbp=0`.

This commits implements a heuristic to work around this issue. Any
process that's been compiled normally will have at least two frames, so
let's drop samples that only contain one and generate unwind tables for
them directly.

As a side benefit, we will have a chance of capturing more samples as
we'll generate the unwind tables a bit earlier.

Later on we can have better detection of the stack boundary. We will
have to pass this info to the BPF program.

Test Plan
=========

Ran Go, C, C++ apps: https://pprof.me/c63f887/