### PR TITLE
unwinder/native: Remove polling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,6 @@ Flags:
                                    requests.
       --symbolizer-jit-disable     Disable JIT symbolization.
       --dwarf-unwinding-disable    Do not unwind using .eh_frame information.
-      --dwarf-unwinding-use-polling
-                                   Poll procfs to generate the unwind
-                                   information instead of generating them on
-                                   demand.
       --verbose-bpf-logging        Enable verbose BPF logging.
 ```
 

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -170,8 +170,7 @@ type FlagsSymbolizer struct {
 
 // FlagsDWARFUnwinding contains flags to configure DWARF unwinding.
 type FlagsDWARFUnwinding struct {
-	Disable    bool `kong:"help='Do not unwind using .eh_frame information.'"`
-	UsePolling bool `kong:"help='Poll procfs to generate the unwind information instead of generating them on demand.'"` // ,hidden=''"
+	Disable bool `kong:"help='Do not unwind using .eh_frame information.'"`
 }
 
 // FlagsHidden contains hidden flags. Hidden debug flags (only for debugging).
@@ -515,7 +514,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			flags.Hidden.DebugProcessNames,
 			flags.Hidden.DebugNormalizeAddresses,
 			flags.DWARFUnwinding.Disable,
-			flags.DWARFUnwinding.UsePolling,
 			flags.VerboseBpfLogging,
 			bpfProgramLoaded,
 		),


### PR DESCRIPTION
As it's not used or tested anymore, we rely on the on-demand unwind info generation.

Test Plan
=========

Ran the agent for a little while without issues