### PR TITLE
unwinder/native: Refresh process information

### DIFF
--- a/pkg/profiler/cpu/bpf_metrics.go
+++ b/pkg/profiler/cpu/bpf_metrics.go
@@ -113,10 +113,11 @@ func (c *bpfMetricsCollector) readCounters() (unwinderStats, error) {
 		total.Total += partial.Total
 		total.SuccessDwarf += partial.SuccessDwarf
 		total.ErrorTruncated += partial.ErrorTruncated
-		total.ErrorUnsupExpression += partial.ErrorUnsupExpression
-		total.ErrorFramePointerRule += partial.ErrorFramePointerRule
-		total.ErrorShouldNeverHappen += partial.ErrorShouldNeverHappen
+		total.ErrorUnsupportedExpression += partial.ErrorUnsupportedExpression
+		total.ErrorFramePointerAction += partial.ErrorFramePointerAction
+		total.ErrorUnsupportedCfaRegister += partial.ErrorUnsupportedCfaRegister
 		total.ErrorCatchall += partial.ErrorCatchall
+		total.ErrorShouldNeverHappen += partial.ErrorShouldNeverHappen
 		total.ErrorPcNotCovered += partial.ErrorPcNotCovered
 		total.ErrorUnsupportedJit += partial.ErrorUnsupportedJit
 	}

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -111,15 +111,16 @@ const (
 
 // Must be in sync with the BPF program.
 type unwinderStats struct {
-	Total                  uint64
-	SuccessDwarf           uint64
-	ErrorTruncated         uint64
-	ErrorUnsupExpression   uint64
-	ErrorFramePointerRule  uint64
-	ErrorShouldNeverHappen uint64
-	ErrorCatchall          uint64
-	ErrorPcNotCovered      uint64
-	ErrorUnsupportedJit    uint64
+	Total                       uint64
+	SuccessDwarf                uint64
+	ErrorTruncated              uint64
+	ErrorUnsupportedExpression  uint64
+	ErrorFramePointerAction     uint64
+	ErrorUnsupportedCfaRegister uint64
+	ErrorCatchall               uint64
+	ErrorShouldNeverHappen      uint64
+	ErrorPcNotCovered           uint64
+	ErrorUnsupportedJit         uint64
 }
 
 const (

--- a/pkg/profiler/cpu/metrics.go
+++ b/pkg/profiler/cpu/metrics.go
@@ -184,8 +184,9 @@ func (c *bpfMetricsCollector) collectUnwinderStatistics(ch chan<- prometheus.Met
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.SuccessDwarf), "dwarf")
 
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorTruncated), "truncated")
-	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorUnsupExpression), "unsup_expression")
-	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorFramePointerRule), "frame_pointer_rule")
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorUnsupportedExpression), "unsupported_expression")
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorFramePointerAction), "frame_pointer_action")
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorUnsupportedCfaRegister), "unsupported_cfa_register")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorCatchall), "catchall")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorShouldNeverHappen), "should_never_happen")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorPcNotCovered), "pc_not_covered")


### PR DESCRIPTION
We need a way to refresh memory mappings and unwind information when new mappings are added. This PR also improves the metrics, giving more information and fixing an accounting bug. More context in the commit messages.

Test Plan
=======

```python
[javierhonduco@fedora ~]$ cat new_mappings.py
import os
import time
import subprocess

def fetch_metrics():
    stdout = subprocess.run("""curl --silent http://localhost:7071/metrics | grep -v "#" | grep pc_not_covered""", shell=True, capture_output=True).stdout
    for line in filter(None, stdout.split(b"\n")):
        print(f"stats: {line}")

def fetch_map_size():
    p = subprocess.run(f"""bpftool map dump name process_info | grep {os.getpid()} -A4 | grep len""", shell=True, capture_output=True)
    stdout = p.stdout.strip()
    print(f"bpf_map_size: {stdout}")


WAIT_FOR_SECS = 10
start_ts = time.time()

print(f"[info] burning CPU for {WAIT_FOR_SECS}s")
while True:
    now = time.time()
    if now >= start_ts + WAIT_FOR_SECS:
        break

print("done waiting")
fetch_metrics()
fetch_map_size()

# Load some dynamic libraries.
import datetime

start_ts = time.time()

print(f"[info] burning CPU for {WAIT_FOR_SECS}s")
while True:
    now = time.time()
    if now >= start_ts + WAIT_FOR_SECS:
        break
    datetime.datetime.now()

print("[info] done showing the time")
fetch_metrics()
fetch_map_size()
```

The PC not covered counter is bumped, and the process information is regenerated
```
[javierhonduco@fedora ~]$ sudo python new_mappings.py
[info] burning CPU for 10s
done waiting
stats: b'parca_agent_native_unwinder_error_total{reason="pc_not_covered"} 0'
bpf_map_size: b'"len": 11,'
[info] burning CPU for 10s
[info] done showing the time
stats: b'parca_agent_native_unwinder_error_total{reason="pc_not_covered"} 1'
bpf_map_size: b'"len": 12,'
```

