### PR TITLE
bpf: Add mixed-mode unwinding for JIT sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Flags:
                                    Disable caching of debuginfo.
       --symbolizer-jit-disable     Disable JIT symbolization.
       --dwarf-unwinding-disable    Do not unwind using .eh_frame information.
+      --dwarf-unwinding-mixed      Unwind using .eh_frame information and frame
+                                   pointers
       --otlp-address=STRING        The endpoint to send OTLP traces to.
       --otlp-exporter="grpc"       The OTLP exporter to use.
       --verbose-bpf-logging        Enable verbose BPF logging.

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -193,6 +193,7 @@ type FlagsSymbolizer struct {
 // FlagsDWARFUnwinding contains flags to configure DWARF unwinding.
 type FlagsDWARFUnwinding struct {
 	Disable bool `kong:"help='Do not unwind using .eh_frame information.'"`
+	Mixed   bool `kong:"help='Unwind using .eh_frame information and frame pointers'"`
 }
 
 // FlagsHidden contains hidden flags. Hidden debug flags (only for debugging).
@@ -671,6 +672,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			flags.MemlockRlimit,
 			flags.Hidden.DebugProcessNames,
 			flags.DWARFUnwinding.Disable,
+			flags.DWARFUnwinding.Mixed,
 			flags.VerboseBpfLogging,
 			bpfProgramLoaded,
 		),

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -66,8 +66,9 @@ const (
 )
 
 type Config struct {
-	FilterProcesses bool
-	VerboseLogging  bool
+	FilterProcesses   bool
+	VerboseLogging    bool
+	MixedStackWalking bool
 }
 
 type combinedStack [doubleStackDepth]uint64
@@ -105,6 +106,9 @@ type CPU struct {
 	memlockRlimit     uint64
 	bpfLoggingVerbose bool
 
+	mixedUnwinding    bool
+	verboseBpfLogging bool
+
 	// Notify that the BPF program was loaded.
 	bpfProgramLoaded chan bool
 }
@@ -121,6 +125,7 @@ func NewCPUProfiler(
 	memlockRlimit uint64,
 	debugProcessNames []string,
 	disableDWARFUnwinding bool,
+	mixedUnwinding bool,
 	verboseBpfLogging bool,
 	bpfProgramLoaded chan bool,
 ) *CPU {
@@ -148,6 +153,7 @@ func NewCPUProfiler(
 		debugProcessNames: debugProcessNames,
 
 		dwarfUnwindingDisable: disableDWARFUnwinding,
+		mixedUnwinding:        mixedUnwinding,
 		bpfLoggingVerbose:     verboseBpfLogging,
 
 		bpfProgramLoaded: bpfProgramLoaded,
@@ -222,7 +228,7 @@ func loadBpfProgram(logger log.Logger, reg prometheus.Registerer, debugEnabled, 
 			return nil, nil, fmt.Errorf("failed to adjust map sizes: %w", err)
 		}
 
-		if err := m.InitGlobalVariable(configKey, Config{FilterProcesses: debugEnabled, VerboseLogging: verboseBpfLogging}); err != nil {
+		if err := m.InitGlobalVariable(configKey, Config{FilterProcesses: debugEnabled, VerboseLogging: verboseBpfLogging, MixedStackWalking: mixedUnwinding}); err != nil {
 			return nil, nil, fmt.Errorf("init global variable: %w", err)
 		}
 
@@ -396,7 +402,7 @@ func (p *CPU) Run(ctx context.Context) error {
 
 	debugEnabled := len(matchers) > 0
 
-	m, bpfMaps, err := loadBpfProgram(p.logger, p.reg, debugEnabled, p.bpfLoggingVerbose, p.memlockRlimit)
+	m, bpfMaps, err := loadBpfProgram(p.logger, p.reg, p.mixedUnwinding, debugEnabled, p.bpfLoggingVerbose, p.memlockRlimit)
 	if err != nil {
 		return fmt.Errorf("load bpf program: %w", err)
 	}
@@ -636,7 +642,7 @@ func (p *CPU) watchProcesses(ctx context.Context, pfs procfs.FS, matchers []*reg
 			for _, thread := range allThreads() {
 				comm, err := thread.Comm()
 				if err != nil {
-					level.Debug(p.logger).Log("msg", "failed to read process name", "err", err)
+					level.Debug(p.logger).Log("msg", "failed to read process name", "pid", thread.PID, "err", err)
 					continue
 				}
 
@@ -874,6 +880,10 @@ func (p *CPU) obtainProfiles(ctx context.Context) ([]*profiler.Profile, error) {
 						level.Debug(p.logger).Log("msg", "failed to get process info", "pid", id.PID, "err", err)
 						continue
 					}
+					m := pi.Mappings.MappingForAddr(addr)
+
+					// TODO(kakkoyun): What should we do if the mapping is not found for this addr?
+					l := profiler.NewLocation(uint64(locationIndex+1), addr, m)
 
 					m := pi.Mappings.MappingForAddr(addr)
 					if m == nil {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -188,7 +188,7 @@ func (p *CPU) debugProcesses() bool {
 
 // loadBpfProgram loads the BPF program and maps adjusting the unwind shards to
 // the highest possible value.
-func loadBpfProgram(logger log.Logger, reg prometheus.Registerer, debugEnabled, verboseBpfLogging bool, memlockRlimit uint64) (*bpf.Module, *bpfMaps, error) {
+func loadBpfProgram(logger log.Logger, reg prometheus.Registerer, mixedUnwinding, debugEnabled, verboseBpfLogging bool, memlockRlimit uint64) (*bpf.Module, *bpfMaps, error) {
 	var lerr error
 
 	maxLoadAttempts := 10
@@ -880,10 +880,8 @@ func (p *CPU) obtainProfiles(ctx context.Context) ([]*profiler.Profile, error) {
 						level.Debug(p.logger).Log("msg", "failed to get process info", "pid", id.PID, "err", err)
 						continue
 					}
-					m := pi.Mappings.MappingForAddr(addr)
 
 					// TODO(kakkoyun): What should we do if the mapping is not found for this addr?
-					l := profiler.NewLocation(uint64(locationIndex+1), addr, m)
 
 					m := pi.Mappings.MappingForAddr(addr)
 					if m == nil {

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -33,11 +33,12 @@ import (
 // BPF program.
 func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	t.Helper()
-	logger := logger.NewLogger("error", logger.LogFormatLogfmt, "parca-cpu-test")
+	logger := logger.NewLogger("debug", logger.LogFormatLogfmt, "parca-cpu-test")
 
 	memLock := uint64(1200 * 1024 * 1024) // ~1.2GiB
 	m, _, err := loadBpfProgram(logger, prometheus.NewRegistry(), true, true, true, memLock)
 	require.NoError(t, err)
+	require.NotNil(t, m)
 
 	return m, err
 }

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -36,7 +36,7 @@ func SetUpBpfProgram(t *testing.T) (*bpf.Module, error) {
 	logger := logger.NewLogger("error", logger.LogFormatLogfmt, "parca-cpu-test")
 
 	memLock := uint64(1200 * 1024 * 1024) // ~1.2GiB
-	m, _, err := loadBpfProgram(logger, prometheus.NewRegistry(), true, true, memLock)
+	m, _, err := loadBpfProgram(logger, prometheus.NewRegistry(), true, true, true, memLock)
 	require.NoError(t, err)
 
 	return m, err

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -277,6 +277,7 @@ func prepareProfiler(t *testing.T, profileWriter profiler.ProfileWriter, logger 
 		memlockRlimit,
 		[]string{},
 		false,
+		false,
 		true,
 		bpfProgramLoaded,
 	)


### PR DESCRIPTION
This patch introduces support for mixed-mode unwinding for binaries with mixed JIT and AoT(ahead of time) compiled sections with the `dwarf-unwinding-mixed` flag.

As of now, DWARF-based stackwalking discards or skips JIT sections of binaries resulting in incomplete/incorrect stacks. Currently, we can only unwind JITed sections in binaries that retain frame pointers through FP-based stackwalking mode.

This patch adds a JIT unwinder for walking JITed sections without frame pointers. The agent bpf unwinder can now switch between JIT-unwinding and DWARF-unwinding modes while profiling stripped binaries with both JIT and Ahead-of-Time sections.

Test Plan
=========

The current integration tests `make test/profiler` pass(both with and without the flag enabled).

```
$ make test/integration GO=$(which go)
=== RUN   TestCPUProfilerWorks
--- PASS: TestCPUProfilerWorks
PASS
ok  	github.com/parca-dev/parca-agent/test/integration
```

Stacks are correctly symbolised in Parca for the `basic-cpp-jit-no-fp` toy jit binary.

![image](https://github.com/parca-dev/parca-agent/assets/35404119/f5bf2d15-15ed-4778-b068-d5862802917e)




<!--

copilot:poem

-->
