### PR TITLE
chore: Disable deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,10 @@ linters:
     - style
     - unused
   disable:
+    - structcheck
+    - varcheck
+    - deadcode
+    - ifshort
     - exhaustivestruct
     - exhaustruct
     - funlen


### PR DESCRIPTION
### Why?
I keep seeing the following warnings when running `make go/lint`:

WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.

### What?
Disable deprecated linters.

I'm not sure if renovate bot handles this usually. But let me know if we would prefer some other way to get around these warnings rather than disabling them.


