### PR TITLE
Always normalize vdso addresses

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -43,7 +43,6 @@ import (
 	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
 
-	"github.com/parca-dev/parca-agent/pkg/address"
 	"github.com/parca-dev/parca-agent/pkg/byteorder"
 	"github.com/parca-dev/parca-agent/pkg/objectfile"
 	"github.com/parca-dev/parca-agent/pkg/process"
@@ -108,7 +107,9 @@ type CPU struct {
 
 	memlockRlimit uint64
 
-	debugProcessNames      []string
+	debugProcessNames []string
+	// isNormalizationEnabled indicates whether the profiler has to
+	// normalize sampled addresses for PIC/PIE (position independent code/executable).
 	isNormalizationEnabled bool
 	disableDWARFUnwinding  bool
 	dwarfUnwindingPolling  bool
@@ -129,6 +130,7 @@ func NewCPUProfiler(
 	profileWriter profiler.ProfileWriter,
 	debuginfoProcessor profiler.DebugInfoManager,
 	labelsManager profiler.LabelsManager,
+	normalizer profiler.Normalizer,
 	profilingDuration time.Duration,
 	profilingSamplingFrequency uint64,
 	memlockRlimit uint64,
@@ -147,7 +149,7 @@ func NewCPUProfiler(
 		profileWriter:    profileWriter,
 		debuginfoManager: debuginfoProcessor,
 		labelsManager:    labelsManager,
-		normalizer:       address.NewNormalizer(logger, objFileCache),
+		normalizer:       normalizer,
 		processMappings:  process.NewMapping(psMapCache),
 
 		// Shared caches between all profilers.
@@ -163,9 +165,7 @@ func NewCPUProfiler(
 
 		memlockRlimit: memlockRlimit,
 
-		debugProcessNames: debugProcessNames,
-		// isNormalizationEnabled indicates whether the profiler has to
-		// normalize sampled addresses for PIC/PIE (position independent code/executable).
+		debugProcessNames:      debugProcessNames,
 		isNormalizationEnabled: enableNormalization,
 		disableDWARFUnwinding:  disableDWARFUnwinding,
 		dwarfUnwindingPolling:  dwarfUnwindingPolling,

--- a/pkg/vdso/vdso.go
+++ b/pkg/vdso/vdso.go
@@ -11,6 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package vdso is responsible for resolving vdso function names.
+//
+// The "vDSO" (virtual dynamic shared object) is a shared library
+// that the kernel automatically maps into the address space
+// of all user-space applications.
+// The vDSO is most commonly called by the C library
+// to use faster (but backward incompatible) instructions
+// to initiate system calls if a processor supports that.
+// Rather than require the C library to figure out
+// if this functionality is available at run time,
+// the C library can use functions provided by the kernel in the vDSO.
 package vdso
 
 import (


### PR DESCRIPTION
The agent resolves function names using addresses found in kernel stack traces (ksym) and user stack traces (vdso, JIT).
The kernel stack traces are never normalized, and according to #1537 JIT addresses mustn't be normalized. Therefore only vdso addresses have to be normalized before resolving the symbols.