### PR TITLE
Locally download and use libbpf dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 .idea
-/goreleaser
+*.bpf.o
+/bin
+/data
 /dist
+/goreleaser
+/out
 /target
 /tmp
-/out
-/bin
-*.bpf.o
-TODO.md
 minikube-*
-/data
+TODO.md
 
 # Snap Packaging Artifacts
 *.snap

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CMD_GIT ?= git
 CMD_EMBEDMD ?= embedmd
 
 # environment:
-ARCH ?= $(shell go env x)
+ARCH ?= $(shell go env GOARCH)
 
 # kernel headers:
 KERN_RELEASE ?= $(shell uname -r)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ OUT_BIN_EH_FRAME := $(OUT_DIR)/eh-frame
 OUT_DOCKER ?= ghcr.io/parca-dev/parca-agent
 DOCKER_BUILDER ?= parca-dev/cross-builder
 
+LIBBPF_DEPS_DIR := dist/static-libs/$(ARCH)
+# Needs to be hardcoded because Make is too eager to evaluate variables.
+LIBBPF_DEPS_OBJS = $(LIBBPF_DEPS_DIR)/libelf.a $(LIBBPF_DEPS_DIR)/libz.a $(LIBBPF_DEPS_DIR)/libzstd.a
 LIBBPF_SRC := 3rdparty/libbpf/src
 LIBBPF_DIR := $(OUT_DIR)/libbpf/$(ARCH)
 LIBBPF_HEADERS := $(LIBBPF_DIR)/usr/include
@@ -71,12 +74,12 @@ OUT_PID_NAMESPACE := $(OUT_BPF_CONTAINED_DIR)/pid_namespace.bpf.o
 PKG_CONFIG ?= pkg-config
 CGO_CFLAGS_STATIC =-I$(abspath $(LIBBPF_HEADERS))
 CGO_CFLAGS ?= $(CGO_CFLAGS_STATIC)
-CGO_LDFLAGS_STATIC = -fuse-ld=ld -lzstd $(abspath $(LIBBPF_OBJ))
+CGO_LDFLAGS_STATIC = -fuse-ld=ld $(abspath $(LIBBPF_OBJ) $(LIBBPF_DEPS_OBJS))
 CGO_LDFLAGS ?= $(CGO_LDFLAGS_STATIC)
 
 CGO_EXTLDFLAGS =-extldflags=-static
 CGO_CFLAGS_DYN = -I$(abspath $(LIBBPF_HEADERS))
-CGO_LDFLAGS_DYN = -L$(abspath $(LIBBPF_DIR)) -fuse-ld=ld -lelf -lz -lbpf
+CGO_LDFLAGS_DYN = -L$(abspath $(LIBBPF_DIR)) -fuse-ld=ld -lelf -lz -lbpf -lzstd
 
 # possible other CGO flags:
 # CGO_CPPFLAGS ?=
@@ -107,13 +110,13 @@ $(OUT_DIR):
 .PHONY: build
 build: $(OUT_BPF) $(OUT_BIN) $(OUT_BIN_EH_FRAME)
 
-GO_ENV := CGO_ENABLED=1 GOOS=linux GOARCH=$(ARCH) CC="$(CMD_CC)"
+GO_ENV := CGO_ENABLED=1 GOOS=linux PKG_CONFIG="$(PKG_CONFIG)" GOARCH=$(ARCH) CC="$(CMD_CC)"
 CGO_ENV := CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)"
 GO_BUILD_FLAGS := -tags osusergo,netgo -mod=readonly -trimpath -v
 GO_BUILD_DEBUG_FLAGS := -tags osusergo,netgo -v
 
 ifndef DOCKER
-$(OUT_BIN): libbpf $(filter-out *_test.go,$(GO_SRC)) go/deps | $(OUT_DIR)
+$(OUT_BIN): $(LIBBPF_DEPS_DIR) $(filter-out *_test.go,$(GO_SRC)) go/deps | $(OUT_DIR)
 	find dist -exec touch -t 202101010000.00 {} +
 	$(GO_ENV) $(CGO_ENV) $(GO) build $(SANITIZERS) $(GO_BUILD_FLAGS) --ldflags="$(CGO_EXTLDFLAGS)" -o $@ ./cmd/parca-agent
 else
@@ -180,17 +183,25 @@ libbpf: $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
 check_%:
 	@command -v $* >/dev/null || (echo "missing required tool $*" ; false)
 
-libbpf_compile_tools = $(CMD_LLC) $(CMD_CC)
-.PHONY: libbpf_compile_tools
-$(libbpf_compile_tools): % : check_%
+# Only builds for the current architecture.
+.PHONY: libbpf-static-deps
+libbpf-static-deps: $(LIBBPF_DEPS_DIR)
+libbpf-deps: libbpf-static-deps
+
+$(LIBBPF_DEPS_DIR):
+	./scripts/download-and-build-libbpf-deps.sh
+
+libbpf-compile-tools = $(CMD_LLC) $(CMD_CC)
+.PHONY: libbpf-compile-tools
+$(libbpf-compile-tools): % : check_%
 
 $(LIBBPF_SRC):
 	test -d $(LIBBPF_SRC) || (echo "missing libbpf source - maybe do '$(CMD_GIT) submodule init && $(CMD_GIT) submodule update'" ; false)
 
-$(LIBBPF_HEADERS) $(LIBBPF_HEADERS)/bpf $(LIBBPF_HEADERS)/linux: | $(OUT_DIR) libbpf_compile_tools $(LIBBPF_SRC)
+$(LIBBPF_HEADERS) $(LIBBPF_HEADERS)/bpf $(LIBBPF_HEADERS)/linux: | $(OUT_DIR) libbpf-compile-tools $(LIBBPF_SRC)
 	$(MAKE) -C $(LIBBPF_SRC) CC="$(CMD_CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" install_headers install_uapi_headers DESTDIR=$(abspath $(OUT_DIR))/libbpf/$(ARCH)
 
-$(LIBBPF_OBJ): | $(OUT_DIR) libbpf_compile_tools $(LIBBPF_SRC)
+$(LIBBPF_OBJ): | $(OUT_DIR) libbpf-compile-tools $(LIBBPF_SRC)
 	$(MAKE) -C $(LIBBPF_SRC) CC="$(CMD_CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" OBJDIR=$(abspath $(OUT_DIR))/libbpf/$(ARCH) BUILD_STATIC_ONLY=1
 
 $(VMLINUX):

--- a/Tiltfile
+++ b/Tiltfile
@@ -36,6 +36,5 @@ docker_build(
 #     skips_local_docker=True,
 # )
 
-
 k8s_yaml('deploy/tilt/parca-agent-daemonSet.yaml')
 k8s_resource('parca-agent', port_forwards=[7071])

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -14,7 +14,6 @@ OUT_DIR ?= ../dist
 OUT_BPF_BASE_DIR := out
 OUT_BPF_DIR := $(OUT_BPF_BASE_DIR)/$(ARCH)
 OUT_BPF := $(OUT_BPF_DIR)/native.bpf.o
-# TODO(kakkoyun): DRY.
 OUT_RBPERF := $(OUT_BPF_DIR)/rbperf.bpf.o
 OUT_PYPERF := $(OUT_BPF_DIR)/pyperf.bpf.o
 OUT_PID_NAMESPACE_DETECTOR := $(OUT_BPF_DIR)/pid_namespace.bpf.o
@@ -24,7 +23,6 @@ BPF_BUNDLE := $(OUT_DIR)/parca-agent.bpf.tar.gz
 LIBBPF_HEADERS := $(OUT_DIR)/libbpf/$(ARCH)/usr/include
 
 VMLINUX_INCLUDE_PATH := $(SHORT_ARCH)
-# TODO(kakkoyun): DRY.
 BPF_SRC := unwinders/native.bpf.c
 RBPERF_SRC := unwinders/rbperf.bpf.c
 PYPERF_SRC := unwinders/pyperf.bpf.c

--- a/make-cross
+++ b/make-cross
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# print commands
+# set -x
+
+# This scripts exports the necessary environment variables to cross-compiles the binaries for all supported architectures.
+# We only support Linux as platform for now.
+
+# Use all possible target architecture or the one specified by the user.
+
+# TODO(kakkoyun): Make it possible to build from MacOS.
+
+TARGETS=${TARGETS:-"amd64 arm64"}
+
+# TODO(kakkoyun): Refine
+cc='zig cc'
+cxx='zig c++'
+ar='zig ar'
+ld='lld'
+host_cc='zig cc'
+host_arch=$(go env GOARCH)
+
+for arch in $TARGETS; do
+    target=''
+    case $arch in
+    amd64)
+        target='x86_64-linux-gnu'
+        ;;
+    arm64)
+        target='aarch64-linux-gnu'
+        ;;
+    *)
+        echo "Unsupported architecture: $arch"
+        exit 1
+        ;;
+    esac
+
+    cc="${cc} -target $target"
+    cxx="${cxx} -target $target"
+    # ar="${ar} -target $target"
+    ld="${ld} -target $target"
+
+    export ARCH="$arch"
+    export TARGET="$target"
+    export CC="$cc"
+    export CXX="$cxx"
+    export AR="$ar"
+    export LD="$ld"
+
+    host=''
+    case $host_arch in
+    amd64)
+        host='x86_64-linux-gnu'
+        ;;
+    arm64)
+        host='aarch64-linux-gnu'
+        ;;
+    *)
+        echo "Unsupported architecture: $host_arch"
+        exit 1
+        ;;
+    esac
+    export HOST="$host"
+    export HOST_CC='$host_cc'
+
+    make ARCH="$arch" CC="$cc" HOST_CC="$host_cc" CXX="$cxx" AR="$ar" LD="$ld" "$@"
+done

--- a/makex
+++ b/makex
@@ -38,16 +38,16 @@ host_arch=$(go env GOARCH)
 for arch in $TARGETS; do
     target=''
     case $arch in
-    amd64)
-        target='x86_64-linux-gnu'
-        ;;
-    arm64)
-        target='aarch64-linux-gnu'
-        ;;
-    *)
-        echo "Unsupported architecture: $arch"
-        exit 1
-        ;;
+        amd64)
+            target='x86_64-linux-gnu'
+            ;;
+        arm64)
+            target='aarch64-linux-gnu'
+            ;;
+        *)
+            echo "Unsupported architecture: $arch"
+            exit 1
+            ;;
     esac
 
     cc="${cc} -target $target"
@@ -60,16 +60,16 @@ for arch in $TARGETS; do
 
     host=''
     case $host_arch in
-    amd64)
-        host='x86_64-linux-gnu'
-        ;;
-    arm64)
-        host='aarch64-linux-gnu'
-        ;;
-    *)
-        echo "Unsupported architecture: $host_arch"
-        exit 1
-        ;;
+        amd64)
+            host='x86_64-linux-gnu'
+            ;;
+        arm64)
+            host='aarch64-linux-gnu'
+            ;;
+        *)
+            echo "Unsupported architecture: $host_arch"
+            exit 1
+            ;;
     esac
     export HOST="$host"
 

--- a/makex
+++ b/makex
@@ -31,12 +31,8 @@ set -u
 
 TARGETS=${TARGETS:-"amd64 arm64"}
 
-# TODO(kakkoyun): Refine
 cc='zig cc'
 cxx='zig c++'
-# ar='zig ar'
-# ld='lld'
-# host_cc='zig cc'
 host_arch=$(go env GOARCH)
 
 for arch in $TARGETS; do
@@ -56,15 +52,11 @@ for arch in $TARGETS; do
 
     cc="${cc} -target $target"
     cxx="${cxx} -target $target"
-    # ar="${ar} -target $target"
-    # ld="${ld} -target $target"
 
     export ARCH="$arch"
     export TARGET="$target"
     export CC="$cc"
     export CXX="$cxx"
-    # export AR="$ar"
-    # export LD="$ld"
 
     host=''
     case $host_arch in
@@ -80,9 +72,6 @@ for arch in $TARGETS; do
         ;;
     esac
     export HOST="$host"
-    # export HOST_CC='$host_cc'
-    # # HOST_CC="$host_cc"
-    # AR="$ar" LD="$ld"
 
-    make ARCH="$arch" TARGET="$target" HOST="$host" BUILD="$host" CC="$cc" CXX="$cxx" "$@"
+    make ARCH="$arch" TARGET="$target" HOST="$host" BUILD="$target" CC="$cc" CXX="$cxx" "$@"
 done

--- a/makex
+++ b/makex
@@ -34,9 +34,9 @@ TARGETS=${TARGETS:-"amd64 arm64"}
 # TODO(kakkoyun): Refine
 cc='zig cc'
 cxx='zig c++'
-ar='zig ar'
-ld='lld'
-host_cc='zig cc'
+# ar='zig ar'
+# ld='lld'
+# host_cc='zig cc'
 host_arch=$(go env GOARCH)
 
 for arch in $TARGETS; do
@@ -57,14 +57,14 @@ for arch in $TARGETS; do
     cc="${cc} -target $target"
     cxx="${cxx} -target $target"
     # ar="${ar} -target $target"
-    ld="${ld} -target $target"
+    # ld="${ld} -target $target"
 
     export ARCH="$arch"
     export TARGET="$target"
     export CC="$cc"
     export CXX="$cxx"
-    export AR="$ar"
-    export LD="$ld"
+    # export AR="$ar"
+    # export LD="$ld"
 
     host=''
     case $host_arch in
@@ -80,7 +80,9 @@ for arch in $TARGETS; do
         ;;
     esac
     export HOST="$host"
-    export HOST_CC='$host_cc'
+    # export HOST_CC='$host_cc'
+    # # HOST_CC="$host_cc"
+    # AR="$ar" LD="$ld"
 
-    make ARCH="$arch" CC="$cc" HOST_CC="$host_cc" CXX="$cxx" AR="$ar" LD="$ld" "$@"
+    make ARCH="$arch" TARGET="$target" HOST="$host" BUILD="$host" CC="$cc" CXX="$cxx" "$@"
 done

--- a/scripts/download-and-build-libbpf-deps.sh
+++ b/scripts/download-and-build-libbpf-deps.sh
@@ -28,10 +28,6 @@ if [ -n "${DEBUG:-}" ]; then
     set -x
 fi
 
-CC="${CC:-zig cc}"
-CXX="${CXX:zig c++}"
-ARCH="${ARCH:-amd64}"
-
 NPROC=$(nproc --all)
 ELFUTILS_VERSION="0.189"
 ELFUTILS_SHA_512="93a877e34db93e5498581d0ab2d702b08c0d87e4cafd9cec9d6636dfa85a168095c305c11583a5b0fb79374dd93bc8d0e9ce6016e6c172764bcea12861605b71"
@@ -60,9 +56,14 @@ mkdir -p "${STATIC_LIBS_OUT_PATH}"
 # * -fpic is not the same as -FPIC
 # https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html
 #
-# TODO(kakkoyun): Move library specific flags to their own build functions.
+
 # * cflags required for clang to compile elfutils
 export CFLAGS="-fno-omit-frame-pointer -fpic -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter -Wno-unused-but-set-variable"
+export CC="${CC}"
+export CXX="${CXX}"
+export HOST="${HOST}"
+export BUILD="${BUILD}"
+export TARGET="${TARGET}"
 
 zlib_build() {
     build_artifact="${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}/lib/libz.a"
@@ -137,6 +138,7 @@ elf_build() {
 
     run pushd "elfutils-${ELFUTILS_VERSION}"
 
+    make clean || true
     export BUILD_STATIC=1
     run ./configure --prefix="${STATIC_LIBS_OUT_PATH}/elfutils-${ELFUTILS_VERSION}" --target="$TARGET" --build="$BUILD" --host="$HOST" --disable-debuginfod --disable-libdebuginfod --without-bzlib --without-lzma
 

--- a/scripts/download-and-build-libbpf-deps.sh
+++ b/scripts/download-and-build-libbpf-deps.sh
@@ -28,6 +28,10 @@ if [ -n "${DEBUG:-}" ]; then
     set -x
 fi
 
+CC="${CC:-zig cc}"
+CXX="${CXX:zig c++}"
+ARCH="${ARCH:-amd64}"
+
 NPROC=$(nproc --all)
 ELFUTILS_VERSION="0.189"
 ELFUTILS_SHA_512="93a877e34db93e5498581d0ab2d702b08c0d87e4cafd9cec9d6636dfa85a168095c305c11583a5b0fb79374dd93bc8d0e9ce6016e6c172764bcea12861605b71"
@@ -58,10 +62,7 @@ mkdir -p "${STATIC_LIBS_OUT_PATH}"
 #
 # TODO(kakkoyun): Move library specific flags to their own build functions.
 # * cflags required for clang to compile elfutils
-# export CFLAGS="-g -O2 -Wall -fpic -fno-omit-frame-pointer -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter"
 export CFLAGS="-fno-omit-frame-pointer -fpic -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter -Wno-unused-but-set-variable"
-export CC="$CC"
-export CXX="$CXX"
 
 zlib_build() {
     build_artifact="${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}/lib/libz.a"
@@ -115,13 +116,7 @@ zstd_build() {
 }
 
 elf_build() {
-    # TODO(kakkoyun): Refine
-    # export CC="$CC -std=c99" # -std=gnu11
-    # export CXX=clang++
-    # export CXX="$CXX -std=c++11"
-    export CPP="${CPP} -E"
-    # export CXXCPP="${CXX} -E"
-    export CFLAGS="${CFLAGS} -Wno-yacc -I${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}/include -I${STATIC_LIBS_OUT_PATH}/zstd-${ZSTD_VERSION}/include"
+    export CFLAGS="${CFLAGS} -I${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}/include -I${STATIC_LIBS_OUT_PATH}/zstd-${ZSTD_VERSION}/include"
     export LDFLAGS="${LDFLAGS} -L${STATIC_LIBS_OUT_PATH}"
 
     build_artifact="${STATIC_LIBS_OUT_PATH}/elfutils-${ELFUTILS_VERSION}/lib/libelf.a"
@@ -141,10 +136,13 @@ elf_build() {
     run tar xjf "$elfutils"
 
     run pushd "elfutils-${ELFUTILS_VERSION}"
+
     export BUILD_STATIC=1
-    run ./configure --prefix="${STATIC_LIBS_OUT_PATH}/elfutils-${ELFUTILS_VERSION}" --build="$HOST" --host="$HOST" --target="$TARGET" --disable-debuginfod --disable-libdebuginfod --without-bzlib --without-lzma --enable-maintainer-mode --disable-symbol-versioning
-    run make # "-j${NPROC}"
-    run make -C libelf install
+    run ./configure --prefix="${STATIC_LIBS_OUT_PATH}/elfutils-${ELFUTILS_VERSION}" --target="$TARGET" --build="$BUILD" --host="$HOST" --disable-debuginfod --disable-libdebuginfod --without-bzlib --without-lzma
+
+    run make -C lib "-j${NPROC}"
+    run make -C libelf install "-j${NPROC}"
+
     cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
     run popd
 }

--- a/scripts/download-and-build-libbpf-deps.sh
+++ b/scripts/download-and-build-libbpf-deps.sh
@@ -22,81 +22,143 @@
 
 set -o errexit nounset pipefail
 
+DEBUG="${DEBUG:-}"
+if [ -n "${DEBUG:-}" ]; then
+    # Enable for debugging:
+    set -x
+fi
+
 NPROC=$(nproc --all)
 ELFUTILS_VERSION="0.189"
 ELFUTILS_SHA_512="93a877e34db93e5498581d0ab2d702b08c0d87e4cafd9cec9d6636dfa85a168095c305c11583a5b0fb79374dd93bc8d0e9ce6016e6c172764bcea12861605b71"
 
-ZLIB_VERSION="1.2.13"
-ZLIB_SHA256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
+ZLIB_VERSION="1.3"
+ZLIB_SHA256="ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e"
 
 ZSTD_VERSION="1.5.5"
 ZSTD_SHA256="9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4"
 
+LOGS_FILE="${PWD}/dist/static-libs/run-logs.txt"
 run() {
-    "$@" >/dev/null 2>&1
+    if [ -z "${DEBUG:-}" ]; then
+        "$@" >/dev/null 2>&1
+    else
+        "$@" >"$LOGS_FILE" 2>&1
+    fi
 }
 
 STATIC_LIBS_SRC_PATH=${PWD}/dist/static-libs/src
-mkdir -p "${STATIC_LIBS_SRC_PATH}"/libz
-mkdir -p "${STATIC_LIBS_SRC_PATH}"/elfutils
-
-ARCH=$(go env GOARCH)
-STATIC_LIBS_OUT_PATH="${PWD}/dist/static-libs/${ARCH}/"
+mkdir -p "${STATIC_LIBS_SRC_PATH}"
+STATIC_LIBS_OUT_PATH="${PWD}/dist/static-libs/${ARCH}"
 mkdir -p "${STATIC_LIBS_OUT_PATH}"
-
-run pushd "${STATIC_LIBS_SRC_PATH}"
 
 # Notes:
 # * -fpic is not the same as -FPIC
 # https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html
 #
+# TODO(kakkoyun): Move library specific flags to their own build functions.
 # * cflags required for clang to compile elfutils
-export CFLAGS="-fno-omit-frame-pointer -fpic -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter"
-export CC=clang
+# export CFLAGS="-g -O2 -Wall -fpic -fno-omit-frame-pointer -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter"
+export CFLAGS="-fno-omit-frame-pointer -fpic -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter -Wno-unused-but-set-variable"
+export CC="$CC"
+export CXX="$CXX"
 
-echo "=> Building elfutils"
-run curl -L -O "https://sourceware.org/pub/elfutils/${ELFUTILS_VERSION}/elfutils-${ELFUTILS_VERSION}.tar.bz2"
-if ! sha512sum "elfutils-${ELFUTILS_VERSION}.tar.bz2" | grep -q "$ELFUTILS_SHA_512"; then
-    echo "Checksum for elfutils doesn't match"
-    exit 1
-fi
+zlib_build() {
+    build_artifact="${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}/lib/libz.a"
 
-run tar xjf "elfutils-${ELFUTILS_VERSION}.tar.bz2"
+    if [ -f "${build_artifact}" ]; then
+        echo "Already built"
+        cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
+        return
+    fi
 
-run pushd "elfutils-${ELFUTILS_VERSION}"
-run ./configure --prefix="${STATIC_LIBS_SRC_PATH}/elfutils" --disable-debuginfod --disable-libdebuginfod
-run make "-j${NPROC}"
-run make install
-cp "${STATIC_LIBS_SRC_PATH}/elfutils/lib/libelf.a" "${STATIC_LIBS_OUT_PATH}"
-run popd
+    zlib="zlib-${ZLIB_VERSION}.tar.gz"
+    test -f "$zlib" || run curl -L -O "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
+    if ! sha256sum "$zlib" | grep -q "$ZLIB_SHA256"; then
+        echo "Checksum for zlib doesn't match"
+        exit 1
+    fi
+    run tar xzf "$zlib"
+
+    mkdir -p "${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}"
+    run pushd "zlib-${ZLIB_VERSION}"
+    run ./configure --prefix="${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}"
+    run make "-j${NPROC}"
+    run make install
+    cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
+    run popd
+}
+
+zstd_build() {
+    build_artifact="${STATIC_LIBS_OUT_PATH}/zstd-${ZSTD_VERSION}/lib/libzstd.a"
+
+    if [ -f "${build_artifact}" ]; then
+        echo "Already built"
+        cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
+        return
+    fi
+
+    zstd="zstd-${ZSTD_VERSION}.tar.gz"
+    test -f "$zstd" || run curl -L -O "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
+    if ! sha256sum "$zstd" | grep -q "$ZSTD_SHA256"; then
+        echo "Checksum for zstd doesn't match"
+        exit 1
+    fi
+    run tar xzf "$zstd"
+
+    mkdir -p "${STATIC_LIBS_OUT_PATH}/zstd-${ZSTD_VERSION}"
+    run pushd "zstd-${ZSTD_VERSION}"
+    run make "-j${NPROC}"
+    run make install PREFIX="${STATIC_LIBS_OUT_PATH}/zstd-${ZSTD_VERSION}"
+    cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
+    run popd
+}
+
+elf_build() {
+    # TODO(kakkoyun): Refine
+    # export CC="$CC -std=c99" # -std=gnu11
+    # export CXX=clang++
+    # export CXX="$CXX -std=c++11"
+    export CPP="${CPP} -E"
+    # export CXXCPP="${CXX} -E"
+    export CFLAGS="${CFLAGS} -Wno-yacc -I${STATIC_LIBS_OUT_PATH}/libz-${ZLIB_VERSION}/include -I${STATIC_LIBS_OUT_PATH}/zstd-${ZSTD_VERSION}/include"
+    export LDFLAGS="${LDFLAGS} -L${STATIC_LIBS_OUT_PATH}"
+
+    build_artifact="${STATIC_LIBS_OUT_PATH}/elfutils-${ELFUTILS_VERSION}/lib/libelf.a"
+
+    if [ -f "${build_artifact}" ]; then
+        echo "Already built"
+        cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
+        return
+    fi
+
+    elfutils="elfutils-${ELFUTILS_VERSION}.tar.bz2"
+    test -f "$elfutils" || run curl -L -O "https://sourceware.org/pub/elfutils/${ELFUTILS_VERSION}/elfutils-${ELFUTILS_VERSION}.tar.bz2"
+    if ! sha512sum "$elfutils" | grep -q "$ELFUTILS_SHA_512"; then
+        echo "Checksum for elfutils doesn't match"
+        exit 1
+    fi
+    run tar xjf "$elfutils"
+
+    run pushd "elfutils-${ELFUTILS_VERSION}"
+    export BUILD_STATIC=1
+    run ./configure --prefix="${STATIC_LIBS_OUT_PATH}/elfutils-${ELFUTILS_VERSION}" --build="$HOST" --host="$HOST" --target="$TARGET" --disable-debuginfod --disable-libdebuginfod --without-bzlib --without-lzma --enable-maintainer-mode --disable-symbol-versioning
+    run make # "-j${NPROC}"
+    run make -C libelf install
+    cp "${build_artifact}" "${STATIC_LIBS_OUT_PATH}"
+    run popd
+}
+
+echo "=> Downloading and building static libraries for ${ARCH}"
+run pushd "${STATIC_LIBS_SRC_PATH}"
 
 echo "=> Building zlib"
-run curl -L -O "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
-if ! sha256sum "zlib-${ZLIB_VERSION}.tar.gz" | grep -q "$ZLIB_SHA256"; then
-    echo "Checksum for zlib doesn't match"
-    exit 1
-fi
-run tar xzf zlib-${ZLIB_VERSION}.tar.gz
-
-run pushd "zlib-${ZLIB_VERSION}"
-run ./configure --prefix="${STATIC_LIBS_SRC_PATH}/libz" >/dev/null
-run make "-j${NPROC}" >/dev/null
-run make install >/dev/null
-cp "${STATIC_LIBS_SRC_PATH}/libz/lib/libz.a" "${STATIC_LIBS_OUT_PATH}"
-run popd
+zlib_build
 
 echo "=> Building zstd"
-run curl -L -O "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
-if ! sha256sum "zstd-${ZSTD_VERSION}.tar.gz" | grep -q "$ZSTD_SHA256"; then
-    echo "Checksum for zstd doesn't match"
-    exit 1
-fi
-run tar xzf zstd-${ZSTD_VERSION}.tar.gz
+zstd_build
 
-run pushd "zstd-${ZSTD_VERSION}"
-run make "-j${NPROC}" >/dev/null
-run make install PREFIX="${STATIC_LIBS_SRC_PATH}/zstd" >/dev/null
-cp "${STATIC_LIBS_SRC_PATH}/zstd/lib/libzstd.a" "${STATIC_LIBS_OUT_PATH}"
-run popd
+echo "=> Building elfutils"
+elf_build
 
 run popd

--- a/scripts/download-and-build-libbpf-deps.sh
+++ b/scripts/download-and-build-libbpf-deps.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 The rbperf authors
+#
+# TODO: This license is not consistent with the license used in the project.
+#       Delete the inconsistent license and above line and rerun pre-commit to insert a good license.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2023 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit nounset pipefail
+
+NPROC=$(nproc --all)
+ELFUTILS_VERSION="0.189"
+ELFUTILS_SHA_512="93a877e34db93e5498581d0ab2d702b08c0d87e4cafd9cec9d6636dfa85a168095c305c11583a5b0fb79374dd93bc8d0e9ce6016e6c172764bcea12861605b71"
+
+ZLIB_VERSION="1.2.13"
+ZLIB_SHA256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
+
+ZSTD_VERSION="1.5.5"
+ZSTD_SHA256="9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4"
+
+run() {
+    "$@" >/dev/null 2>&1
+}
+
+STATIC_LIBS_SRC_PATH=${PWD}/dist/static-libs/src
+mkdir -p "${STATIC_LIBS_SRC_PATH}"/libz
+mkdir -p "${STATIC_LIBS_SRC_PATH}"/elfutils
+
+ARCH=$(go env GOARCH)
+STATIC_LIBS_OUT_PATH="${PWD}/dist/static-libs/${ARCH}/"
+mkdir -p "${STATIC_LIBS_OUT_PATH}"
+
+run pushd "${STATIC_LIBS_SRC_PATH}"
+
+# Notes:
+# * -fpic is not the same as -FPIC
+# https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html
+#
+# * cflags required for clang to compile elfutils
+export CFLAGS="-fno-omit-frame-pointer -fpic -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter"
+export CC=clang
+
+echo "=> Building elfutils"
+run curl -L -O "https://sourceware.org/pub/elfutils/${ELFUTILS_VERSION}/elfutils-${ELFUTILS_VERSION}.tar.bz2"
+if ! sha512sum "elfutils-${ELFUTILS_VERSION}.tar.bz2" | grep -q "$ELFUTILS_SHA_512"; then
+    echo "Checksum for elfutils doesn't match"
+    exit 1
+fi
+
+run tar xjf "elfutils-${ELFUTILS_VERSION}.tar.bz2"
+
+run pushd "elfutils-${ELFUTILS_VERSION}"
+run ./configure --prefix="${STATIC_LIBS_SRC_PATH}/elfutils" --disable-debuginfod --disable-libdebuginfod
+run make "-j${NPROC}"
+run make install
+cp "${STATIC_LIBS_SRC_PATH}/elfutils/lib/libelf.a" "${STATIC_LIBS_OUT_PATH}"
+run popd
+
+echo "=> Building zlib"
+run curl -L -O "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
+if ! sha256sum "zlib-${ZLIB_VERSION}.tar.gz" | grep -q "$ZLIB_SHA256"; then
+    echo "Checksum for zlib doesn't match"
+    exit 1
+fi
+run tar xzf zlib-${ZLIB_VERSION}.tar.gz
+
+run pushd "zlib-${ZLIB_VERSION}"
+run ./configure --prefix="${STATIC_LIBS_SRC_PATH}/libz" >/dev/null
+run make "-j${NPROC}" >/dev/null
+run make install >/dev/null
+cp "${STATIC_LIBS_SRC_PATH}/libz/lib/libz.a" "${STATIC_LIBS_OUT_PATH}"
+run popd
+
+echo "=> Building zstd"
+run curl -L -O "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
+if ! sha256sum "zstd-${ZSTD_VERSION}.tar.gz" | grep -q "$ZSTD_SHA256"; then
+    echo "Checksum for zstd doesn't match"
+    exit 1
+fi
+run tar xzf zstd-${ZSTD_VERSION}.tar.gz
+
+run pushd "zstd-${ZSTD_VERSION}"
+run make "-j${NPROC}" >/dev/null
+run make install PREFIX="${STATIC_LIBS_SRC_PATH}/zstd" >/dev/null
+cp "${STATIC_LIBS_SRC_PATH}/zstd/lib/libzstd.a" "${STATIC_LIBS_OUT_PATH}"
+run popd
+
+run popd


### PR DESCRIPTION
### Why?

After `libbpf` started requiring `zstd` as a dependency, my system can't build libbpf locally. That's why I have started changes. (Thanks @javierhonduco, for the pointers). 

This is a first step towards to system-independent way of reproducibly building our binary. This will also simplify our CI dependencies. We need to enhance the script to handle cross-platform builds and configure goreleaser accordingly.

related: https://github.com/parca-dev/parca-agent/issues/1304

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5b7e98</samp>

This pull request adds support for building the parca-agent binary with static libraries for libbpf and its dependencies. It introduces a new script `scripts/download-and-build-libbpf-deps.sh` and modifies the `Makefile` and the `Tiltfile` accordingly. This enables the parca-agent binary to run on systems without dynamic libraries for libbpf.

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5b7e98</samp>

*  Define and use variables for libbpf dependencies in `Makefile` ([link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R54-R56), [link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L69-R77), [link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L105-R108), [link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L111-R114), [link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L173-R194))
* Add a new script `scripts/download-and-build-libbpf-deps.sh` to download and build the static libraries for libbpf dependencies ([link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-2df6b8021f4eb6f37f6ecd921284f2f70e7c340c237d6292a477127278fb4d6eR1-R100))
* Remove an empty line from `Tiltfile` ([link](https://github.com/parca-dev/parca-agent/pull/1602/files?diff=unified&w=0#diff-c2ee8653e1d6b85f0aadf87cd438a9250806c052877248442be4d434cbc52425L39))

Original work: https://github.com/javierhonduco/rbperf/blob/573ebc0a90f05ca0ef9b26ae7825d27468035cf1/tools/build_deps#L8

### TODO
- [ ] Make sure cross-compilation works with goreleaser
- [ ] Handle #1304 