### PR TITLE
vmtest: Update packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,9 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
       - name: Install dependencies
-        run: sudo apt -y install qemu-system-x86 curl
+        run: |
+          sudo apt-get update -y
+          sudo apt -y install qemu-system-x86 curl
 
       - name: Download previously generated initramfs
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2


### PR DESCRIPTION
We are seeing failures with

```
Fetched 37.7 MB in 10s (3639 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/p/pulseaudio/libpulse0_15.99.1%2bdfsg1-1ubuntu2_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/ceph/librados2_17.2.0-0ubuntu0.22.04.2_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/ceph/librbd1_17.2.0-0ubuntu0.22.04.2_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```


> Note: Always run sudo apt-get update before installing a package. In case the apt index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.

https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners