### PR TITLE
tests/integration: Improve assertions

### DIFF
--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -175,22 +175,36 @@ func symbolizeProfile(t *testing.T, profile *profile.Profile, demangle bool) [][
 	return aggregatedStacks
 }
 
-func anyStackEqual(aggregatedStacks [][]string, stack []string) bool {
-	for _, aggregatedStack := range aggregatedStacks {
-		if len(aggregatedStack) == len(stack) {
+func anyStackContains(foundStacks [][]string, stack []string) bool {
+	foundEqualSubslice := false
+
+	for _, foundStack := range foundStacks {
+		if len(stack) <= len(foundStack) {
 			equal := true
-			for i := range aggregatedStack {
-				if aggregatedStack[i] != stack[i] {
+
+			for i := range stack {
+				if stack[i] != foundStack[i] {
 					equal = false
 					break
 				}
 			}
+
 			if equal {
-				return true
+				foundEqualSubslice = true
+				break
 			}
 		}
 	}
-	return false
+
+	return foundEqualSubslice
+}
+
+func assertAnyStackContains(t *testing.T, foundStacks [][]string, stack []string) {
+	t.Helper()
+
+	if !anyStackContains(foundStacks, stack) {
+		t.Fatal("The stack", stack, "is not contained in any of", foundStacks)
+	}
 }
 
 func prepareProfiler(t *testing.T, profileWriter profiler.ProfileWriter, logger log.Logger, tempDir string) (*cpu.CPU, *objectfile.Pool) {
@@ -326,8 +340,8 @@ func TestCPUProfilerWorks(t *testing.T) {
 		// Test symbolized stacks.
 		aggregatedStacks := symbolizeProfile(t, sample.profile, true)
 		require.True(t, len(aggregatedStacks) > 0)
-		require.True(t, anyStackEqual(aggregatedStacks, []string{"top2()", "c2()", "b2()", "a2()", "main", "__libc_start_call_main", "__libc_start_main_alias_2"}))
-		require.True(t, anyStackEqual(aggregatedStacks, []string{"top1()", "c1()", "b1()", "a1()", "main", "__libc_start_call_main", "__libc_start_main_alias_2"}))
+		assertAnyStackContains(t, aggregatedStacks, []string{"top2()", "c2()", "b2()", "a2()", "main"})
+		assertAnyStackContains(t, aggregatedStacks, []string{"top1()", "c1()", "b1()", "a1()", "main"})
 	}
 
 	{
@@ -353,6 +367,6 @@ func TestCPUProfilerWorks(t *testing.T) {
 		// Test symbolized stacks.
 		aggregatedStacks := symbolizeProfile(t, sample.profile, false)
 		require.True(t, len(aggregatedStacks) > 0)
-		require.True(t, anyStackEqual(aggregatedStacks, []string{"time.Now", "main.main", "runtime.main", "runtime.goexit.abi0"}))
+		assertAnyStackContains(t, aggregatedStacks, []string{"time.Now", "main.main"})
 	}
 }


### PR DESCRIPTION
@kakkoyun reported that on his box the integration tests fail because the bottom frames set up by the loader are different. This commit removes those as they are an implementation detail and might change at any time. Now we only assert the symbols we have control over.

Another nuisance was that if a test failed, the result was not very user friendly. Now the stack we are trying to find if it's contained in a slice of stacks will both be printed if the assertion fails:

Test Plan
=========

`$ make test/integration`

**happy path worked**

**bad assertion works too**
```
=== RUN   TestCPUProfilerWorks
    profiler_test.go:343: The stack [top2() c2() b2() a2() not_main] is not contained in any of [[top2() c2() b2() a2() main __libc_start_call_main __libc_start_main_alias_2] [top2() c2() b2() a2() main __libc_start_call_main __libc_start_main_alias_2] [top1() c1() b1() a1() main __libc_start_call_main __libc_start_main_alias_2] [top1() c1() b1() a1() main __libc_start_call_main __libc_start_main_alias_2] [top1() c1() b1() a1() main __libc_start_call_main __libc_start_main_alias_2] [top2() c2() b2() a2() main __libc_start_call_main __libc_start_main_alias_2]]
```