### PR TITLE
pkg/discovery: Handle multi-target discovery groups properly

### DIFF
--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -21,7 +21,7 @@ var _ burrow.Cache = &noopCache{}
 // It is useful for testing, so let's keep it around.
 type noopCache struct{}
 
-func NewNopCache() *noopCache {
+func NewNoopCache() *noopCache {
 	return &noopCache{}
 }
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -31,7 +31,7 @@ type Discoverer interface {
 	// Run hands a channel to the discovery provider (Consul, DNS, etc.) through which
 	// it can send updated target groups. It must return when the context is canceled.
 	// It should not close the update channel on returning.
-	Run(ctx context.Context, up chan<- []*Group) error
+	Run(ctx context.Context, up chan<- []Group) error
 }
 
 // DiscovererOptions provides options for a Discoverer.
@@ -53,4 +53,4 @@ type Config interface {
 // to represent itself as a mapping of the Config values grouped by their types.
 type Configs []Config
 
-type StaticConfig []*Group
+type StaticConfig []Group

--- a/pkg/discovery/systemd.go
+++ b/pkg/discovery/systemd.go
@@ -47,7 +47,7 @@ type SystemdDiscoverer struct {
 	units  map[string]systemd.Unit
 }
 
-func (d *SystemdDiscoverer) Run(ctx context.Context, up chan<- []*Group) error {
+func (d *SystemdDiscoverer) Run(ctx context.Context, up chan<- []Group) error {
 	var err error
 	d.client, err = systemd.New()
 	if err != nil {
@@ -75,10 +75,10 @@ func (d *SystemdDiscoverer) Run(ctx context.Context, up chan<- []*Group) error {
 				continue
 			}
 
-			groups := make([]*Group, 0, len(update))
+			groups := make([]Group, 0, len(update))
 			for unitName, unit := range update {
 				if unit.Name == "" || unit.SubState != "running" {
-					groups = append(groups, &Group{Source: unitName})
+					groups = append(groups, &SingleTargetGroup{source: unitName})
 					continue
 				}
 
@@ -92,13 +92,12 @@ func (d *SystemdDiscoverer) Run(ctx context.Context, up chan<- []*Group) error {
 					continue
 				}
 
-				groups = append(groups, &Group{
-					Targets: []model.LabelSet{{}},
-					Labels: model.LabelSet{
+				groups = append(groups, &SingleTargetGroup{
+					source: unitName,
+					labels: model.LabelSet{
 						model.LabelName("systemd_unit"): model.LabelValue(unitName),
 					},
-					Source:   unitName,
-					EntryPID: int(pid),
+					Target: int(pid),
 				})
 			}
 

--- a/pkg/discovery/target.go
+++ b/pkg/discovery/target.go
@@ -18,22 +18,64 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// Group is a set of targets with a common label set(production, test, staging etc.).
-type Group struct {
-	// Targets is a list of targets identified by a label set. Each target is
-	// uniquely identifiable in the group by its address label.
-	Targets []model.LabelSet
-
-	// Labels is a set of labels that is common across all targets in the group.
-	Labels model.LabelSet
-
+// Group is a set of target(s) with a common label set (production, test, staging etc.).
+type Group interface {
 	// Source is an identifier that describes a group of targets.
-	Source string
+	Source() string
+	// Labels is a set of labels that is common across all targets in the group.
+	Labels() model.LabelSet
+	// NumberOfTargets returns the number of targets in the group.
+	NumberOfTargets() int
 
-	// EntryPID entry process for this group (e.g. container or systemd unit). This is used to match processes to other metadata.
-	EntryPID int
+	String() string
 }
 
-func (tg Group) String() string {
-	return tg.Source
+type SingleTargetGroup struct {
+	labels model.LabelSet
+	source string
+
+	// Target entry process for this group (e.g. container or systemd unit).
+	// This is used to match processes to other metadata.
+	Target int
+}
+
+func (tg SingleTargetGroup) Source() string {
+	return tg.source
+}
+
+func (tg SingleTargetGroup) Labels() model.LabelSet {
+	return tg.labels
+}
+
+func (tg SingleTargetGroup) NumberOfTargets() int {
+	return 1
+}
+
+func (tg SingleTargetGroup) String() string {
+	return tg.source
+}
+
+type MultiTargetGroup struct {
+	labels model.LabelSet
+	source string
+
+	// Targets is a map of PIDs identified by a label set. Each target is
+	// uniquely identifiable in the group by its address label.
+	Targets map[int]model.LabelSet
+}
+
+func (tg MultiTargetGroup) Source() string {
+	return tg.source
+}
+
+func (tg MultiTargetGroup) Labels() model.LabelSet {
+	return tg.labels
+}
+
+func (tg MultiTargetGroup) NumberOfTargets() int {
+	return len(tg.Targets)
+}
+
+func (tg MultiTargetGroup) String() string {
+	return tg.source
 }

--- a/pkg/process/tree.go
+++ b/pkg/process/tree.go
@@ -149,15 +149,11 @@ func (t *Tree) FindAllAncestorProcessIDsInSameCgroup(pid int) ([]int, error) {
 
 		// Process could have been already terminated.
 		// And this could be a problem if we haven't updated the process tree yet.
-		proc, err := t.procfs.Proc(pid)
+		proc, err := t.readProcess(pid)
 		if err != nil {
 			return nil, err
 		}
-		stat, err := proc.Stat()
-		if err != nil {
-			return nil, err
-		}
-		if p.starttime == stat.Starttime {
+		if p.starttime == proc.starttime {
 			return findAncestorPIDsInSameCgroup(p.proc, t.ancestorsFromCache(p))
 		}
 

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -927,7 +927,7 @@ func (p *CPU) obtainProfiles(ctx context.Context) ([]*profiler.Profile, error) {
 
 		info, err := p.processInfoManager.Info(ctx, int(id.PID))
 		if err != nil {
-			level.Debug(p.logger).Log("msg", "failed to get process info", "pid", id.PID, "err", err)
+			level.Warn(p.logger).Log("msg", "failed to get process info", "pid", id.PID, "err", err)
 			continue
 		}
 


### PR DESCRIPTION
### Why?
<!-- author to complete -->
Depending on the discovery medium, a service discovery target group represents a single systemd unit or a pod. A pod can have multiple containers, containers can have numerous processes, and the systemd-units have a single running process.
The previous version of the code had wrongly assumed that a pod could have a single entry process which should be a container that can have a single entry point. This was causing mismatched or missing metadata labels for processes.

Fix https://github.com/parca-dev/parca-agent/issues/1643

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb9727e</samp>

Refactored the discovery package to use an interface for different kinds of target groups. Improved the performance and error handling of the process tree. Fixed a typo and increased the log level of a message in the CPU profiler.

### How?
<!-- Please explain us hwo should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb9727e</samp>

*  Changed the `Group` type from a struct to an interface and added two implementing structs, `SingleTargetGroup` and `MultiTargetGroup`, to handle different kinds of groups of targets for service discovery ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-575fa3989e657a52df3b74634d119e8eb8c5461b79a616466852d7e578f30155L21-R80))
*  Updated the `Discoverer` interface and the `StaticConfig` type alias to use the `Group` interface instead of the `Group` struct ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-10bda8021b225706da64124ae6d771ef8da346af6c535e8dc1a3cecfc7d5887fL34-R34), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-10bda8021b225706da64124ae6d771ef8da346af6c535e8dc1a3cecfc7d5887fL56-R56))
*  Updated the `Manager` struct and its methods to use the `Group` interface instead of the `Group` struct and to access the `Source` field of the `Group` struct as a method call of the `Group` interface ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L96-R100), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L117-R118), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L142-R142), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L157-R157), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L190-R190), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L203-R203), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L261-R279), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-13a577592bd80f3d398f9ea4848fd767e8a9677e1e64db96848d6700ac231055L286-R286))
*  Updated the `PodDiscoverer` struct and its `Run` method to use the `MultiTargetGroup` struct instead of the `Group` struct and to initialize and populate the `Targets` map field of the `MultiTargetGroup` struct with the process IDs and labels of the containers in the pod ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-3dc8abcd2944f4509ca97b93172a17d435720e4fbfcbc6c88731dc72b9d20e20L76-R76), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-3dc8abcd2944f4509ca97b93172a17d435720e4fbfcbc6c88731dc72b9d20e20L86-R86), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-3dc8abcd2944f4509ca97b93172a17d435720e4fbfcbc6c88731dc72b9d20e20L94-R94), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-3dc8abcd2944f4509ca97b93172a17d435720e4fbfcbc6c88731dc72b9d20e20L104-R108), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-3dc8abcd2944f4509ca97b93172a17d435720e4fbfcbc6c88731dc72b9d20e20L114-R127))
*  Updated the `SystemdDiscoverer` struct and its `Run` method to use the `SingleTargetGroup` struct instead of the `Group` struct and to assign the process ID of the systemd unit to the `Target` field of the `SingleTargetGroup` struct ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-88b52da5d6889758b1487f80d81625f0f315344fde19cd81d3d41e101533fbf2L50-R50), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-88b52da5d6889758b1487f80d81625f0f315344fde19cd81d3d41e101533fbf2L78-R81), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-88b52da5d6889758b1487f80d81625f0f315344fde19cd81d3d41e101533fbf2L95-R100))
*  Updated the `ServiceDiscoveryProvider` struct and its `Run` method to use the `Group` interface instead of the `Group` struct and to handle different kinds of groups of targets with a type switch and a new `updateState` function ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-68130d7471ff4ea4d32bcccb18ffa2635b8a8b490e65529422e2d7ab84352b91L38-R38), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-68130d7471ff4ea4d32bcccb18ffa2635b8a8b490e65529422e2d7ab84352b91L78-R78), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-68130d7471ff4ea4d32bcccb18ffa2635b8a8b490e65529422e2d7ab84352b91L99-R109), [link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-68130d7471ff4ea4d32bcccb18ffa2635b8a8b490e65529422e2d7ab84352b91R119-R132))
*  Changed the log level of the message "failed to get process info" from `Debug` to `Warn` in the `cpu` package to indicate a more serious problem ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-a3297cf4e3be27cabb198588463f4c04ca0f4aa5d81cbe206e467e1f1f7e772dL930-R930))
*  Changed the function name `NewNopCache` to `NewNoopCache` in the `cache` package to be consistent with the type name `noopCache` and the convention of using "noop" as an abbreviation for "no operation" ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-c9ee7661a3f8b7fd9b621d74b63680d2ef0d6cf6ba74c003e34687f87570bb3cL24-R24))
*  Used the `readProcess` method of the `Tree` struct instead of the `Proc` method of the `procfs.FS` interface to get the process information for a given PID in the `tree` package to improve performance and avoid errors ([link](https://github.com/parca-dev/parca-agent/pull/1682/files?diff=unified&w=0#diff-643496599018cefb3a5515f7bbcca83fa38ef2f91be47d423e5bb8e662406760L152-R156))

### Test Plan
Run agent in a local cluster which has a multi-container pod.

![CleanShot 2023-05-23 at 16 42 53](https://github.com/parca-dev/parca-agent/assets/536449/5bf12ef3-b60a-4877-9265-8583285e7774)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eb9727e</samp>

> _Oh, we're the coders of the sea, and we work with groups of PIDs_
> _We changed the `Group` type from a struct to an interface_
> _So we can discover different targets with labels and names_
> _And scrape them all for profiles with our `noopCache` and `Tree`_
