### PR TITLE
chore(container): add commit timestamp to image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,13 @@ ifeq ($(GITHUB_BRANCH_NAME),)
 else
 	BRANCH := $(GITHUB_BRANCH_NAME)-
 endif
+COMMIT_TIMESTAMP := $(shell $(CMD_GIT) show --no-patch --format=%ct)-
 ifeq ($(GITHUB_SHA),)
-	COMMIT := $(shell $(CMD_GIT) describe --no-match --dirty --always --abbrev=8)
+	COMMIT := $(shell $(CMD_GIT) rev-parse --short=8 HEAD)
 else
 	COMMIT := $(shell echo $(GITHUB_SHA) | cut -c1-8)
 endif
-VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags || echo '$(subst /,-,$(BRANCH))$(COMMIT)'))
+VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags || echo '$(subst /,-,$(BRANCH))$(COMMIT_TIMESTAMP)$(COMMIT)'))
 
 # renovate: datasource=docker depName=docker.io/goreleaser/goreleaser-cross
 GOLANG_CROSS_VERSION := v1.20.4


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

Same as parca-dev/parca#3095

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 550d0c9</samp>

Add commit timestamp to version variable in `Makefile`. This improves the version information for pre-release builds of the parca-agent binary and docker images.

### How?
<!-- Please explain us hwo should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 550d0c9</samp>

*  Add a `COMMIT_TIMESTAMP` variable to get the current commit timestamp ([link](https://github.com/parca-dev/parca-agent/pull/1621/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L34-R40))

### Test Plan
<!-- How did you test it? How can we test it? -->

<!--

copilot:poem

-->

Watch the `main`'s container workflow release the new image tag.