### PR TITLE
Add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Flags:
       --log-format="logfmt"        Configure if structured logging as JSON or as
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
+      --version
       --node="hostname"           The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Flags:
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
       --version                    Show application version.
-      --node="hostname"           
-                                   The name of the node that the process is
+      --node="hostname"           The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Flags:
       --log-format="logfmt"        Configure if structured logging as JSON or as
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
-      --version
-      --node="hostname"           The name of the node that the process is
+      --version                    Show application version.
+      --node="hostname"           
+                                   The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -97,7 +97,7 @@ const (
 type flags struct {
 	Log         FlagsLogs `embed:"" prefix:"log-"`
 	HTTPAddress string    `kong:"help='Address to bind HTTP server to.',default=':7071'"`
-	Version     bool      `kong:"help:'Show application version.'"`
+	Version     bool      `help:"Show application version."`
 
 	Node          string `kong:"help='The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name.',default='${hostname}'"`
 	ConfigPath    string `default:"" help:"Path to config file."`

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -192,7 +192,7 @@ func main() {
 	// Fetch build info such as the git revision we are based off
 	buildInfo, err := buildinfo.FetchBuildInfo()
 	if err != nil {
-		fmt.Println("failed to fetch build info: %w", err)
+		fmt.Println("failed to fetch build info: %w", err) //nolint:forbidigo
 		os.Exit(1)
 	}
 
@@ -216,7 +216,7 @@ func main() {
 	})
 
 	if flags.Version {
-		fmt.Printf("parca-agent, version %s (commit: %s, date: %s), arch: %s\n", version, commit, date, goArch)
+		fmt.Printf("parca-agent, version %s (commit: %s, date: %s), arch: %s\n", version, commit, date, goArch) //nolint:forbidigo
 		os.Exit(0)
 	}
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -97,6 +97,7 @@ const (
 type flags struct {
 	Log         FlagsLogs `embed:"" prefix:"log-"`
 	HTTPAddress string    `kong:"help='Address to bind HTTP server to.',default=':7071'"`
+	Version     bool      `kong:"help:'Show application version.'"`
 
 	Node          string `kong:"help='The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name.',default='${hostname}'"`
 	ConfigPath    string `default:"" help:"Path to config file."`
@@ -188,7 +189,24 @@ type Profiler interface {
 }
 
 func main() {
-	hostname, hostnameErr := os.Hostname()
+	// Fetch build info such as the git revision we are based off
+	buildInfo, err := buildinfo.FetchBuildInfo()
+	if err != nil {
+		fmt.Println("failed to fetch build info: %w", err)
+		os.Exit(1)
+	}
+
+	if commit == "" {
+		commit = buildInfo.VcsRevision
+	}
+	if date == "" {
+		date = buildInfo.VcsTime
+	}
+	if goArch == "" {
+		goArch = buildInfo.GoArch
+	}
+
+	hostname, hostnameErr := os.Hostname() // hotnameErr handled below.
 
 	flags := flags{}
 	kong.Parse(&flags, kong.Vars{
@@ -197,10 +215,22 @@ func main() {
 		"default_cpu_sampling_frequency": strconv.Itoa(defaultCPUSamplingFrequency),
 	})
 
+	if flags.Version {
+		fmt.Printf("parca-agent, version %s (commit: %s, date: %s), arch: %s\n", version, commit, date, goArch)
+		os.Exit(0)
+	}
+
 	logger := logger.NewLogger(flags.Log.Level, flags.Log.Format, "parca-agent")
+	level.Debug(logger).Log("msg", "parca-agent initialized",
+		"version", version,
+		"commit", commit,
+		"date", date,
+		"config", fmt.Sprintf("%+v", flags),
+		"arch", goArch,
+	)
 
 	if flags.Node == "" && hostnameErr != nil {
-		level.Error(logger).Log("msg", "failed to get host name. Please set it with the --node flag", "err", hostnameErr)
+		level.Error(logger).Log("msg", "failed to get hostname. Please set it with the --node flag", "err", hostnameErr)
 		os.Exit(1)
 	}
 
@@ -294,29 +324,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 	} else {
 		level.Info(logger).Log("msg", "eBPF is supported and enabled by the host kernel")
 	}
-
-	// Fetch build info such as the git revision we are based off
-	buildInfo, err := buildinfo.FetchBuildInfo()
-	if err != nil {
-		return fmt.Errorf("failed to fetch build info: %w", err)
-	}
-
-	if commit == "" {
-		commit = buildInfo.VcsRevision
-	}
-	if date == "" {
-		date = buildInfo.VcsTime
-	}
-	if goArch == "" {
-		goArch = buildInfo.GoArch
-	}
-	level.Debug(logger).Log("msg", "parca-agent initialized",
-		"version", version,
-		"commit", commit,
-		"date", date,
-		"config", fmt.Sprintf("%+v", flags),
-		"arch", goArch,
-	)
 
 	profileStoreClient := agent.NewNoopProfileStoreClient()
 	var debuginfoClient debuginfopb.DebuginfoServiceClient = debuginfo.NewNoopClient()


### PR DESCRIPTION
```shell
$ parca-agent --version
> parca-agent, version  (commit: 7ff593d3d399e778d446e24759f35ddafb4bcdc6, date: 2023-04-12T15:18:42Z), arch: amd64
```

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7ff593d</samp>

### Summary
🚀♻️📝

<!--
1.  🚀 - This emoji represents a new feature being added, which is the `--version` flag.
2.  ♻️ - This emoji represents a refactoring of existing code, which is the build info assignment and logging to the `main` function.
3.  📝 - This emoji represents a documentation update, which is the addition of the `--version` flag to the usage message and the README file.
-->
Added a `--version` flag and improved build info logging in `parca-agent`.

> _Show me the `--version` of your doom_
> _The build info is your final tomb_
> _Refactor the code in the `main` function_
> _You can't escape the metal destruction_

### Walkthrough
* Add a `Version` flag to show the application version with the `--version` option ([link](https://github.com/parca-dev/parca-agent/pull/1552/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR100))
* Move the code to fetch and assign the build info variables (`commit`, `date`, `goArch`) from the `run` function to the `main` function in `cmd/parca-agent/main.go`, to avoid duplication and make the build info available for the `Version` flag ([link](https://github.com/parca-dev/parca-agent/pull/1552/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL191-R210), [link](https://github.com/parca-dev/parca-agent/pull/1552/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL298-L320))
* Check and handle the `Version` flag in the `main` function in `cmd/parca-agent/main.go`, to print the version information and exit the program if the flag is set ([link](https://github.com/parca-dev/parca-agent/pull/1552/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL200-R233))
* Move the log message for the initialization of the parca-agent from the `run` function to the `main` function in `cmd/parca-agent/main.go`, to match the location of the build info assignment ([link](https://github.com/parca-dev/parca-agent/pull/1552/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL200-R233), [link](https://github.com/parca-dev/parca-agent/pull/1552/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL298-L320))

