### PR TITLE
pkg/asyncprofiler: Fix options format in SetAction

### DIFF
--- a/pkg/asyncprofiler/asyncprofiler.go
+++ b/pkg/asyncprofiler/asyncprofiler.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 )
 
 // Action represents the various actions available for AsyncProfiler.
@@ -93,9 +94,12 @@ func (p *AsyncProfiler) SetAction(action string, options ...ProfilerOptions) err
 	p.action = Action(action)
 
 	if len(options) > 0 {
-		p.options = options[0]
-	} else {
-		p.options = ProfilerOptions{}
+		optionsSlice := []string{}
+		for k, v := range options[0] {
+			optionsSlice = append(optionsSlice, fmt.Sprintf("%s=%s", k, v))
+		}
+		optionsStr := strings.Join(optionsSlice, ",")
+		p.action = Action(fmt.Sprintf("%s,%s", action, optionsStr))
 	}
 
 	return nil


### PR DESCRIPTION
### Why?
The expected format of the command is:
`jattach pid load libasyncProfiler.so true start,event=cpu,file=prof.jfr`.
Current code doesn't add the semicolon while building a command. Fix this as part of the options format.

This commit also improves the code to handle the situation when we have multiple ProfilerOptions maps.

### Test Plan

Result of the current #1590 

```
vaishali@pop-os:~/parca-agent/pkg/asyncprofiler$ go test
Executing command: /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/jattach 9771 load /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/libasyncProfiler.so true start,event=cpu,file=prof.jfr
Executing command: /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/jattach 9771 load /home/vaishali/parca-agent/pkg/asyncprofiler/testdata/libasyncProfiler.so true stop
PASS
ok  	github.com/parca-dev/parca-agent/pkg/asyncprofiler	160.289s
```

cc @javierhonduco