### PR TITLE
main: Add pprof config flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Flags:
                                    of memory that may be locked into RAM. It is
                                    used to ensure the agent can lock memory for
                                    eBPF maps. 0 means no limit.
+      --mutex-profile-fraction=0
+                                   Fraction of mutex profile samples to collect.
+      --block-profile-rate=0       Sample rate for block profile.
       --profiling-duration=10s     The agent profiling duration to use. Leave
                                    this empty to use the defaults.
       --profiling-cpu-sampling-frequency=19

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -112,6 +112,10 @@ type flags struct {
 	ConfigPath    string `default:"" help:"Path to config file."`
 	MemlockRlimit uint64 `default:"${default_memlock_rlimit}" help:"The value for the maximum number of bytes of memory that may be locked into RAM. It is used to ensure the agent can lock memory for eBPF maps. 0 means no limit."`
 
+	// pprof.
+	MutexProfileFraction int `default:"0" help:"Fraction of mutex profile samples to collect."`
+	BlockProfileRate     int `default:"0" help:"Sample rate for block profile."`
+
 	Profiling      FlagsProfiling      `embed:"" prefix:"profiling-"`
 	Metadata       FlagsMetadata       `embed:"" prefix:"metadata-"`
 	LocalStore     FlagsLocalStore     `embed:"" prefix:"local-store-"`
@@ -293,6 +297,10 @@ func main() {
 	})); err != nil {
 		level.Warn(logger).Log("msg", "failed to set GOMAXPROCS automatically", "err", err)
 	}
+
+	// Set profiling rates.
+	runtime.SetBlockProfileRate(flags.BlockProfileRate)
+	runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
 
 	if err := run(logger, reg, flags); err != nil {
 		level.Error(logger).Log("err", err)


### PR DESCRIPTION
### Why?

Add pprof configuration for scraping endpoints. They are useful for debugging and testing.

related #1674 

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd54f01</samp>

Add flags to control mutex and block profiling rates. This pull request introduces two new flags, `mutex-profile-fraction` and `block-profile-rate`, to the `parca-agent` command and the `README.md` file. These flags allow users to adjust the sampling rates of pprof profiles that measure contention and blocking in the Go runtime.

### How?
<!-- Please explain us hwo should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd54f01</samp>

* Add flags to control mutex and block profiling rates ([link](https://github.com/parca-dev/parca-agent/pull/1683/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR115-R118), [link](https://github.com/parca-dev/parca-agent/pull/1683/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R75))
* Set the profiling rates using the runtime package ([link](https://github.com/parca-dev/parca-agent/pull/1683/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR301-R304))

### Test Plan
<!-- How did you test it? How can we test it? -->

<!--

copilot:poem

-->
