### PR TITLE
Do not normalize addresses from JIT'd code

### DIFF
--- a/pkg/address/normalizer.go
+++ b/pkg/address/normalizer.go
@@ -64,8 +64,12 @@ func (n *normalizer) Normalize(m *process.Mapping, addr uint64) (uint64, error) 
 	if m == nil {
 		return 0, errors.New("mapping is nil")
 	}
+
+	// Do not normalize JIT sections.
+	//
+	// TODO: Improve this, as some JITs might actually create files.
 	if m.Pathname == "" {
-		return 0, errors.New("mapping pathname is empty")
+		return addr, nil
 	}
 
 	if m.Pathname == "[vdso]" {

--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -341,9 +341,10 @@ func (m *Mapping) computeBase(addr uint64) error {
 
 // ConvertToPprof converts the Mapping to a pprof profile.Mapping.
 func (m *Mapping) ConvertToPprof() *profile.Mapping {
-	buildID := "<unknown build id>"
-	path := "<unknown path>"
-	// ^ could be JIT segments, validate this!
+	buildID := "unknown"
+	// TODO: Maybe add detection for JITs that use files.
+	path := "jit"
+
 	if m.objFile != nil {
 		buildID = m.objFile.BuildID
 		path = m.objFile.Path

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -155,7 +155,7 @@ func symbolizeProfile(t *testing.T, profile *profile.Profile, demangle bool) [][
 			address := frame.Address
 			file := frame.Mapping.File
 
-			if file == "<unknown path>" {
+			if file == "jit" {
 				continue
 			}
 


### PR DESCRIPTION
Addresses written to "perf maps" or jitdump are absolute to the processes, so currently symbolization is broken.

This the first step to unblock the broken JIT symbolization. There is more work to do, will open an issue to track this.

Test Plan
=========

The current integration tests `make test/profiler` pass. Will add an integration test once we have the mixed-mode unwinder ready.

<img width="166" alt="image" src="https://github.com/parca-dev/parca-agent/assets/959128/c43abcb0-5136-402e-847c-46509e276055">
