### PR TITLE
Move fdtransfer to target directory

### DIFF
--- a/scripts/download-async-profiler.sh
+++ b/scripts/download-async-profiler.sh
@@ -25,6 +25,7 @@ wget -O - "https://github.com/async-profiler/async-profiler/releases/download/v$
 
 mkdir -p "${target_dir}/x64/libc"
 mv "${target_dir}/async-profiler-${version}-linux-x64/build/jattach" "${target_dir}/x64/libc"
+mv "${target_dir}/async-profiler-${version}-linux-x64/build/fdtransfer" "${target_dir}/x64/libc"
 mv "${target_dir}/async-profiler-${version}-linux-x64/build/libasyncProfiler.so" "${target_dir}/x64/libc"
 mv "${target_dir}/async-profiler-${version}-linux-x64/LICENSE" "${target_dir}/"
 rm -rf "${target_dir}/async-profiler-${version}-linux-x64"


### PR DESCRIPTION
### Why?
Initially we thought that fdtransfer is not needed. But as libasyncprofiler.so gets loaded as an agent in JVM, we can't be sure about the privileges of the running Java process(on both host and containers). Luckily, async-profiler already has a small program called 'fdtransfer' to deal with such issues and access perf_event_open. So let's use it!

See [https://github.com/async-profiler/async-profiler#troubleshooting](async-profiler-troubleshooting) for more details.

### What?
Move fdtransfer to target directory from the fetched async profiler tarball.

### Test Plan

Java process running on the host without root privileges:
```
vaishali@pop-os:~/parca-agent$ jps
510479 Jps
510333 spring-two-0.0.2-SNAPSHOT.jar
```
Running `profiler.sh` without  fdtransfer
```
root@pop-os:~# /home/vaishali/async-profiler/profiler.sh start -e cpu 510333
[WARN] Kernel symbols are unavailable due to restrictions. Try
  sysctl kernel.perf_event_paranoid=1
  sysctl kernel.kptr_restrict=0
```
Running `profiler.sh` with fdtransfer
```
root@pop-os:~# /home/vaishali/async-profiler/profiler.sh --fdtransfer start -e cpu 510333
```

**Note:** I'm just using `profiler.sh` to show this because it's easier. One can also use the raw command like `/home/vaishali/async-profiler/build/jattach 510333 load /home/vaishali/async-profiler/build/libasyncProfiler.so true stop event=cpu file=prof.jfr` to notice the warning.
