### PR TITLE
pkg/process: Save whether mapping contains debuginfo to upload

### DIFF
--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -274,8 +274,8 @@ func (im *InfoManager) ensureDebuginfoUploaded(ctx context.Context, pid int, map
 		wg = &sync.WaitGroup{}
 	)
 	for _, m := range mappings {
-		// There is no need to extract and upload debug information of non-symbolizable mappings.
-		if !m.isSymbolizable() {
+		if !m.containsDebuginfoToUpload {
+			// Nothing to do for mappings without debuginfo.
 			continue
 		}
 


### PR DESCRIPTION
### Why?
`isSymbolizable` alone is taking ~5% of parca agent's CPU time. I suspect this patch might even remove the whole `ensureDebuginfoUploaded` path (~13-14%): https://pprof.me/fc33516/?filter_by_function=isSymbolizable&search_string=isSymbolizable

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aac915d</samp>

This pull request optimizes the debug information upload process for the parca-agent by adding a new field `containsDebuginfoToUpload` to the `Mapping` struct. This field indicates whether a mapping has any debug information that needs to be uploaded and avoids unnecessary file operations and uploads for non-symbolizable or unsupported mappings.

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aac915d</samp>

* Optimize debug information uploading by avoiding repeated object file parsing ([link](https://github.com/parca-dev/parca-agent/pull/1730/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L277-R278), [link](https://github.com/parca-dev/parca-agent/pull/1730/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL196-R218))
* Exclude JIT-compiled code from debug information uploading ([link](https://github.com/parca-dev/parca-agent/pull/1730/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dR250))

### Test Plan
CI
