### PR TITLE
*: Remove retry limit and fix race conditions around ObjectFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Flags:
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
       --version                    Show application version.
-      --node="hostname"
-                                   The name of the node that the process is
+      --node="hostname"            The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Flags:
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
       --version                    Show application version.
-      --node="hostname"           The name of the node that the process is
+      --node="hostname"           
+                                   The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.
@@ -109,9 +110,6 @@ Flags:
       --debuginfo-strip            Only upload information needed for
                                    symbolization. If false the exact binary the
                                    agent sees will be uploaded unmodified.
-      --debuginfo-upload-retry-count=3
-                                   The number of times to retry uploading
-                                   debuginfo files.
       --debuginfo-upload-timeout-duration=2m
                                    The timeout duration to cancel upload
                                    requests.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Flags:
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
       --version                    Show application version.
-      --node="hostname"           
+      --node="hostname"
                                    The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Flags:
       --debuginfo-strip            Only upload information needed for
                                    symbolization. If false the exact binary the
                                    agent sees will be uploaded unmodified.
+      --debuginfo-upload-max-parallel=25
+                                   The maximum number of debuginfo upload
+                                   requests to make in parallel.
       --debuginfo-upload-timeout-duration=2m
                                    The timeout duration to cancel upload
                                    requests.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Flags:
                                    logfmt
       --http-address=":7071"       Address to bind HTTP server to.
       --version                    Show application version.
-      --node="hostname"            The name of the node that the process is
+      --node="hostname"           The name of the node that the process is
                                    running on. If on Kubernetes, this must match
                                    the Kubernetes node name.
       --config-path=""             Path to config file.

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -165,7 +165,6 @@ type FlagsDebuginfo struct {
 	Directories           []string      `kong:"help='Ordered list of local directories to search for debuginfo files.',default='/usr/lib/debug'"`
 	TempDir               string        `kong:"help='The local directory path to store the interim debuginfo files.',default='/tmp'"`
 	Strip                 bool          `kong:"help='Only upload information needed for symbolization. If false the exact binary the agent sees will be uploaded unmodified.',default='true'"`
-	UploadRetryCount      int           `kong:"help='The number of times to retry uploading debuginfo files.',default='3'"`
 	UploadTimeoutDuration time.Duration `kong:"help='The timeout duration to cancel upload requests.',default='2m'"`
 	UploadCacheDuration   time.Duration `kong:"help='The duration to cache debuginfo upload exists checks for.',default='5m'"`
 }
@@ -531,7 +530,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			ofp,
 			debuginfoClient,
 			flags.Debuginfo.UploadTimeoutDuration,
-			flags.Debuginfo.UploadRetryCount,
 			flags.Debuginfo.UploadCacheDuration,
 			flags.Debuginfo.Directories,
 			flags.Debuginfo.Strip,

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -165,6 +165,7 @@ type FlagsDebuginfo struct {
 	Directories           []string      `kong:"help='Ordered list of local directories to search for debuginfo files.',default='/usr/lib/debug'"`
 	TempDir               string        `kong:"help='The local directory path to store the interim debuginfo files.',default='/tmp'"`
 	Strip                 bool          `kong:"help='Only upload information needed for symbolization. If false the exact binary the agent sees will be uploaded unmodified.',default='true'"`
+	UploadMaxParallel     int           `kong:"help='The maximum number of debuginfo upload requests to make in parallel.',default='25'"`
 	UploadTimeoutDuration time.Duration `kong:"help='The timeout duration to cancel upload requests.',default='2m'"`
 	UploadCacheDuration   time.Duration `kong:"help='The duration to cache debuginfo upload exists checks for.',default='5m'"`
 }
@@ -529,6 +530,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			reg,
 			ofp,
 			debuginfoClient,
+			flags.Debuginfo.UploadMaxParallel,
 			flags.Debuginfo.UploadTimeoutDuration,
 			flags.Debuginfo.UploadCacheDuration,
 			flags.Debuginfo.Directories,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/alecthomas/kong v0.7.1
 	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cilium/ebpf v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/debuginfo/extract.go
+++ b/pkg/debuginfo/extract.go
@@ -29,6 +29,11 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/elfwriter"
 )
 
+type SeekReaderAt interface {
+	io.ReaderAt
+	io.Seeker
+}
+
 // Extractor extracts debug information from a binary.
 type Extractor struct {
 	logger log.Logger
@@ -71,14 +76,14 @@ func (e *Extractor) ExtractAll(ctx context.Context, srcDsts map[string]io.WriteS
 
 // Extract extracts debug information from the given executable.
 // Cleaning up the temporary directory and the interim file is the caller's responsibility.
-func Extract(ctx context.Context, dst io.WriteSeeker, f *os.File) error {
+func Extract(ctx context.Context, dst io.WriteSeeker, src SeekReaderAt) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
 
-	w, err := elfwriter.NewFromSource(dst, f)
+	w, err := elfwriter.NewFromSource(dst, src)
 	if err != nil {
 		return fmt.Errorf("failed to initialize writer: %w", err)
 	}

--- a/pkg/debuginfo/find.go
+++ b/pkg/debuginfo/find.go
@@ -83,7 +83,7 @@ func (f *Finder) Find(ctx context.Context, root string, objFile *objectfile.Obje
 			return "", v
 		default:
 			// We didn't put you there?!
-			return "", errors.New("unexpected type")
+			return "", fmt.Errorf("unexpected type in cache: %T", val)
 		}
 	}
 

--- a/pkg/debuginfo/find_test.go
+++ b/pkg/debuginfo/find_test.go
@@ -15,6 +15,7 @@
 package debuginfo
 
 import (
+	"debug/elf"
 	"os"
 	"testing"
 
@@ -293,7 +294,10 @@ func Test_readDebuglink(t *testing.T) {
 			f, err := os.Open(tt.args.path)
 			require.NoError(t, err)
 
-			got, gotSum, err := readDebuglink(f)
+			ef, err := elf.NewFile(f)
+			require.NoError(t, err)
+
+			got, gotSum, err := readDebuglink(ef)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readDebuglink() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -294,7 +294,7 @@ func TestUploadSingleFlight(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			err = dim.Upload(context.Background(), dbgFile)
+			err := dim.Upload(context.Background(), dbgFile)
 			require.NoError(t, err)
 		}()
 	}

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -18,15 +18,23 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -59,19 +67,245 @@ func BenchmarkUploadInitiateUploadError(b *testing.B) {
 		prometheus.NewRegistry(),
 		objFilePool,
 		c,
+		25,
 		2*time.Minute,
 		5*time.Minute,
 		[]string{"/usr/lib/debug"},
 		true,
 		"/tmp",
 	)
-	ctx := context.Background()
 
+	ctx := context.Background()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		err = debuginfoManager.upload(ctx, o)
 		require.Equal(b, codes.Internal, status.Code(errors.Unwrap(err)))
 	}
+}
+
+func TestUpload(t *testing.T) {
+	name := filepath.Join("../../internal/pprof/binutils/testdata", "exe_linux_64")
+	objFilePool := objectfile.NewPool(log.NewNopLogger(), prometheus.NewRegistry(), 1024)
+	t.Cleanup(func() {
+		objFilePool.Close()
+	})
+
+	// Create a mock object file.
+	dbgFile, err := objFilePool.Open(name)
+	require.NoError(t, err)
+
+	counter := atomic.NewInt32(1)
+	// Create a mock server to inject errors.
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { counter.Add(1) }()
+		switch {
+		case counter.Load() < 2:
+			w.WriteHeader(http.StatusNotFound) // 4xx error.
+			fmt.Fprintln(w, "client-side error")
+		case counter.Load() == 2:
+			w.WriteHeader(http.StatusInternalServerError) // 5xx error.
+			fmt.Fprintln(w, "server-side error")
+		case counter.Load() == 3:
+			fmt.Fprintln(w, "uploaded")
+		case counter.Load() > 3:
+			w.WriteHeader(http.StatusAlreadyReported)
+		default:
+			fmt.Fprintln(w, "Hello, client")
+		}
+	}))
+	t.Cleanup(func() {
+		testServer.Close()
+	})
+
+	// Create a mock client.
+	c := &testClient{
+		ShouldInitiateUploadF: func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
+			resp := debuginfopb.ShouldInitiateUploadResponse{
+				ShouldInitiateUpload: true,
+			}
+			return &resp, nil
+		},
+		InitiateUploadF: func(in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error) {
+			if counter.Load() > 3 {
+				return nil, status.Error(codes.AlreadyExists, "already exists")
+			}
+			return &debuginfopb.InitiateUploadResponse{
+				UploadInstructions: &debuginfopb.UploadInstructions{
+					UploadId:       "upload-id",
+					BuildId:        dbgFile.BuildID,
+					UploadStrategy: debuginfopb.UploadInstructions_UPLOAD_STRATEGY_SIGNED_URL,
+					SignedUrl:      testServer.URL,
+				},
+			}, nil
+		},
+		MarkUploadFinishedF: func(in *debuginfopb.MarkUploadFinishedRequest, opts ...grpc.CallOption) (*debuginfopb.MarkUploadFinishedResponse, error) {
+			return &debuginfopb.MarkUploadFinishedResponse{}, nil
+		},
+	}
+
+	// Create a Manager instance.
+	dim := New(
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		objFilePool,
+		c,
+		25,
+		2*time.Minute,
+		5*time.Minute,
+		[]string{"/usr/lib/debug"},
+		true,
+		"/tmp",
+	)
+
+	// Upload: 1 (canceled)
+	err = dim.Upload(context.Background(), dbgFile)
+	require.Error(t, err)
+
+	// Assert metrics were incremented.
+	require.Equal(t, 1.0, testutil.ToFloat64(dim.metrics.uploadRequests))
+	require.Equal(t, 1.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 1.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvFail)))
+
+	// Upload: 2 (error)
+	err = dim.Upload(context.Background(), dbgFile)
+	require.Error(t, err)
+
+	// Assert metrics were incremented.
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.uploadRequests))
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvFail)))
+
+	// Upload: 3 (success)
+	err = dim.Upload(context.Background(), dbgFile)
+	require.NoError(t, err)
+
+	// Assert metrics were incremented.
+	require.Equal(t, 3.0, testutil.ToFloat64(dim.metrics.uploadRequests))
+	require.Equal(t, 3.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvFail)))
+
+	// Assert the upload was successful.
+	require.Equal(t, 1.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvSuccess)))
+
+	// Upload: 4 (already exists)
+	err = dim.Upload(context.Background(), dbgFile)
+	require.NoError(t, err)
+
+	// Assert metrics were incremented.
+	require.Equal(t, 4.0, testutil.ToFloat64(dim.metrics.uploadRequests))
+	require.Equal(t, 4.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvFail)))
+	// Already exists is not a failure.
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvSuccess)))
+
+	// Upload: 5 (cached)
+	err = dim.Upload(context.Background(), dbgFile)
+	require.NoError(t, err)
+
+	// Assert metrics were incremented.
+	require.Equal(t, 5.0, testutil.ToFloat64(dim.metrics.uploadRequests))
+	// When the response is cached, the upload is not attempted.
+	require.Equal(t, 4.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvFail)))
+	require.Equal(t, 3.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvSuccess)))
+}
+
+func TestUploadSingleFlight(t *testing.T) {
+	name := filepath.Join("../../internal/pprof/binutils/testdata", "exe_linux_64")
+	objFilePool := objectfile.NewPool(log.NewNopLogger(), prometheus.NewRegistry(), 1024)
+	t.Cleanup(func() {
+		objFilePool.Close()
+	})
+
+	// Create a mock object file.
+	dbgFile, err := objFilePool.Open(name)
+	require.NoError(t, err)
+
+	inflight := atomic.NewUint32(0)
+	counter := atomic.NewUint32(0)
+	// Create a mock server to inject errors.
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inflight.Inc()
+		defer inflight.Dec()
+
+		counter.Inc()
+
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond) //nolint:gosec
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	t.Cleanup(func() {
+		testServer.Close()
+	})
+
+	// Create a mock client.
+	c := &testClient{
+		ShouldInitiateUploadF: func(in *debuginfopb.ShouldInitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.ShouldInitiateUploadResponse, error) {
+			resp := debuginfopb.ShouldInitiateUploadResponse{
+				ShouldInitiateUpload: counter.Load() < 1,
+			}
+			return &resp, nil
+		},
+		InitiateUploadF: func(in *debuginfopb.InitiateUploadRequest, opts ...grpc.CallOption) (*debuginfopb.InitiateUploadResponse, error) {
+			return &debuginfopb.InitiateUploadResponse{
+				UploadInstructions: &debuginfopb.UploadInstructions{
+					UploadId:       "upload-id",
+					BuildId:        dbgFile.BuildID,
+					UploadStrategy: debuginfopb.UploadInstructions_UPLOAD_STRATEGY_SIGNED_URL,
+					SignedUrl:      testServer.URL,
+				},
+			}, nil
+		},
+		MarkUploadFinishedF: func(in *debuginfopb.MarkUploadFinishedRequest, opts ...grpc.CallOption) (*debuginfopb.MarkUploadFinishedResponse, error) {
+			return &debuginfopb.MarkUploadFinishedResponse{}, nil
+		},
+	}
+
+	// Create a Manager instance.
+	dim := New(
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		objFilePool,
+		c,
+		5,
+		2*time.Minute,
+		5*time.Minute,
+		[]string{"/usr/lib/debug"},
+		true,
+		"/tmp",
+	)
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				// There should be only one upload in flight.
+				require.LessOrEqualf(t, inflight.Load(), uint32(1), "there should be only one upload in flight")
+				require.LessOrEqualf(t, testutil.ToFloat64(dim.metrics.uploadInflight), 5.0, "there should be only max number of upload requests started")
+			}
+		}
+	}()
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			err = dim.Upload(context.Background(), dbgFile)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	close(done)
+
+	require.Equal(t, 10.0, testutil.ToFloat64(dim.metrics.uploadRequests))
+	require.Equal(t, 1.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 0.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvFail)))
+	require.Equal(t, 5.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvShared)))
+	require.Equal(t, 10.0, testutil.ToFloat64(dim.metrics.upload.WithLabelValues(lvSuccess)))
 }
 
 func TestDisableStripping(t *testing.T) {
@@ -94,7 +328,12 @@ func TestDisableStripping(t *testing.T) {
 	f, err := m.extractDebuginfo(context.Background(), objFile)
 	require.NoError(t, err)
 
-	strippedContent, err := os.ReadFile(f.File.Name())
+	r, done, err := f.Reader()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		done()
+	})
+	strippedContent, err := io.ReadAll(r)
 	require.NoError(t, err)
 
 	if !bytes.Equal(originalContent, strippedContent) {

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -60,7 +60,6 @@ func BenchmarkUploadInitiateUploadError(b *testing.B) {
 		objFilePool,
 		c,
 		2*time.Minute,
-		3,
 		5*time.Minute,
 		[]string{"/usr/lib/debug"},
 		true,

--- a/pkg/debuginfo/metrics.go
+++ b/pkg/debuginfo/metrics.go
@@ -32,7 +32,6 @@ type metrics struct {
 	findDuration              prometheus.Histogram
 	uploadRequests            prometheus.Counter
 	uploadAttempts            prometheus.Counter
-	uploadRetry               prometheus.Counter
 	uploadInflight            prometheus.Gauge
 	uploadRequestWaitDuration prometheus.Histogram
 	upload                    *prometheus.CounterVec
@@ -66,10 +65,6 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		uploadRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "parca_agent_debuginfo_upload_requests_total",
 			Help: "Total number of requests to upload debuginfo.",
-		}),
-		uploadRetry: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "parca_agent_debuginfo_upload_retry_total",
-			Help: "Total number of retries to upload debuginfo.",
 		}),
 		uploadInflight: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "parca_agent_debuginfo_upload_inflight_requests",

--- a/pkg/debuginfo/noop.go
+++ b/pkg/debuginfo/noop.go
@@ -20,8 +20,8 @@ import (
 
 type NoopDebuginfoManager struct{}
 
-func (NoopDebuginfoManager) ExtractOrFindDebugInfo(context.Context, string, *objectfile.ObjectFile) (*objectfile.ObjectFile, error) {
-	return nil, nil //nolint:nilnil
+func (NoopDebuginfoManager) ExtractOrFindDebugInfo(_ context.Context, _ string, obj *objectfile.ObjectFile) (*objectfile.ObjectFile, error) {
+	return obj, nil
 }
 
 func (NoopDebuginfoManager) Upload(context.Context, *objectfile.ObjectFile) error { return nil }

--- a/pkg/debuginfo/noop.go
+++ b/pkg/debuginfo/noop.go
@@ -20,12 +20,10 @@ import (
 
 type NoopDebuginfoManager struct{}
 
-func (NoopDebuginfoManager) ExtractOrFindDebugInfo(context.Context, string, *objectfile.ObjectFile) error {
-	return nil
+func (NoopDebuginfoManager) ExtractOrFindDebugInfo(context.Context, string, *objectfile.ObjectFile) (*objectfile.ObjectFile, error) {
+	return nil, nil //nolint:nilnil
 }
 
-func (NoopDebuginfoManager) UploadWithRetry(context.Context, *objectfile.ObjectFile) error {
-	return nil
-}
 func (NoopDebuginfoManager) Upload(context.Context, *objectfile.ObjectFile) error { return nil }
-func (NoopDebuginfoManager) Close() error                                         { return nil }
+
+func (NoopDebuginfoManager) Close() error { return nil }

--- a/pkg/discovery/discovery_manager.go
+++ b/pkg/discovery/discovery_manager.go
@@ -86,7 +86,7 @@ type provider struct {
 type Manager struct {
 	logger log.Logger
 
-	mtx            sync.RWMutex
+	mtx            *sync.RWMutex
 	discoverCancel []context.CancelFunc
 
 	metrics *metrics
@@ -116,6 +116,7 @@ func NewManager(logger log.Logger, reg prometheus.Registerer, options ...func(*M
 		logger:         logger,
 		syncCh:         make(chan map[string][]*Group),
 		Targets:        make(map[poolKey]map[string]*Group),
+		mtx:            &sync.RWMutex{},
 		discoverCancel: []context.CancelFunc{},
 		metrics:        newMetrics(reg),
 		updatert:       5 * time.Second,

--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -85,13 +85,10 @@ func Compiler(logger log.Logger, reg prometheus.Registerer, objFilePool *objectf
 				return cachedLabels, nil
 			}
 
-			if !objFile.IsOpen() {
-				if err := objFile.ReOpen(); err != nil {
-					return nil, fmt.Errorf("failed to open object file for process %d: %w", pid, err)
-				}
-				defer objFile.Close()
+			ef, err := objFile.ELF()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get ELF file for process %d: %w", pid, err)
 			}
-			ef := objFile.ElfFile
 			labels := model.LabelSet{
 				"compiler": model.LabelValue(ainur.Compiler(ef)),
 				"stripped": model.LabelValue(fmt.Sprintf("%t", ainur.Stripped(ef))),

--- a/pkg/objectfile/object_file.go
+++ b/pkg/objectfile/object_file.go
@@ -44,11 +44,7 @@ type ObjectFile struct {
 	// Closing should be done using File.Close.
 	ElfFile *elf.File
 
-	// TODO(kakkoyun): Maybe tt would be a better design if we don't tie them up.
-	DebuginfoFile *ObjectFile
-
-	closed   *atomic.Bool
-	uploaded *atomic.Bool
+	closed *atomic.Bool
 }
 
 func (o *ObjectFile) IsOpen() bool {
@@ -90,14 +86,6 @@ func (o *ObjectFile) ReOpen() error {
 	return nil
 }
 
-func (o *ObjectFile) IsUploaded() bool {
-	return o != nil && o.uploaded.Load()
-}
-
-func (o *ObjectFile) MarkUploaded() {
-	o.uploaded.Store(true)
-}
-
 func (o *ObjectFile) Rewind() error {
 	if err := rewind(o.File); err != nil {
 		return fmt.Errorf("failed to seek to the beginning of the file %s: %w", o.Path, err)
@@ -123,10 +111,6 @@ func (o *ObjectFile) Close() error {
 		err = errors.Join(err, o.File.Close())
 	}
 	o.closed.Store(true)
-	// No need to close o.ElfFile as it is closed by o.File.Close.
-	if o.DebuginfoFile != nil && o.DebuginfoFile != o {
-		err = errors.Join(err, o.DebuginfoFile.Close())
-	}
 	return err
 }
 

--- a/pkg/objectfile/object_file.go
+++ b/pkg/objectfile/object_file.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"go.uber.org/atomic"
@@ -36,22 +37,23 @@ type ObjectFile struct {
 	BuildID string
 
 	Path    string
-	File    *os.File
 	Size    int64
 	Modtime time.Time
 
-	// Opened using elf.NewFile.
-	// Closing should be done using File.Close.
-	ElfFile *elf.File
+	mtx  *sync.RWMutex
+	file *os.File
+	elf  *elf.File // Opened using elf.NewFile, no need to close.
 
 	closed *atomic.Bool
 }
 
-func (o *ObjectFile) IsOpen() bool {
-	return o != nil && o.File != nil && !o.closed.Load()
-}
+// open opens the specified executable or library file from the given path.
+// In normal use, the pool should be used instead of this function.
+// This is used to open prematurely closed files.
+func (o *ObjectFile) open() error {
+	o.mtx.Lock()
+	defer o.mtx.Unlock()
 
-func (o *ObjectFile) ReOpen() error {
 	f, err := os.Open(o.Path)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", o.Path, err)
@@ -62,35 +64,64 @@ func (o *ObjectFile) ReOpen() error {
 		}
 		return err
 	}
-
-	ok, err := isELF(f)
-	if err != nil {
-		return closer(fmt.Errorf("failed check whether file is an ELF file %s: %w", o.Path, err))
-	}
-	if !ok {
-		return closer(fmt.Errorf("unrecognized binary format: %s", o.Path))
-	}
-	ef, err := elfNewFile(f)
+	// > Clients of ReadAt can execute parallel ReadAt calls on the
+	//   same input source.
+	ef, err := elfNewFile(f) // requires ReaderAt.
 	if err != nil {
 		return closer(fmt.Errorf("error opening %s: %w", o.Path, err))
 	}
 	stat, err := f.Stat()
 	if err != nil {
-		return fmt.Errorf("failed to stat the file: %w", err)
+		return closer(fmt.Errorf("failed to stat the file: %w", err))
 	}
-	o.File = f
-	o.ElfFile = ef
+	o.file = f
+	o.elf = ef
 	o.Size = stat.Size()
 	o.Modtime = stat.ModTime()
-	o.closed.Store(false)
 	return nil
 }
 
-func (o *ObjectFile) Rewind() error {
-	if err := rewind(o.File); err != nil {
-		return fmt.Errorf("failed to seek to the beginning of the file %s: %w", o.Path, err)
+// Reader returns a reader for the file.
+// Parallel reads are NOT allowed. The caller must call the returned function when done with the reader.
+func (o *ObjectFile) Reader() (*os.File, func() error, error) {
+	if o.file == nil {
+		// This should never happen.
+		return nil, nil, fmt.Errorf("file is not initialized")
 	}
-	return nil
+	reOpened := false
+	if o.closed.Load() {
+		// File is closed, prematurely. Reopen it.
+		if err := o.open(); err != nil {
+			return nil, nil, fmt.Errorf("failed to reopen the file %s: %w", o.Path, err)
+		}
+		reOpened = true
+	}
+
+	done := func() (ret error) {
+		defer o.mtx.RUnlock()
+		defer func() {
+			// The file was already closed, so we should keep it closed.
+			if reOpened {
+				if err := o.Close(); err != nil {
+					ret = errors.Join(ret, fmt.Errorf("failed to close the file %s: %w", o.Path, err))
+				}
+			}
+		}()
+
+		if err := rewind(o.file); err != nil {
+			return fmt.Errorf("failed to seek to the beginning of the file %s: %w", o.Path, err)
+		}
+		return nil
+	}
+
+	o.mtx.RLock()
+	// Make sure file is rewound before returning.
+	if err := rewind(o.file); err != nil {
+		o.mtx.RUnlock()
+		return nil, nil, fmt.Errorf("failed to seek to the beginning of the file %s: %w", o.Path, err)
+	}
+
+	return o.file, done, nil
 }
 
 func rewind(f io.ReadSeeker) error {
@@ -98,6 +129,31 @@ func rewind(f io.ReadSeeker) error {
 	return err
 }
 
+func (o *ObjectFile) ELF() (_ *elf.File, ret error) {
+	if o.elf == nil {
+		// This should never happen.
+		return nil, fmt.Errorf("elf file is not initialized")
+	}
+	// TODO(kakkoyun): Probably we do not need to reopen the file here.
+	// - Add metrics to track and remove it the files never reopened.
+	if o.closed.Load() {
+		// File is closed, prematurely. Reopen it.
+		if err := o.open(); err != nil {
+			return nil, fmt.Errorf("failed to reopen the file %s: %w", o.Path, err)
+		}
+		defer func() {
+			// The file was already closed, so we should keep it closed.
+			if err := o.Close(); err != nil {
+				ret = errors.Join(ret, fmt.Errorf("failed to close the file %s: %w", o.Path, err))
+			}
+		}()
+	}
+	return o.elf, nil
+}
+
+// Close closes the underlying file descriptor.
+// It is safe to call this function multiple times.
+// File should only be closed once.
 func (o *ObjectFile) Close() error {
 	if o == nil {
 		return nil
@@ -107,8 +163,10 @@ func (o *ObjectFile) Close() error {
 	}
 
 	var err error
-	if o.File != nil {
-		err = errors.Join(err, o.File.Close())
+	if o.file != nil {
+		o.mtx.Lock()
+		err = errors.Join(err, o.file.Close())
+		o.mtx.Unlock()
 	}
 	o.closed.Store(true)
 	return err
@@ -134,7 +192,7 @@ func isELF(f *os.File) (_ bool, err error) {
 }
 
 func (o *ObjectFile) HasTextSection() bool {
-	if textSection := o.ElfFile.Section(".text"); textSection == nil {
+	if textSection := o.elf.Section(".text"); textSection == nil {
 		return false
 	}
 	return true

--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -212,14 +212,6 @@ func (im *InfoManager) extractAndUploadDebuginfo(ctx context.Context, pid int, m
 			continue
 		}
 
-		if !m.isOpen() {
-			if err := m.openObjFile(); err != nil {
-				level.Debug(im.logger).Log("msg", "failed to re-open objfile", "err", err)
-			}
-			multiErr = multierror.Append(multiErr, fmt.Errorf("mapping %s is not open", m.Pathname))
-			continue
-		}
-
 		var (
 			srcObjFile = m.objFile // objectfile should exist and be open at this point.
 			logger     = log.With(im.logger, "pid", pid, "buildid", srcObjFile.BuildID, "path", srcObjFile.Path)

--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -38,7 +38,7 @@ type DebuginfoManager interface {
 	Close() error
 }
 
-// TODO(kakkoyun): Unify PID types.
+// TODO: Unify PID types.
 type LabelManager interface {
 	LabelSet(pid int) model.LabelSet
 }
@@ -260,13 +260,10 @@ func (im *InfoManager) extractAndUploadDebuginfo(ctx context.Context, pid int, m
 			// NOTICE: The upload timeout and upload retry logic controlled by debuginfo manager.
 			if err := di.Upload(ctx, dbgObjFile); err != nil {
 				im.metrics.upload.WithLabelValues(lvFail).Inc()
-				// TODO(kakkoyun): Should we keep the file open or closed?
 				level.Error(logger).Log("msg", "failed to upload debuginfo", "err", err)
 				return
 			}
 			im.metrics.upload.WithLabelValues(lvSuccess).Inc()
-
-			// TODO(kakkoyun): Make sure MappingManager done with the object file.
 			if err := srcObjFile.Close(); err != nil {
 				level.Debug(logger).Log("msg", "failed to close objfile", "err", err)
 			}

--- a/pkg/process/maps_test.go
+++ b/pkg/process/maps_test.go
@@ -255,8 +255,8 @@ func TestELFObjAddr(t *testing.T) {
 				},
 			}
 
-			if err := m.open(); err != nil {
-				t.Errorf("openELF got error %v, want any error=%v", err, tc.wantOpenError)
+			if err := m.init(); err != nil {
+				t.Errorf("init got error %v, want any error=%v", err, tc.wantOpenError)
 			}
 			t.Cleanup(func() { m.close() })
 			if err != nil {
@@ -333,7 +333,7 @@ func TestELFObjAddrNoPIE(t *testing.T) {
 		},
 	}
 
-	if err := m.open(); err != nil {
+	if err := m.init(); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { m.close() })
@@ -422,7 +422,7 @@ func TestELFObjAddrPIE(t *testing.T) {
 		},
 	}
 
-	if err := m.open(); err != nil {
+	if err := m.init(); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { m.close() })

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -116,7 +116,7 @@ type Profile struct {
 	Functions []*Function
 }
 
-// TODO(kakkoyun): Unify PID types.
+// TODO: Unify PID types.
 type ProcessInfoManager interface {
 	Fetch(ctx context.Context, pid int) error
 	Info(ctx context.Context, pid int) (*process.Info, error)

--- a/pkg/symbol/symbol.go
+++ b/pkg/symbol/symbol.go
@@ -25,7 +25,6 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/perf"
 	"github.com/parca-dev/parca-agent/pkg/process"
 	"github.com/parca-dev/parca-agent/pkg/profiler"
-	"github.com/parca-dev/parca-agent/pkg/vdso"
 )
 
 type SymbolResolver interface {
@@ -51,7 +50,7 @@ type Symbolizer struct {
 	vdsoCache VDSOResolver
 }
 
-func NewSymbolizer(logger log.Logger, perfCache PerfMapFinder, ksymCache SymbolResolver, vdsoCache *vdso.Cache, disableJIT bool) *Symbolizer {
+func NewSymbolizer(logger log.Logger, perfCache PerfMapFinder, ksymCache SymbolResolver, vdsoCache VDSOResolver, disableJIT bool) *Symbolizer {
 	return &Symbolizer{
 		logger: logger,
 

--- a/pkg/vdso/vdso.go
+++ b/pkg/vdso/vdso.go
@@ -55,6 +55,11 @@ func NewCache(objFilePool *objectfile.Pool) (*Cache, error) {
 	}
 	defer objFile.Close()
 
+	ef, err := objFile.ELF()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get elf file:%s, err:%w", path, err)
+	}
+
 	// output of readelf --dyn-syms vdso.so:
 	//  Num:    Value          Size Type    Bind   Vis      Ndx Name
 	//     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
@@ -68,7 +73,7 @@ func NewCache(objFilePool *objectfile.Pool) (*Cache, error) {
 	//     8: ffffffffff700f70    61 FUNC    WEAK   DEFAULT   13 getcpu@@LINUX_2.6
 	//     9: ffffffffff700700  1389 FUNC    GLOBAL DEFAULT   13 __vdso_clock_gettime@@LINUX_2.6
 	//    10: ffffffffff700f50    22 FUNC    GLOBAL DEFAULT   13 __vdso_time@@LINUX_2.6
-	syms, err := objFile.ElfFile.DynamicSymbols()
+	syms, err := ef.DynamicSymbols()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vdso/vdso.go
+++ b/pkg/vdso/vdso.go
@@ -25,6 +25,10 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/process"
 )
 
+type NoopCache struct{}
+
+func (NoopCache) Resolve(uint64, *process.Mapping) (string, error) { return "", nil }
+
 type Cache struct {
 	searcher symbolsearcher.Searcher
 	f        string
@@ -40,7 +44,7 @@ func NewCache(objFilePool *objectfile.Pool) (*Cache, error) {
 		merr    error
 		path    string
 	)
-	// find a file is enough
+	// This file is not present on all systems. It's an optimization.
 	for _, vdso := range []string{"vdso.so", "vdso64.so"} {
 		path = fmt.Sprintf("/usr/lib/modules/%s/vdso/%s", kernelVersion, vdso)
 		objFile, err = objFilePool.Open(path)

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -211,8 +211,12 @@ func prepareProfiler(t *testing.T, profileWriter profiler.ProfileWriter, logger 
 
 	ofp := objectfile.NewPool(logger, reg, curr)
 
-	vdsoCache, err := vdso.NewCache(ofp)
-	require.NoError(t, err)
+	var vdsoCache symbol.VDSOResolver
+	vdsoCache, err = vdso.NewCache(ofp)
+	if err != nil {
+		t.Log("VDSO cache not available, using noop cache")
+		vdsoCache = vdso.NoopCache{}
+	}
 
 	dbginfo := debuginfo.NoopDebuginfoManager{}
 	labelsManager := labels.NewManager(


### PR DESCRIPTION
### Why?

There are two major fixes in this PR:

1) The Parca server sometimes restarts; if we don't ask the server constantly, we miss debuginfo files. Therefore, I'm removing the retry limit, and we will ask the server always if it has the necessary debuginfo.

2) Avoid any possible race conditions while reading the object files. 
Fixes https://github.com/parca-dev/parca-agent/issues/1614

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a62d7f9</samp>

*  Add a new flag `--debuginfo-upload-max-parallel` to control the maximum number of parallel uploads of debuginfo files ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL168-R168),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL533-R534),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L79-R78),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L101-R100),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-e34917e1d967c4b448d1cd842e1aace9c273ab0bf4e4ca198186f70d82dbfd74L62-R71),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-e34917e1d967c4b448d1cd842e1aace9c273ab0bf4e4ca198186f70d82dbfd74R86-R310))
*  Refactor the `DebuginfoManager` interface and the `Manager` type to return the debuginfo object file instead of modifying the source object file, and to remove the retry logic and use a singleflight mechanism instead ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L18-R19),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L27),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L66),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L126-R123),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L142-R134),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L153-R147),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L168-R163),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L194-R196),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R202),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L230-R218),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L281-R226),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L309-R256),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L329-L330),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R277),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L350-R307),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L380-R339),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R389),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R395-R398),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L453-R414),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-4938d357026bd7ab52d9b4b374899dd4eced576aed8c33f9f871f6537bc03328L35),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-4938d357026bd7ab52d9b4b374899dd4eced576aed8c33f9f871f6537bc03328L70-L73),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L36-R41),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L198-R250),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L231-R267))
*  Refactor the `ObjectFile` type to hide the underlying file descriptor and elf file, and to provide methods for concurrent access to the file with proper locking ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537R25),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L39-R56),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L69-R124),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537R132-R156),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L122-R171),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L153-R195),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L74-R83),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L87-R93),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L94-R102),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L106-R120),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L129-R136),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL214-R212),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL229-R222),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL257-R251),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL327-R326),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL353-R332),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-2fbc63cb8ebb2eae13c9bd2ff211fe4abf8a4a939fe97b804012f013d9a1a6eaL258-R259),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-2fbc63cb8ebb2eae13c9bd2ff211fe4abf8a4a939fe97b804012f013d9a1a6eaL336-R336),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-2fbc63cb8ebb2eae13c9bd2ff211fe4abf8a4a939fe97b804012f013d9a1a6eaL425-R425),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-38da4938004f35685ca8cb0368582c999d7db09d15a029522c945feff69e6ad5L119-R119),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-b3a7f294a0fa5a71ab06af71de938e5dfbc119109c6d13ce194e58efec847517R58-R62),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-b3a7f294a0fa5a71ab06af71de938e5dfbc119109c6d13ce194e58efec847517L71-R76))
*  Add a new type `SeekReaderAt` that combines the `io.ReaderAt` and `io.Seeker` interfaces, and modify the `Extract` function to take a `SeekReaderAt` instead of an `*os.File` as the source parameter ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803R32-R36),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803L74-R79),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803L81-R86))
*  Modify the `readDebuglink` function to take an `*elf.File` instead of an `*os.File` as the parameter, and use the cached value if available ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-a01e25a5f5c397126a4a459eee2a2c30fb9acbd1a6ea9fc5e32dd3136b978d56L86-R86),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-a01e25a5f5c397126a4a459eee2a2c30fb9acbd1a6ea9fc5e32dd3136b978d56L140-R145),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-a01e25a5f5c397126a4a459eee2a2c30fb9acbd1a6ea9fc5e32dd3136b978d56L188-R190),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-a01e25a5f5c397126a4a459eee2a2c30fb9acbd1a6ea9fc5e32dd3136b978d56L205-R201),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-ce8f0dbf47ed5d0ee688ab01344a7de40c12a3690b890014a36fe073bd0fc865R18),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-ce8f0dbf47ed5d0ee688ab01344a7de40c12a3690b890014a36fe073bd0fc865L296-R300))
*  Modify the `Mapping` type to rename the `open` method to `init`, and to call the `computeKernelOffset` method from the `openObjFile` method ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL74-R75),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL134-R137),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL155-R154))
*  Add a new field `debuginfoSrcCache` to the `InfoManager` type, to cache the debuginfo object files by their build IDs ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7R120-R121),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7R136-R140),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L156-R173))
*  Modify the type of the `mtx` field of the `Manager` type in the `pkg/discovery` package to be a pointer to a `sync.RWMutex` instead of a value ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L89-R89),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055R119))
*  Remove the `noopDebuginfoManager` type and its methods, as they are no longer needed ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL916-R918))
*  Remove the import of the `github.com/cenkalti/backoff` package, as it is no longer used ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L8))
*  Add tests for the `Upload` method of the `Manager` type in the `pkg/debuginfo` package ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-e34917e1d967c4b448d1cd842e1aace9c273ab0bf4e4ca198186f70d82dbfd74L21-R28),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-e34917e1d967c4b448d1cd842e1aace9c273ab0bf4e4ca198186f70d82dbfd74L29-R37),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-e34917e1d967c4b448d1cd842e1aace9c273ab0bf4e4ca198186f70d82dbfd74R86-R310))
*  Modify the error message and the panic message in the `readDebuglink` function and the `pkg/objectfile/pool.go` file to include the type of the unexpected value in the cache ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-a01e25a5f5c397126a4a459eee2a2c30fb9acbd1a6ea9fc5e32dd3136b978d56L86-R86),[link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L129-R136))
*  Modify the condition to check for a successful status code in the `uploadViaHTTP` function to allow any 2xx status code instead of only 200 ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L453-R414))
*  Update the documentation of the `--debuginfo-upload-max-parallel` flag in the `README.md` file ([link](https://github.com/parca-dev/parca-agent/pull/1623/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R114))

### Test Plan

Relevant tests are added.

1. `make test`
1. Run `scripts/local-run.sh`
1. Run `make dev/up`

<!--
copilot:poem
-->

### <samp>🤖 Generated by Copilot at 07d7cda</samp>

> _Debuginfo manager_
> _Simplifies and improves code_
> _No more `backoff`_