### PR TITLE
chore: Remove exclude-rules for the arguments pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,15 +52,6 @@ issues:
     - path: pkg/elfwriter
       linters:
         - dupl
-    - path: pkg/arguments
-      linters:
-        - stylecheck
-        - nonamedreturns
-        - gosimple
-        - deadcode
-        - forcetypeassert
-        - dupword
-        - interfacebloat
 
 linters-settings:
   depguard:


### PR DESCRIPTION
We no longer have arguments package after #1518. Remove exclude-rules for it in the CI.
