### PR TITLE
*: Fix metadata caching issues

### DIFF
--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -1,0 +1,46 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import burrow "github.com/goburrow/cache"
+
+var _ burrow.Cache = &noopCache{}
+
+// noopCache implements the burrow.Cache interface but does not cache anything.
+// It is useful for testing, so let's keep it around.
+type noopCache struct{}
+
+func NewNopCache() *noopCache {
+	return &noopCache{}
+}
+
+func (c *noopCache) GetIfPresent(burrow.Key) (burrow.Value, bool) {
+	return nil, false
+}
+
+func (c *noopCache) Put(burrow.Key, burrow.Value) {
+}
+
+func (c *noopCache) Invalidate(burrow.Key) {
+}
+
+func (c *noopCache) InvalidateAll() {
+}
+
+func (c *noopCache) Stats(*burrow.Stats) {
+}
+
+func (c *noopCache) Close() error {
+	return nil
+}

--- a/pkg/metadata/java_process.go
+++ b/pkg/metadata/java_process.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-kit/log"
@@ -24,8 +25,12 @@ import (
 )
 
 func JavaProcess(logger log.Logger) Provider {
-	return &StatelessProvider{"java process", func(pid int) (model.LabelSet, error) {
-		cache := hsperfdata.NewCache(logger)
+	cache := hsperfdata.NewCache(logger)
+
+	return &StatelessProvider{"java process", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 
 		java, err := cache.IsJavaProcess(pid)
 		if err != nil {

--- a/pkg/metadata/labels/manager_test.go
+++ b/pkg/metadata/labels/manager_test.go
@@ -14,6 +14,7 @@
 package labels_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -59,13 +60,19 @@ func TestManager(t *testing.T) {
 		time.Second,
 	)
 
+	ls, err := lm.LabelSet(context.TODO(), 1)
+	require.NoError(t, err)
+
 	// Should have the node_pid label
 	require.Equal(t, model.LabelSet{
 		"__name__": "fake_profiler",
 		"node":     "test",
 		"pid":      "1",
 		"node_pid": "test;1",
-	}, labels.WithProfilerName(lm.LabelSet(1), "fake_profiler"))
+	}, labels.WithProfilerName(ls, "fake_profiler"))
+
+	lbs, err := lm.Labels(context.TODO(), 1)
+	require.NoError(t, err)
 
 	require.Equal(t,
 		promlabels.New(promlabels.Labels{
@@ -74,10 +81,15 @@ func TestManager(t *testing.T) {
 			{Name: "pid", Value: "1"},
 			{Name: "node_pid", Value: "test;1"},
 		}...),
-		promlabels.New(append(lm.Labels(1), labels.ProfilerName("fake_profiler"))...),
+		promlabels.New(append(lbs, labels.ProfilerName("fake_profiler"))...),
 	)
 
 	// Should be dropped
-	require.Empty(t, lm.LabelSet(2))
-	require.Empty(t, lm.Labels(2))
+	ls, err = lm.LabelSet(context.TODO(), 2)
+	require.NoError(t, err)
+	require.Empty(t, ls)
+
+	lbs, err = lm.Labels(context.TODO(), 2)
+	require.NoError(t, err)
+	require.Empty(t, lbs)
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -15,22 +15,24 @@
 package metadata
 
 import (
+	"context"
+
 	"github.com/prometheus/common/model"
 )
 
 type Provider interface {
-	Labels(pid int) (model.LabelSet, error)
+	Labels(ctx context.Context, pid int) (model.LabelSet, error)
 	Name() string
 	ShouldCache() bool
 }
 
 type StatelessProvider struct {
 	name      string
-	labelFunc func(pid int) (model.LabelSet, error)
+	labelFunc func(ctx context.Context, pid int) (model.LabelSet, error)
 }
 
-func (p *StatelessProvider) Labels(pid int) (model.LabelSet, error) {
-	return p.labelFunc(pid)
+func (p *StatelessProvider) Labels(ctx context.Context, pid int) (model.LabelSet, error) {
+	return p.labelFunc(ctx, pid)
 }
 
 func (p *StatelessProvider) Name() string {

--- a/pkg/metadata/pod_hosts.go
+++ b/pkg/metadata/pod_hosts.go
@@ -16,6 +16,7 @@ package metadata
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -31,9 +32,12 @@ var (
 	errInitHostname error
 )
 
-// PodHosts provide pod_ip and pod if pid is a pod.
+// PodHosts provide pod_ip and pod_hostname if pid is a pod.
 func PodHosts() Provider {
-	return &StatelessProvider{"hosts", func(pid int) (model.LabelSet, error) {
+	return &StatelessProvider{"hosts", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		initHostname.Do(func() {
 			local, err := getExternalIPAndHost(1)
 			if err != nil {
@@ -52,8 +56,8 @@ func PodHosts() Provider {
 		if hostname != e.hostname {
 			// pod
 			return model.LabelSet{
-				"pod_ip": model.LabelValue(e.ip),
-				"pod":    model.LabelValue(e.hostname),
+				"pod_ip":       model.LabelValue(e.ip),
+				"pod_hostname": model.LabelValue(e.hostname),
 			}, nil
 		}
 		return nil, nil

--- a/pkg/metadata/process.go
+++ b/pkg/metadata/process.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -25,7 +26,11 @@ import (
 )
 
 func Process(procfs procfs.FS) Provider {
-	return &StatelessProvider{"process", func(pid int) (model.LabelSet, error) {
+	return &StatelessProvider{"process", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		p, err := procfs.Proc(pid)
 		if err != nil {
 			return nil, fmt.Errorf("failed to instantiate procfs for PID %d: %w", pid, err)

--- a/pkg/metadata/system.go
+++ b/pkg/metadata/system.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"syscall"
@@ -42,7 +43,10 @@ func (p *systemProvider) ShouldCache() bool {
 func System() Provider {
 	once.Do(setMetadata)
 
-	return &systemProvider{StatelessProvider{"system", func(_ int) (model.LabelSet, error) {
+	return &systemProvider{StatelessProvider{"system", func(ctx context.Context, _ int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return labels, nil
 	}}}
 }
@@ -62,7 +66,6 @@ func setMetadata() {
 	if err == nil {
 		revision = b.VcsRevision
 	}
-
 	labels = model.LabelSet{
 		"kernel_release": model.LabelValue(release),
 		"agent_revision": model.LabelValue(revision),

--- a/pkg/metadata/target.go
+++ b/pkg/metadata/target.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"context"
 	"strings"
 
 	"github.com/prometheus/common/model"
@@ -23,7 +24,11 @@ import (
 // Target metadata provider.
 func Target(node string, externalLabels map[string]string) Provider {
 	target := targetLabels(node, externalLabels)
-	return &StatelessProvider{"target", func(pid int) (model.LabelSet, error) {
+	return &StatelessProvider{"target", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		labels := model.LabelSet{}
 		for labelname, labelvalue := range target {
 			if !strings.HasPrefix(string(labelname), "__") {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -578,7 +578,12 @@ func (p *CPU) Run(ctx context.Context) error {
 				processLastErrors[int(prof.ID.PID)] = err
 				continue
 			}
-			labelSet := pi.Labels
+			labelSet, err := pi.Labels(ctx)
+			if err != nil {
+				level.Warn(p.logger).Log("msg", "failed to get process labels", "pid", prof.ID.PID, "err", err)
+				processLastErrors[int(prof.ID.PID)] = err
+				continue
+			}
 			if len(labelSet) == 0 {
 				level.Debug(p.logger).Log("msg", "profile dropped", "pid", prof.ID.PID)
 				continue


### PR DESCRIPTION
### Why?
Fetching metadata labels earlier and caching the fetched labels prematurely was causing problems. This PR makes sure all of the issues are solved. 

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3b562c</samp>

This pull request adds context and error handling to the metadata and label fetching logic of the `parca-agent`, and refactors some of the related code to improve performance and reliability. It also changes the `Run` method of the CPU profiler to handle label errors, and adds a `noopCache` type for testing.

### Test Plan
1. `make dev/up`


![CleanShot 2023-05-16 at 15 56 57](https://github.com/parca-dev/parca-agent/assets/536449/df62240d-5acd-4b7b-983f-c046182b0e02)
![CleanShot 2023-05-16 at 15 56 01](https://github.com/parca-dev/parca-agent/assets/536449/0b5b934c-99ce-4e0e-ab93-1ff27f07a448)

[Fetch the labels in the first encouter](https://github.com/parca-dev/parca-agent/commit/b3b562c6b4b16c91be883456739d4f36de0be823)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b3b562c</samp>

> _Sing, O Muse, of the valiant `parca-agent` and its deeds_
> _How it faced the challenge of labeling processes with speed_
> _How it used the `context` package, a gift from the gods of code_
> _To handle errors and timeouts, and lighten its heavy load_
