### PR TITLE
Use libbpf's cpu number helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/alecthomas/kong v0.7.1
-	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690
+	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230531181948-7c15abd45366
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cilium/ebpf v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible h1:9gWa46nstkJ9miBReJcN8Gq34cBFbzSpQZVVT9N09TM=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690 h1:iDvZaf9Xcw9JfzJyqG9L9cYDwSpaFRg5pLddu4IvId0=
-github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
+github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230531181948-7c15abd45366 h1:565njMPZfgYTdNXm/qvzskocwpwUAw0KqSpMFChNeY4=
+github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230531181948-7c15abd45366/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/pkg/profiler/cpu/bpf_metrics_collector.go
+++ b/pkg/profiler/cpu/bpf_metrics_collector.go
@@ -22,9 +22,10 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"runtime"
 	"strconv"
 	"unsafe"
+
+	"github.com/aquasecurity/libbpfgo"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -86,7 +87,10 @@ func (c *bpfMetricsCollector) getBPFMetrics() []*bpfMetrics {
 
 // readPerCpuCounter reads the value of the given key from the per CPU stats map.
 func (c *bpfMetricsCollector) readCounters() (unwinderStats, error) {
-	numCpus := runtime.NumCPU()
+	numCpus, err := libbpfgo.NumPossibleCPUs()
+	if err != nil {
+		return unwinderStats{}, fmt.Errorf("NumPossibleCPUs failed: %w", err)
+	}
 	sizeOfUnwinderStats := int(unsafe.Sizeof(unwinderStats{}))
 
 	statsMap, err := c.m.GetMap(perCPUStatsMapName)


### PR DESCRIPTION
As this is causing issues in some AMD CPUs. For context: https://github.com/parca-dev/parca-agent/issues/1696#issuecomment-1568736923.

Note: This should never be used in perf_event_open(2) as it will fail in the CPUs that are overreported by some AMD systems.

Fixes https://github.com/parca-dev/parca-agent/issues/1696