### PR TITLE
pkg/asyncprofiler: Refactor NewAsyncProfiler to use functional options

### DIFF
--- a/pkg/asyncprofiler/asyncprofiler.go
+++ b/pkg/asyncprofiler/asyncprofiler.go
@@ -64,12 +64,11 @@ func WithOutputFile(outputFile string) ProfilerOption {
 
 // TODO: Move this to profiler package
 // NewAsyncProfiler initializes a new AsyncProfiler instance with the given paths, process ID, event type, and duration.
-func NewAsyncProfiler(jattachPath, libasyncPath string, pid int, options ProfilerOptions, opts ...ProfilerOption) *AsyncProfiler {
+func NewAsyncProfiler(jattachPath, libasyncPath string, pid int, opts ...func(*AsyncProfiler)) *AsyncProfiler {
 	profiler := &AsyncProfiler{
 		jattachPath:  jattachPath,
 		libasyncPath: libasyncPath,
 		pid:          pid,
-		options:      options,
 	}
 
 	for _, opt := range opts {
@@ -79,7 +78,7 @@ func NewAsyncProfiler(jattachPath, libasyncPath string, pid int, options Profile
 	return profiler
 }
 
-func (p *AsyncProfiler) SetAction(action string) error {
+func (p *AsyncProfiler) SetAction(action string, options ...ProfilerOptions) error {
 	isValid := false
 	for _, validAction := range validActions {
 		if action == validAction {
@@ -92,6 +91,13 @@ func (p *AsyncProfiler) SetAction(action string) error {
 		return fmt.Errorf("invalid action: %s", action)
 	}
 	p.action = Action(action)
+
+	if len(options) > 0 {
+		p.options = options[0]
+	} else {
+		p.options = ProfilerOptions{}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
In preparation of the separate package for the per process asyncprofiler, refactor NewAsyncProfiler by removing the options parameter and utilizing functional options instead. Also, use SetAction function to accept functional options, as these options are more tied to the actions and we can leave the decision of using particular options on users.

This is more convenient and easier to use for testing as well.

### Test Plan
See updated #1590 for the intended use.

Before when start and stop commands were executed:
```
Executing command: /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/jattach 43220 load /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/libasyncProfiler.so true start event=cpu duration=60s file=prof.jfr
Executing command: /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/jattach 43220 load /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/libasyncProfiler.so true stop file=prof.jfr event=cpu duration=60s
```
After this change:
```
Executing command: /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/jattach 54980 load /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/libasyncProfiler.so true start event=cpu duration=60s file=prof.jfr
Executing command: /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/jattach 54980 load /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/libasyncProfiler.so true stop
```
