### PR TITLE
pkg/discovery: Fix panic when systemd gets corrupted header

### DIFF
--- a/pkg/discovery/systemd/config.go
+++ b/pkg/discovery/systemd/config.go
@@ -14,7 +14,6 @@
 package systemd
 
 import (
-	"net"
 	"time"
 )
 
@@ -41,8 +40,9 @@ const (
 
 // Config represents a Client config.
 type Config struct {
-	// conn is a connection to a D-Bus server.
-	conn *net.UnixConn
+	// busAddr is a bus address, for example,
+	// unix:path=/var/run/dbus/system_bus_socket.
+	busAddr string
 	// connTimeout is a connection timeout set with SetDeadline.
 	connTimeout time.Duration
 	// connReadSize defines the length of a buffer to read from
@@ -57,11 +57,10 @@ type Config struct {
 // Option sets up a Config.
 type Option func(*Config)
 
-// WithConnection sets a D-Bus connection to use instead
-// of establishing a default connection.
-func WithConnection(conn *net.UnixConn) Option {
+// WithAddress sets a bus address.
+func WithAddress(addr string) Option {
 	return func(c *Config) {
-		c.conn = conn
+		c.busAddr = addr
 	}
 }
 

--- a/pkg/discovery/systemd/decoder.go
+++ b/pkg/discovery/systemd/decoder.go
@@ -111,17 +111,16 @@ func (d *decoder) String() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Account for a null byte at the end of the string.
-	strLen++
 
-	// Read the string content.
-	b, err := readN(d.src, d.buf, int(strLen))
+	// Read the string content
+	// accounting for a null byte at the end of the string.
+	b, err := readN(d.src, d.buf, int(strLen)+1)
 	if err != nil {
 		return nil, err
 	}
+	d.offset += strLen + 1
 
-	d.offset += strLen
-	return b[:strLen-1], nil
+	return b[:strLen], nil
 }
 
 // Signature decodes D-Bus SIGNATURE
@@ -132,17 +131,16 @@ func (d *decoder) Signature() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Account for a null byte at the end of the string.
-	strLen++
 
-	// Read the string content.
-	b, err := readN(d.src, d.buf, int(strLen))
+	// Read the string content
+	// accounting for a null byte at the end of the string.
+	b, err := readN(d.src, d.buf, int(strLen)+1)
 	if err != nil {
 		return nil, err
 	}
+	d.offset += uint32(strLen) + 1
 
-	d.offset += uint32(strLen)
-	return b[:strLen-1], nil
+	return b[:strLen], nil
 }
 
 // readN reads exactly n bytes from src into the buffer.

--- a/pkg/discovery/systemd/header.go
+++ b/pkg/discovery/systemd/header.go
@@ -119,7 +119,7 @@ func decodeHeader(dec *decoder, conv *stringConverter, h *header, skipFields boo
 	h.ByteOrder = b[0]
 	order := h.Order()
 	if order == nil {
-		return fmt.Errorf("unknown byte order: %b", h.ByteOrder)
+		return fmt.Errorf("unknown byte order: %d", h.ByteOrder)
 	}
 	dec.SetOrder(order)
 

--- a/pkg/discovery/systemd/header.go
+++ b/pkg/discovery/systemd/header.go
@@ -118,6 +118,9 @@ func decodeHeader(dec *decoder, conv *stringConverter, h *header, skipFields boo
 
 	h.ByteOrder = b[0]
 	order := h.Order()
+	if order == nil {
+		return fmt.Errorf("unknown byte order: %b", h.ByteOrder)
+	}
 	dec.SetOrder(order)
 
 	h.Type = b[1]

--- a/pkg/discovery/systemd/header_test.go
+++ b/pkg/discovery/systemd/header_test.go
@@ -213,6 +213,31 @@ func TestDecodeHeader(t *testing.T) {
 	}
 }
 
+func FuzzDecodeHeader(f *testing.F) {
+	conv := newStringConverter(DefaultStringConverterSize)
+
+	tt := [][]byte{
+		helloRequest,
+		helloResponse,
+		nameAcquiredSignal,
+		mainPIDRequest,
+		mainPIDResponse,
+		mainPIDUnknownPropertyResponse,
+		listUnitsRequest,
+		listUnitsResponse,
+		listUnitsAccessDeniedResponse,
+	}
+	for _, tc := range tt {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, orig []byte) {
+		dec := newDecoder(bytes.NewReader(orig))
+		// Mustn't panic.
+		decodeHeader(dec, conv, &header{}, false)
+	})
+}
+
 func BenchmarkDecodeHeader(b *testing.B) {
 	conn := bytes.NewReader(mainPIDResponse)
 	dec := newDecoder(conn)


### PR DESCRIPTION
Javier found a bug in systemd package which occurs when the header decoder receives a corrupted dbus message, see https://github.com/parca-dev/parca-agent/issues/1511.

```
github.com/parca-dev/parca-agent/pkg/discovery/systemd.(*Client).ListUnits(0xc000b08000, 0xc000a8aba0?, 0xc000191a00?)
	github.com/parca-dev/parca-agent/pkg/discovery/systemd/message.go:159 +0x99
github.com/parca-dev/parca-agent/pkg/discovery/systemd.(*messageDecoder).DecodeListUnits(0xc00074c4b0, {0x231d880?, 0xc000b08060}, 0x33bea80?, 0xc001361a48)
	github.com/parca-dev/parca-agent/pkg/discovery/systemd/header.go:126 +0x149
github.com/parca-dev/parca-agent/pkg/discovery/systemd.decodeHeader(0xc000b06030, 0x206bad6?, 0xc00074c578, 0x1)
goroutine 88 [running]:
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x19eb869]
panic: runtime error: invalid memory address or nil pointer dereference
level=warn name=parca-agent ts=2023-03-30T08:29:50.691486947Z caller=systemd.go:65 discovery=systemd msg="failed to get units from systemd D-Bus API" err="decode ListUnits: message body: read unix @->/run/dbus/system_bus_socket: i/o timeout"
```