### PR TITLE
perf(grpc): use optimized code from vtprotobuf

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -39,6 +39,7 @@ import (
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
 	profilestorepb "github.com/parca-dev/parca/gen/proto/go/parca/profilestore/v1alpha1"
 	parcadebuginfo "github.com/parca-dev/parca/pkg/debuginfo"
+	vtproto "github.com/planetscale/vtprotobuf/codec/grpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -48,6 +49,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/proto"
 
 	"github.com/parca-dev/parca-agent/pkg/agent"
 	"github.com/parca-dev/parca-agent/pkg/buildinfo"
@@ -329,6 +332,8 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 	var debuginfoClient debuginfopb.DebuginfoServiceClient = debuginfo.NewNoopClient()
 
 	if len(flags.RemoteStore.Address) > 0 {
+		encoding.RegisterCodec(vtproto.Codec{})
+
 		conn, err := grpcConn(reg, flags.RemoteStore)
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/opencontainers/runtime-spec v1.1.0-rc.2
 	github.com/parca-dev/parca v0.17.0
+	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/prometheus/client_golang v1.15.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.4.0 h1:NEI+g4woRaAZgeZ3sAvbtyvMBRjIv5kE7EWYQ8m4JwY=
+github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

Same as parca-dev/parca#3019, but client-side only

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69d1c65</samp>

Use `vtproto` codec for faster and more efficient gRPC communication. This requires adding a new dependency to `go.mod`.

### How?
<!-- Please explain us hwo should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 69d1c65</samp>

*  Register `vtproto` codec as the default codec for gRPC communication with the parca server to improve performance and memory usage ([link](https://github.com/parca-dev/parca-agent/pull/1581/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR335-R336))
* Import `vtproto` package from `github.com/planetscale/vtprotobuf/codec/grpc` and `encoding` package from `google.golang.org/grpc/encoding` in `cmd/parca-agent/main.go` ([link](https://github.com/parca-dev/parca-agent/pull/1581/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR42), [link](https://github.com/parca-dev/parca-agent/pull/1581/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR52-R53))
* Add dependency on `github.com/planetscale/vtprotobuf` to `go.mod` file ([link](https://github.com/parca-dev/parca-agent/pull/1581/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R29))

### Test Plan
<!-- How did you test it? How can we test it? -->

Run server and agent, check all uploads work properly.

<!--

copilot:poem

-->
