### PR TITLE
profiler: Reduce mem usage in maps with no filters

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -205,7 +205,7 @@ typedef struct {
 
 /*================================ MAPS =====================================*/
 
-BPF_HASH(debug_pids, int, u8, MAX_PROCESSES);
+BPF_HASH(debug_pids, int, u8, 1); // Table size will be updated in userspace.
 BPF_HASH(process_info, int, process_info_t, MAX_PROCESSES);
 
 BPF_STACK_TRACE(stack_traces, MAX_STACK_TRACES_ENTRIES);

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -258,7 +258,7 @@ func loadBpfProgram(logger log.Logger, reg prometheus.Registerer, debugEnabled, 
 		}
 
 		level.Info(logger).Log("msg", "Attempting to create unwind shards", "count", unwindShards)
-		if err := bpfMaps.adjustMapSizes(unwindShards); err != nil {
+		if err := bpfMaps.adjustMapSizes(debugEnabled, unwindShards); err != nil {
 			return nil, nil, fmt.Errorf("failed to adjust map sizes: %w", err)
 		}
 


### PR DESCRIPTION
Right now we always allocate 5k entries in `debug_pids` in kernel memory even if the filter mode `--debug-process-names` is not enabled. Let's only allocate the entries if we are filtering processes.

The saved memory isn't too much, around a few KB, but kernel memory is precious and in particular this memory, as it's locked.

Test Plan
=========

**no filters**
```
[javierhonduco@fedora parca-agent]$ sudo bpftool map | grep debug_pids -A3
739: hash  name debug_pids  flags 0x0
        key 4B  value 1B  max_entries 1  memlock 4096B
        btf_id 670
        pids parca-agent-deb(154991)
```

**with filters**
```
[javierhonduco@fedora parca-agent]$ sudo bpftool map | grep debug_pids -A3
765: hash  name debug_pids  flags 0x0
        key 4B  value 1B  max_entries 5000  memlock 40960B
        btf_id 697
        pids parca-agent-deb(156286)
```