### PR TITLE
Disable RPC logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ Flags:
                                    TLS.
       --remote-store-insecure-skip-verify
                                    Skip TLS certificate verification.
-      --remote-store-debuginfo-upload-disable
-                                   Disable debuginfo collection and upload.
       --remote-store-batch-write-interval=10s
                                    Interval between batch remote client writes.
                                    Leave this empty to use the default value of
                                    10s.
+      --remote-store-enable-rpc-logging
+                                   Enable gRPC logging.
       --debuginfo-directories=/usr/lib/debug,...
                                    Ordered list of local directories to search
                                    for debuginfo files.
@@ -114,6 +114,8 @@ Flags:
       --debuginfo-strip            Only upload information needed for
                                    symbolization. If false the exact binary the
                                    agent sees will be uploaded unmodified.
+      --debuginfo-upload-disable
+                                   Disable debuginfo collection and upload.
       --debuginfo-upload-max-parallel=25
                                    The maximum number of debuginfo upload
                                    requests to make in parallel.

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -164,13 +164,13 @@ type FlagsLocalStore struct {
 
 // FlagsRemoteStore provides remote store configuration flags.
 type FlagsRemoteStore struct {
-	Address                string        `kong:"help='gRPC address to send profiles and symbols to.'"`
-	BearerToken            string        `kong:"help='Bearer token to authenticate with store.'"`
-	BearerTokenFile        string        `kong:"help='File to read bearer token from to authenticate with store.'"`
-	Insecure               bool          `kong:"help='Send gRPC requests via plaintext instead of TLS.'"`
-	InsecureSkipVerify     bool          `kong:"help='Skip TLS certificate verification.'"`
-	DebuginfoUploadDisable bool          `kong:"help='Disable debuginfo collection and upload.',default='false'"`
-	BatchWriteInterval     time.Duration `kong:"help='Interval between batch remote client writes. Leave this empty to use the default value of 10s.',default='10s'"`
+	Address            string        `kong:"help='gRPC address to send profiles and symbols to.'"`
+	BearerToken        string        `kong:"help='Bearer token to authenticate with store.'"`
+	BearerTokenFile    string        `kong:"help='File to read bearer token from to authenticate with store.'"`
+	Insecure           bool          `kong:"help='Send gRPC requests via plaintext instead of TLS.'"`
+	InsecureSkipVerify bool          `kong:"help='Skip TLS certificate verification.'"`
+	BatchWriteInterval time.Duration `kong:"help='Interval between batch remote client writes. Leave this empty to use the default value of 10s.',default='10s'"`
+	EnableRPCLogging   bool          `kong:"help='Enable gRPC logging.',default='false'"`
 }
 
 // FlagsDebuginfo contains flags to configure debuginfo.
@@ -178,6 +178,7 @@ type FlagsDebuginfo struct {
 	Directories           []string      `kong:"help='Ordered list of local directories to search for debuginfo files.',default='/usr/lib/debug'"`
 	TempDir               string        `kong:"help='The local directory path to store the interim debuginfo files.',default='/tmp'"`
 	Strip                 bool          `kong:"help='Only upload information needed for symbolization. If false the exact binary the agent sees will be uploaded unmodified.',default='true'"`
+	UploadDisable         bool          `kong:"help='Disable debuginfo collection and upload.',default='false'"`
 	UploadMaxParallel     int           `kong:"help='The maximum number of debuginfo upload requests to make in parallel.',default='25'"`
 	UploadTimeoutDuration time.Duration `kong:"help='The timeout duration to cancel upload requests.',default='2m'"`
 	UploadCacheDuration   time.Duration `kong:"help='The duration to cache debuginfo upload responses for.',default='5m'"`
@@ -407,6 +408,9 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			)
 		}
 
+		if flags.Debuginfo.UploadDisable {
+			logger = log.NewNopLogger()
+		}
 		conn, err := parcagrpc.Conn(logger, reg, tp, flags.RemoteStore.Address, opts...)
 		if err != nil {
 			return err
@@ -414,7 +418,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		defer conn.Close()
 
 		profileStoreClient = profilestorepb.NewProfileStoreServiceClient(conn)
-		if !flags.RemoteStore.DebuginfoUploadDisable {
+		if !flags.Debuginfo.UploadDisable {
 			debuginfoClient = debuginfopb.NewDebuginfoServiceClient(conn)
 		} else {
 			level.Info(logger).Log("msg", "debug information collection is disabled")
@@ -617,7 +621,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 	}
 
 	var dbginfo process.DebuginfoManager
-	if !flags.RemoteStore.DebuginfoUploadDisable {
+	if !flags.Debuginfo.UploadDisable {
 		dbginfo = debuginfo.New(
 			log.With(logger, "component", "debuginfo"),
 			tp.Tracer("debuginfo"),


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Why?
RPC logs are too noisy even though they come handy some times. So let's disable them by default and making configurable to enable them.

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74b372b</samp>

Added and updated flags for debuginfo and gRPC logging features. Updated `README.md` to reflect the changes.

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74b372b</samp>

*  Removed the `DebuginfoUploadDisable` field from the `FlagsRemoteStore` struct and added the `EnableRPCLogging` field to enable gRPC logging ([link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL167-R173))
* Added the `UploadDisable` field to the `FlagsDebuginfo` struct to allow disabling the debuginfo collection and upload feature ([link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR181), [link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117-R118))
* Replaced the `flags.RemoteStore.DebuginfoUploadDisable` expression with the `flags.Debuginfo.UploadDisable` expression in the `run` function to use the new flag ([link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL417-R421), [link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL620-R624))
* Removed the `--remote-store-debuginfo-upload-disable` flag from the README.md file and added the `--debuginfo-upload-disable` flag to document the new feature ([link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R107), [link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117-R118))
* Added an `if` statement to the `run` function to disable the logger for the debuginfo feature if the `UploadDisable` flag is set ([link](https://github.com/parca-dev/parca-agent/pull/1725/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR411-R413))


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 74b372b</samp>

> _Oh we're the parca-agent crew and we've got some work to do_
> _We've got to update our flags and our README too_
> _We'll use `--debuginfo-upload-disable` to control our feature_
> _And we'll heave away on the count of three, heave ho, heave ho, heave ho_

