### PR TITLE
pkg/debuginfo: Fix extraction logic

### DIFF
--- a/pkg/debuginfo/extract.go
+++ b/pkg/debuginfo/extract.go
@@ -46,7 +46,7 @@ func NewExtractor(logger log.Logger) *Extractor {
 func (e *Extractor) ExtractAll(ctx context.Context, srcDsts map[string]io.WriteSeeker) error {
 	var result *multierror.Error
 	for src, dst := range srcDsts {
-		if err := e.Extract(ctx, dst, src); err != nil {
+		if err := Extract(ctx, dst, src); err != nil {
 			level.Debug(e.logger).Log(
 				"msg", "failed to extract debug information", "file", src, "err", err,
 			)
@@ -62,7 +62,7 @@ func (e *Extractor) ExtractAll(ctx context.Context, srcDsts map[string]io.WriteS
 
 // Extract extracts debug information from the given executable.
 // Cleaning up the temporary directory and the interim file is the caller's responsibility.
-func (e *Extractor) Extract(ctx context.Context, dst io.WriteSeeker, src string) error {
+func Extract(ctx context.Context, dst io.WriteSeeker, src string) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/debuginfo/extract_test.go
+++ b/pkg/debuginfo/extract_test.go
@@ -19,7 +19,6 @@ import (
 	"debug/elf"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/rzajac/flexbuf"
 	"github.com/stretchr/testify/require"
 )
@@ -55,11 +54,8 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Extractor{
-				logger: log.NewNopLogger(),
-			}
 			buf := flexbuf.New()
-			err := e.Extract(context.TODO(), buf, tt.args.src)
+			err := Extract(context.TODO(), buf, tt.args.src)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -15,8 +15,10 @@
 package debuginfo
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -107,5 +109,26 @@ func TestHasTextSection(t *testing.T) {
 
 			require.Equal(t, tc.textSectionExists, ok)
 		})
+	}
+}
+
+func TestDisableStripping(t *testing.T) {
+	file := "./testdata/readelf-sections"
+	originalContent, err := os.ReadFile(file)
+	require.NoError(t, err)
+
+	m := &Manager{
+		stripDebuginfos: false,
+		tempDir:         os.TempDir(),
+	}
+	f, cleanup, _, _, err := m.stripDebuginfo(context.Background(), file, "test")
+	require.NoError(t, err)
+	defer cleanup()
+
+	strippedContent, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+
+	if !bytes.Equal(originalContent, strippedContent) {
+		t.Fatal("stripped file content is not equal to original file content")
 	}
 }


### PR DESCRIPTION
Previously the `stripDebuginfo` field was constantly overridden by whether or not the given binary had a text section or not, which lead to disregarding if stipping debuginfos was explicitly turned off.

Additionally, this was unsafe as it was overriding the global configuration, which could have been written concurrently.