### PR TITLE
chore(nix-shell): add static zstd dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ OUT_BPF := $(OUT_BPF_DIR)/cpu-profiler.bpf.o
 PKG_CONFIG ?= pkg-config
 CGO_CFLAGS_STATIC =-I$(abspath $(LIBBPF_HEADERS))
 CGO_CFLAGS ?= $(CGO_CFLAGS_STATIC)
-CGO_LDFLAGS_STATIC = -fuse-ld=ld $(abspath $(LIBBPF_OBJ))
+CGO_LDFLAGS_STATIC = -fuse-ld=ld -lzstd $(abspath $(LIBBPF_OBJ))
 CGO_LDFLAGS ?= $(CGO_LDFLAGS_STATIC)
 
 CGO_EXTLDFLAGS =-extldflags=-static

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -33,5 +33,6 @@ in
     pre-commit
     tilt
     zlib.static
+    (zstd.override { static = true; }).dev
   ];
 }


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

The agent now depends on `zstd` (not sure since when?), so the Nix development needs this new dependency. The Nix package does not provide the static library by default and requires extra flags to get it to work. 

```console
$ make build
mkdir -p pkg/profiler/cpu
make -C bpf build
make[1]: Entering directory '/home/maxime/Documents/github.com/maxbrunet/parca-agent/bpf'
make[1]: Nothing to be done for 'build'.
make[1]: Leaving directory '/home/maxime/Documents/github.com/maxbrunet/parca-agent/bpf'
cp bpf/cpu/cpu.bpf.o pkg/profiler/cpu/cpu-profiler.bpf.o
go mod tidy
find dist -exec touch -t 202101010000.00 {} +
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="clang" CGO_CFLAGS="-I/home/maxime/Documents/github.com/maxbrunet/parca-agent/dist/libbpf/amd64/usr/include" CGO_LDFLAGS="-fuse-ld=ld /home/maxime/Documents/github.com/maxbrunet/parca-agent/dist/libbpf/amd64/libbpf.a" go build  -tags osusergo,netgo -mod=readonly -trimpath -v --ldflags="-extldflags=-static" -o dist/parca-agent ./cmd/parca-agent
github.com/parca-dev/parca-agent/cmd/parca-agent
# github.com/parca-dev/parca-agent/cmd/parca-agent
/nix/store/ndlw8ji6g2s0vqn7fivkb8sz7zfd67bm-go-1.20.3/share/go/pkg/tool/linux_amd64/link: running clang failed: exit status 1
/nix/store/f4qnwzv6y0nq8lix33jr5ykkyybs6fxf-binutils-2.40/bin/ld: /nix/store/sd6nsyj6v8qmdr07g5hl5rp8mpkbzasp-elfutils-0.189/lib/libelf.a(elf_compress.o): in function `__libelf_decompress':
(.text+0x60f): undefined reference to `ZSTD_decompress'
/nix/store/f4qnwzv6y0nq8lix33jr5ykkyybs6fxf-binutils-2.40/bin/ld: (.text+0x617): undefined reference to `ZSTD_isError'
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [Makefile:112: dist/parca-agent] Error 1
```

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
copilot:summary

### How?
<!-- Please explain us hwo should it work? Or let the copilot handle it. -->
copilot:walkthrough

### Test Plan
<!-- How did you test it? How can we test it? -->
Run `nix develop --command make build` and `nix develop --command make build-dyn`, the agent should build without errors in both cases.

<!--

copilot:poem

-->
