### PR TITLE
Option to profile a single process

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Flags:
                                    of memory that may be locked into RAM. It is
                                    used to ensure the agent can lock memory for
                                    eBPF maps. 0 means no limit.
+      --profiling-pid=-1           The process id to record events on. Leave
+                                   this empty to use system-wide collection from
+                                   all CPUs.
       --profiling-duration=10s     The agent profiling duration to use. Leave
                                    this empty to use the defaults.
       --profiling-cpu-sampling-frequency=19

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -103,6 +103,7 @@ type flags struct {
 	MemlockRlimit uint64 `default:"${default_memlock_rlimit}" help:"The value for the maximum number of bytes of memory that may be locked into RAM. It is used to ensure the agent can lock memory for eBPF maps. 0 means no limit."`
 
 	// Profiler configuration:
+	ProfilingPID                  int           `kong:"help='The process id to record events on. Leave this empty to use system-wide collection from all CPUs.',default='-1'"`
 	ProfilingDuration             time.Duration `kong:"help='The agent profiling duration to use. Leave this empty to use the defaults.',default='10s'"`
 	ProfilingCPUSamplingFrequency uint64        `kong:"help='The frequency at which profiling data is collected, e.g., 19 samples per second.',default='${default_cpu_sampling_frequency}'"`
 
@@ -457,6 +458,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				flags.DebuginfoTempDir,
 			),
 			labelsManager,
+			flags.ProfilingPID,
 			flags.ProfilingDuration,
 			flags.ProfilingCPUSamplingFrequency,
 			flags.MemlockRlimit,

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -79,6 +79,7 @@ type combinedStack [doubleStackDepth]uint64
 type CPU struct {
 	logger                     log.Logger
 	reg                        prometheus.Registerer
+	profilingPID               int
 	profilingDuration          time.Duration
 	profilingSamplingFrequency uint64
 
@@ -128,6 +129,7 @@ func NewCPUProfiler(
 	profileWriter profiler.ProfileWriter,
 	debuginfoProcessor profiler.DebugInfoManager,
 	labelsManager profiler.LabelsManager,
+	profilingPID int,
 	profilingDuration time.Duration,
 	profilingSamplingFrequency uint64,
 	memlockRlimit uint64,
@@ -152,6 +154,7 @@ func NewCPUProfiler(
 		psMapCache:   psMapCache,
 		objFileCache: objFileCache,
 
+		profilingPID:               profilingPID,
 		profilingDuration:          profilingDuration,
 		profilingSamplingFrequency: profilingSamplingFrequency,
 
@@ -404,7 +407,7 @@ func (p *CPU) Run(ctx context.Context) error {
 			Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
 			Sample: p.profilingSamplingFrequency,
 			Bits:   unix.PerfBitDisabled | unix.PerfBitFreq,
-		}, -1 /* pid */, i /* cpu id */, -1 /* group */, 0 /* flags */)
+		}, p.profilingPID /* pid */, i /* cpu id */, -1 /* group */, 0 /* flags */)
 		if err != nil {
 			return fmt.Errorf("open perf event: %w", err)
 		}


### PR DESCRIPTION
I was not sure why `bpf_get_stackid` returns random memory addresses of instructions of a profiled function. Here is a [blog post](https://marselester.com/diy-cpu-profiler-the-simplest-case-of-symbolization.html) about that. @kakkoyun among other pertinent things advised me to compare results with Parca Agent (the results are similar to findings I described in my blog).

Therefore I've added `--profiling-pid` flag to collect CPU samples of a running process as follows. Perhaps it could be a first step towards https://github.com/parca-dev/parca-agent/issues/250.

```sh
$ ./fib &
$ sudo ./dist/parca-agent --profiling-pid=$(pidof fib) --local-store-directory=./fib-samples/
```