### PR TITLE
grpc: Fix codec issue causes kubernetes metadata problems

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -408,10 +408,13 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			)
 		}
 
+		var grpcLogger log.Logger
 		if !flags.RemoteStore.RPCLoggingEnable {
-			logger = log.NewNopLogger()
+			grpcLogger = log.NewNopLogger()
+		} else {
+			grpcLogger = log.With(logger, "service", "gRPC/client")
 		}
-		conn, err := parcagrpc.Conn(logger, reg, tp, flags.RemoteStore.Address, opts...)
+		conn, err := parcagrpc.Conn(grpcLogger, reg, tp, flags.RemoteStore.Address, opts...)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-kit/log v0.2.1
 	github.com/goburrow/cache v0.1.4
+	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0-rc.0.0.20230515140958-a18e1e2bacb2
@@ -102,7 +103,6 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -54,7 +54,7 @@ func (c *PodConfig) NewDiscoverer(d DiscovererOptions) (Discoverer, error) {
 	createdChan := make(chan *v1.Pod)
 	deletedChan := make(chan string)
 
-	k8sClient, err := kubernetes.NewKubernetesClient(d.Logger, c.nodeName, c.socketPath)
+	k8sClient, err := kubernetes.NewKubernetesClient(log.With(d.Logger, "component", "kubernetes_client"), c.nodeName, c.socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("create kubernetes client: %w", err)
 	}

--- a/pkg/grpc/codec.go
+++ b/pkg/grpc/codec.go
@@ -20,10 +20,7 @@ package grpc
 import (
 	"fmt"
 
-	// use the original golang/protobuf package we can continue serializing
-	// messages from our dependencies, particularly for:
-	//   - grpc.health.v1.Health
-	//   - otel.v1.ExportTraceServiceRequest
+	gogoproto "github.com/gogo/protobuf/proto"
 	"google.golang.org/protobuf/proto"
 
 	_ "google.golang.org/grpc/encoding/proto"
@@ -45,8 +42,10 @@ func (vtprotoCodec) Marshal(v any) ([]byte, error) {
 		return v.MarshalVT()
 	case proto.Message:
 		return proto.Marshal(v)
+	case gogoproto.Message:
+		return gogoproto.Marshal(v)
 	default:
-		return nil, fmt.Errorf("failed to marshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message", v)
+		return nil, fmt.Errorf("failed to marshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message, gogoproto.Message", v)
 	}
 }
 
@@ -56,8 +55,10 @@ func (vtprotoCodec) Unmarshal(data []byte, v any) error {
 		return v.UnmarshalVT(data)
 	case proto.Message:
 		return proto.Unmarshal(data, v)
+	case gogoproto.Message:
+		return gogoproto.Unmarshal(data, v)
 	default:
-		return fmt.Errorf("failed to unmarshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message", v)
+		return fmt.Errorf("failed to unmarshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message, gogoproto.Message", v)
 	}
 }
 

--- a/pkg/grpc/conn.go
+++ b/pkg/grpc/conn.go
@@ -23,14 +23,14 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
-
-	parcadebuginfo "github.com/parca-dev/parca/pkg/debuginfo"
 	"github.com/prometheus/client_golang/prometheus"
 	tracing "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
+
+	parcadebuginfo "github.com/parca-dev/parca/pkg/debuginfo"
 )
 
 type perRequestBearerToken struct {
@@ -56,10 +56,7 @@ func (t *perRequestBearerToken) RequireTransportSecurity() bool {
 }
 
 func Conn(logger log.Logger, reg prometheus.Registerer, tp trace.TracerProvider, address string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	// Register the vtproto codec.
 	encoding.RegisterCodec(vtprotoCodec{})
-
-	logger = log.With(logger, "service", "gRPC/client", "component", "parca-agent")
 
 	// metrics
 	metrics := grpc_prometheus.NewClientMetrics(

--- a/scripts/local-dev-cluster.sh
+++ b/scripts/local-dev-cluster.sh
@@ -23,6 +23,7 @@
 set -euo pipefail
 
 NODE_COUNT=${NODE_COUNT:-1}
+RUNTIME=${RUNTIME:-"containerd"} # docker, containerd, cri-o (containerd what we use in prod)
 
 MINIKUBE_PROFILE_NAME="${MINIKUBE_PROFILE_NAME:-parca-agent}"
 function mk() {
@@ -64,11 +65,13 @@ function up() {
         echo "Starting minikube cluster with driver: $DRIVER"
         mk start \
             --driver="${DRIVER}" \
+            --container-runtime="${RUNTIME}" \
             --nodes="${NODE_COUNT}" \
             --kubernetes-version=stable \
             --cpus=2 \
             --memory=8gb \
             --disk-size=40gb \
+            --delete-on-failure \
             --docker-opt dns=8.8.8.8 \
             --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
     fi

--- a/scripts/local-dev-observable-cluster.sh
+++ b/scripts/local-dev-observable-cluster.sh
@@ -23,6 +23,7 @@
 set -euo pipefail
 
 NODE_COUNT=${NODE_COUNT:-1}
+RUNTIME=${RUNTIME:-"containerd"} # docker, containerd, cri-o (containerd what we use in prod)
 
 MINIKUBE_PROFILE_NAME="${MINIKUBE_PROFILE_NAME:-parca-agent}"
 function mk() {
@@ -64,11 +65,12 @@ function up() {
         echo "Starting minikube cluster with driver: $DRIVER"
         mk start \
             --driver="${DRIVER}" \
-            --nodes="${NODE_COUNT}" \
+            --container-runtime="${RUNTIME}" \
             --kubernetes-version=stable \
             --cpus=4 \
             --memory=16gb \
             --disk-size=80gb \
+            --delete-on-failure \
             --docker-opt dns=8.8.8.8 \
             --docker-opt default-ulimit=memlock=9223372036854775807:9223372036854775807
     fi


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Why?
Even though, we have a codec to encode/decode different type of messages, we have missed a base message type for Kubernetes container runtime messages.

This has bitten us second time. A similar error occurred when we tried to integrate tracing to the agent. I hope this time we have covered all possible bases.

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ecb1c3</samp>

This pull request adds support for `gogo/protobuf` messages in the gRPC codec, improves the logging and error handling of the gRPC and kubernetes clients, and adds container runtime flexibility to the local development scripts.

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ecb1c3</samp>

*  Add support for `gogo/protobuf` messages in the gRPC codec ([link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-24bcaf3a3e7d96a745c36501ca4430ecd26cd32c02f1a14679aa2a77b4b528bfL23-R23),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-24bcaf3a3e7d96a745c36501ca4430ecd26cd32c02f1a14679aa2a77b4b528bfL48-R48),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-24bcaf3a3e7d96a745c36501ca4430ecd26cd32c02f1a14679aa2a77b4b528bfL59-R61),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-9da81253369258488eba5d4542b624d7a307f23184ee5205fd37f4cd8ced68a1R32-R33))
*  Pass logger as an argument to the `Conn` function and add `service` and `component` labels to the gRPC and kubernetes clients ([link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL411-R417),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-3dc8abcd2944f4509ca97b93172a17d435720e4fbfcbc6c88731dc72b9d20e20L57-R57),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-9da81253369258488eba5d4542b624d7a307f23184ee5205fd37f4cd8ced68a1L59-R60))
*  Add `--container-runtime` and `--delete-on-failure` flags to the minikube start commands in the local dev scripts ([link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-31dae5128ee5b87ae736f05e9b1ac273122c986ede476d0161163eda7969df63R26),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-31dae5128ee5b87ae736f05e9b1ac273122c986ede476d0161163eda7969df63R68),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-31dae5128ee5b87ae736f05e9b1ac273122c986ede476d0161163eda7969df63R74),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-b0dc2d579630e47a6ff4a052fdcf8a04b9059f1b1f0c7a3dd765b0ae3c4dd804R26),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-b0dc2d579630e47a6ff4a052fdcf8a04b9059f1b1f0c7a3dd765b0ae3c4dd804L67-R73))
*  Add `github.com/gogo/protobuf` as a direct dependency and remove it as an indirect dependency ([link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R17),[link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L105))
*  Remove unused import of `parcadebuginfo` package ([link](https://github.com/parca-dev/parca-agent/pull/1729/files?diff=unified&w=0#diff-9da81253369258488eba5d4542b624d7a307f23184ee5205fd37f4cd8ced68a1L26-L27))

### Test Plan
1. Test on local minikube cluster using `containerd` and `cri-o` runtimes.

![CleanShot 2023-06-05 at 18 54 52](https://github.com/parca-dev/parca-agent/assets/536449/bd7a1991-eba9-4e02-bea4-30e5bc2ce6bc)

![CleanShot 2023-06-05 at 18 54 35](https://github.com/parca-dev/parca-agent/assets/536449/4d04eabe-0abf-4a1a-8a12-f348c560288b)

![CleanShot 2023-06-05 at 18 54 24](https://github.com/parca-dev/parca-agent/assets/536449/62b5ae9b-bb5c-46d2-8c5e-3f916fdc0748)

![CleanShot 2023-06-05 at 18 54 04](https://github.com/parca-dev/parca-agent/assets/536449/19531ac3-9c8e-4c79-97f5-96833166b71d)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3ecb1c3</samp>

> _`gRPC` and `k8s`_
> _Logging and encoding change_
> _Winter of debugging_

