### PR TITLE
*: Add native histograms

### DIFF
--- a/pkg/agent/batch_remote_write_client.go
+++ b/pkg/agent/batch_remote_write_client.go
@@ -43,9 +43,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		})
 	m.writeRawWithRetriesLatency = promauto.With(reg).NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "parca_agent_batch_writer_latency_seconds",
-			Help:    "Histogram of overall latency when sending WriteRaw gRPC request with retries",
-			Buckets: []float64{.1, .5, 1, 5, 10, 20, 30},
+			Name:                        "parca_agent_batch_writer_latency_seconds",
+			Help:                        "Histogram of overall latency when sending WriteRaw gRPC request with retries",
+			NativeHistogramBucketFactor: 1.1,
 		})
 
 	return &m

--- a/pkg/cache/stats_counter.go
+++ b/pkg/cache/stats_counter.go
@@ -68,9 +68,9 @@ func WithTrackLoadingCacheStats() Option {
 			Help: "Total number of successful cache loads.",
 		}, []string{"result"})
 		c.loadTotalTime = promauto.With(c.reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "cache_load_duration_seconds",
-			Help:    "Total time spent loading cache.",
-			Buckets: []float64{0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1},
+			Name:                        "cache_load_duration_seconds",
+			Help:                        "Total time spent loading cache.",
+			NativeHistogramBucketFactor: 1.1,
 		})
 	}
 }

--- a/pkg/debuginfo/metrics.go
+++ b/pkg/debuginfo/metrics.go
@@ -62,27 +62,27 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Total number of debug information extracted.",
 		}, []string{"result"}),
 		extractDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_debuginfo_extract_duration_seconds",
-			Help:    "Total time spent extracting debuginfo.",
-			Buckets: []float64{0.0001, 0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 60, 90, 120},
+			Name:                        "parca_agent_debuginfo_extract_duration_seconds",
+			Help:                        "Total time spent extracting debuginfo.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		found: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "parca_agent_debuginfo_found_total",
 			Help: "Total number of debug information found.",
 		}, []string{"result"}),
 		findDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_debuginfo_find_duration_seconds",
-			Help:    "Total time spent finding debuginfo.",
-			Buckets: []float64{0.0001, 0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 60, 90, 120},
+			Name:                        "parca_agent_debuginfo_find_duration_seconds",
+			Help:                        "Total time spent finding debuginfo.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		uploadRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "parca_agent_debuginfo_upload_requests_total",
 			Help: "Total number of requests to upload debuginfo.",
 		}),
 		uploadRequestWaitDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_debuginfo_upload_request_wait_duration_seconds",
-			Help:    "Total time spent waiting for upload.",
-			Buckets: []float64{0.0001, 0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 60, 90, 120},
+			Name:                        "parca_agent_debuginfo_upload_request_wait_duration_seconds",
+			Help:                        "Total time spent waiting for upload.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		uploadInflight: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "parca_agent_debuginfo_upload_inflight_requests",
@@ -101,9 +101,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Number of debuginfo successfully uploaded",
 		}, []string{"result"}),
 		uploadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_debuginfo_upload_duration_seconds",
-			Help:    "Total time spent loading cache.",
-			Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+			Name:                        "parca_agent_debuginfo_upload_duration_seconds",
+			Help:                        "Total time spent loading cache.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 	}
 	m.ensureUploadedRequests.WithLabelValues(lvSuccess)

--- a/pkg/grpc/conn.go
+++ b/pkg/grpc/conn.go
@@ -64,7 +64,10 @@ func Conn(logger log.Logger, reg prometheus.Registerer, tp trace.TracerProvider,
 	// metrics
 	metrics := grpc_prometheus.NewClientMetrics(
 		grpc_prometheus.WithClientHandlingTimeHistogram(
-			grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+			grpc_prometheus.WithHistogramOpts(&prometheus.HistogramOpts{
+				NativeHistogramBucketFactor: 1.1,
+				Buckets:                     nil,
+			}),
 		),
 	)
 	reg.MustRegister(metrics)

--- a/pkg/http/instrumented_client.go
+++ b/pkg/http/instrumented_client.go
@@ -1,0 +1,115 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package http
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type metrics struct {
+	inFlightGauge            prometheus.Gauge
+	requestTotalCount        *prometheus.CounterVec
+	dnsLatencyHistogram      *prometheus.HistogramVec
+	tlsLatencyHistogram      *prometheus.HistogramVec
+	requestDurationHistogram *prometheus.HistogramVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		inFlightGauge: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "http_client_in_flight_requests",
+			Help: "A gauge of in-flight requests.",
+		}),
+		requestTotalCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "http_client_request_total",
+			Help: "Total http client request by code and method.",
+		}, []string{"code", "method"}),
+		dnsLatencyHistogram: promauto.With(reg).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:                        "http_client_dns_duration_seconds",
+				Help:                        "Track dns latency histogram.",
+				NativeHistogramBucketFactor: 1.1,
+			},
+			[]string{"event"},
+		),
+		tlsLatencyHistogram: promauto.With(reg).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:                        "http_client_tls_duration_seconds",
+				Help:                        "Track TLS latency histogram.",
+				NativeHistogramBucketFactor: 1.1,
+			},
+			[]string{"event"},
+		),
+		requestDurationHistogram: promauto.With(reg).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:                        "http_client_request_duration_seconds",
+				Help:                        "A histogram of request latencies.",
+				NativeHistogramBucketFactor: 1.1,
+			},
+			[]string{"code", "method"},
+		),
+	}
+	return m
+}
+
+func instrumentedRoundTripper(tripper http.RoundTripper, m *metrics) http.RoundTripper {
+	if m == nil {
+		return tripper
+	}
+
+	trace := &promhttp.InstrumentTrace{
+		DNSStart: func(t float64) {
+			m.dnsLatencyHistogram.WithLabelValues("dns_start").Observe(t)
+		},
+		DNSDone: func(t float64) {
+			m.dnsLatencyHistogram.WithLabelValues("dns_done").Observe(t)
+		},
+		TLSHandshakeStart: func(t float64) {
+			m.tlsLatencyHistogram.WithLabelValues("tls_handshake_start").Observe(t)
+		},
+		TLSHandshakeDone: func(t float64) {
+			m.tlsLatencyHistogram.WithLabelValues("tls_handshake_done").Observe(t)
+		},
+	}
+
+	return promhttp.InstrumentRoundTripperInFlight(
+		m.inFlightGauge,
+		promhttp.InstrumentRoundTripperCounter(
+			m.requestTotalCount,
+			promhttp.InstrumentRoundTripperTrace(
+				trace,
+				promhttp.InstrumentRoundTripperDuration(
+					m.requestDurationHistogram,
+					tripper,
+				),
+			),
+		),
+	)
+}
+
+func NewClient(reg prometheus.Registerer, tripper ...http.RoundTripper) *http.Client {
+	if tripper != nil {
+		return &http.Client{
+			Transport: instrumentedRoundTripper(tripper[0], newMetrics(reg)),
+		}
+	}
+	return &http.Client{
+		Transport: instrumentedRoundTripper(http.DefaultTransport, newMetrics(reg)),
+	}
+}

--- a/pkg/objectfile/pool.go
+++ b/pkg/objectfile/pool.go
@@ -79,9 +79,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Total number of object file close operations.",
 		}, []string{"result"}),
 		keptOpenDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_objectfile_kept_open_duration_seconds",
-			Help:    "Duration of object files kept open.",
-			Buckets: []float64{0.01, 0.1, 0.3, 1, 3, 6, 9, 20, 60, 90, 120, 360, 720},
+			Name:                        "parca_agent_objectfile_kept_open_duration_seconds",
+			Help:                        "Duration of object files kept open.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		openReaders: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "parca_agent_objectfile_open_readers",

--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -77,9 +77,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Total number of debug information loads.",
 		}, []string{"result"}),
 		fetchDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_process_info_fetch_duration_seconds",
-			Help:    "Duration of debug information loads.",
-			Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 360},
+			Name:                        "parca_agent_process_info_fetch_duration_seconds",
+			Help:                        "Duration of debug information loads.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		get: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "parca_agent_process_info_get_total",
@@ -90,9 +90,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help: "Total number of debug information upload errors.",
 		}, []string{"type"}),
 		metadataDuration: promauto.NewHistogram(prometheus.HistogramOpts{
-			Name:    "parca_agent_process_info_metadata_fetch_duration_seconds",
-			Help:    "Duration of metadata fetches.",
-			Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 360},
+			Name:                        "parca_agent_process_info_metadata_fetch_duration_seconds",
+			Help:                        "Duration of metadata fetches.",
+			NativeHistogramBucketFactor: 1.1,
 		}),
 	}
 	m.fetched.WithLabelValues(lvSuccess)


### PR DESCRIPTION
### Why?

1. Convert existing histograms.
2. Add gRPC instrumentation with native histograms.
3. Add HTTP tracing/instrumentations with native histograms.

Fixes #1572 

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7a3719</samp>

This pull request updates various histogram metrics in the agent to use the native Prometheus histogram buckets, which are more suitable for measuring latency and duration. It also adds a new feature to create an instrumented HTTP client with metrics and tracing, and uses it in the `debuginfo` package for uploading debug information. The affected files are `pkg/debuginfo/manager.go`, `pkg/debuginfo/metrics.go`, `pkg/process/info.go`, `pkg/agent/batch_remote_write_client.go`, `pkg/cache/stats_counter.go`, `pkg/grpc/conn.go`, `pkg/http/instrumented_client.go`, and `pkg/objectfile/pool.go`.

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7a3719</samp>

*  Use the `NativeHistogramBucketFactor` option for histogram metrics to use the native Prometheus histogram buckets ([link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-7276397f96515c11ca49f4f72de2237d63936ab985888a5a4fe07ccf8c371d42L46-R48), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-c8d0aae578156ffbbb5a31a8da425b46236228f362f55b8c118d742e2adc2432L71-R73), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-4938d357026bd7ab52d9b4b374899dd4eced576aed8c33f9f871f6537bc03328L65-R67), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-4938d357026bd7ab52d9b4b374899dd4eced576aed8c33f9f871f6537bc03328L74-R76), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-4938d357026bd7ab52d9b4b374899dd4eced576aed8c33f9f871f6537bc03328L83-R85), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-4938d357026bd7ab52d9b4b374899dd4eced576aed8c33f9f871f6537bc03328L104-R106), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L82-R84), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L80-R82), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L93-R95))
* Create an instrumented HTTP client with metrics and tracing in the `NewClient` function in the `parcahttp` package ([link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-f8432d5865d149467e2af9c455cf2c5732b63ff260b10364b4de5b88c77a2dd9R1-R115))
* Use the instrumented HTTP client in the `debuginfo` package to perform the upload request in the `uploadViaSignedURL` function ([link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R46), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R77-R78), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L119-R124), [link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L554-R558))
* Use the `WithHistogramOpts` option instead of the `WithHistogramBuckets` option to create the client metrics in the `grpc` package ([link](https://github.com/parca-dev/parca-agent/pull/1717/files?diff=unified&w=0#diff-9da81253369258488eba5d4542b624d7a307f23184ee5205fd37f4cd8ced68a1L67-R70))

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e7a3719</samp>

> _Oh we are the agents of Parca, and we measure all the things_
> _We use the native buckets for our histograms, and we make them sing_
> _So heave away, me hearties, heave away with glee_
> _We'll instrument our clients with `parcahttp`, and we'll trace them on the sea_