### PR TITLE
pkg/profiler/cpu: Fix condition for RequestUnwindInformation

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -497,7 +497,7 @@ func (p *CPU) Run(ctx context.Context) error {
 				//	- unsafe.Sizeof(uint32(0)) = 4
 				pid := int(int32(payload))
 				//nolint:gocritic
-				if payload&RequestUnwindInformation == RequestUnwindInformation && p.DwarfUnwindingWithoutPolling() {
+				if payload&RequestUnwindInformation == RequestUnwindInformation {
 					requestUnwindInfoChannel <- pid
 				} else if payload&RequestProcessMappings == RequestProcessMappings {
 					// Populate mappings cache.


### PR DESCRIPTION
This somehow slips through, my bad. This is not correct. The issue shows up if no other executables end up triggering a persist of the unwind table