### PR TITLE
*: Introduce lightweight LRU cache and use in hotpaths

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -633,8 +633,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			debuginfoClient,
 			flags.Debuginfo.UploadMaxParallel,
 			flags.Debuginfo.UploadTimeoutDuration,
-			flags.Debuginfo.DisableCaching,
-			flags.Debuginfo.UploadCacheDuration,
 			flags.Debuginfo.Directories,
 			flags.Debuginfo.Strip,
 			flags.Debuginfo.TempDir,
@@ -656,6 +654,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				dbginfo,
 				labelsManager,
 				flags.Profiling.Duration,
+				flags.Debuginfo.UploadCacheDuration,
 			),
 			address.NewNormalizer(logger, reg, flags.Hidden.DebugNormalizeAddresses),
 			vdsoResolver,
@@ -850,7 +849,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				return err
 			}, func(error) {
 				level.Debug(logger).Log("msg", "cleaning up")
-				defer level.Debug(logger).Log("msg", "cleanup finished")
 
 				cancel()
 			})

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -633,6 +633,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			debuginfoClient,
 			flags.Debuginfo.UploadMaxParallel,
 			flags.Debuginfo.UploadTimeoutDuration,
+			flags.Debuginfo.DisableCaching,
 			flags.Debuginfo.Directories,
 			flags.Debuginfo.Strip,
 			flags.Debuginfo.TempDir,
@@ -849,6 +850,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 				return err
 			}, func(error) {
 				level.Debug(logger).Log("msg", "cleaning up")
+				defer level.Debug(logger).Log("msg", "cleanup finished")
 
 				cancel()
 			})

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -15,6 +15,7 @@ package cache
 
 import (
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -54,6 +55,62 @@ func (c *LRUCache[K, V]) Peek(key K) (V, bool) {
 }
 
 func (c *LRUCache[K, V]) Remove(key K) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.lru.Remove(key)
+}
+
+type LRUCacheWithTTL[K comparable, V any] struct {
+	lru *lru.LRU[K, valueWithDeadline[V]]
+	mtx *sync.RWMutex
+
+	ttl time.Duration
+}
+
+type valueWithDeadline[V any] struct {
+	value    V
+	deadline time.Time
+}
+
+func NewLRUCacheWithTTL[K comparable, V any](reg prometheus.Registerer, maxEntries int, ttl time.Duration) *LRUCacheWithTTL[K, V] {
+	return &LRUCacheWithTTL[K, V]{
+		lru: lru.New[K, valueWithDeadline[V]](reg, maxEntries),
+		mtx: &sync.RWMutex{},
+		ttl: ttl,
+	}
+}
+
+func (c *LRUCacheWithTTL[K, V]) Add(key K, value V) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.lru.Add(key, valueWithDeadline[V]{
+		value:    value,
+		deadline: time.Now().Add(c.ttl),
+	})
+}
+
+func (c *LRUCacheWithTTL[K, V]) Get(key K) (V, bool) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	v, ok := c.lru.Get(key)
+	if !ok {
+		return v.value, false
+	}
+	if v.deadline.Before(time.Now()) {
+		c.lru.Remove(key)
+		return v.value, false
+	}
+	return v.value, true
+}
+
+func (c *LRUCacheWithTTL[K, V]) Peek(key K) (V, bool) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	v, ok := c.lru.Peek(key)
+	return v.value, ok
+}
+
+func (c *LRUCacheWithTTL[K, V]) Remove(key K) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	c.lru.Remove(key)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,10 +1,24 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cache
 
 import (
 	"sync"
 
-	"github.com/parca-dev/parca-agent/pkg/cache/lru"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/parca-dev/parca-agent/pkg/cache/lru"
 )
 
 type LRUCache[K comparable, V any] struct {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/parca-dev/parca-agent/pkg/cache/lru"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type LRUCache[K comparable, V any] struct {
+	lru *lru.LRU[K, V]
+	mtx *sync.RWMutex
+}
+
+func NewLRUCache[K comparable, V any](reg prometheus.Registerer, maxEntries int) *LRUCache[K, V] {
+	return &LRUCache[K, V]{
+		lru: lru.New[K, V](reg, maxEntries),
+		mtx: &sync.RWMutex{},
+	}
+}
+
+func (c *LRUCache[K, V]) Add(key K, value V) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.lru.Add(key, value)
+}
+
+func (c *LRUCache[K, V]) Get(key K) (V, bool) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.lru.Get(key)
+}
+
+// Peek returns the value associated with key without updating the "recently
+// used"-ness of that key.
+func (c *LRUCache[K, V]) Peek(key K) (V, bool) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return c.lru.Peek(key)
+}
+
+func (c *LRUCache[K, V]) Remove(key K) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.lru.Remove(key)
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,86 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestLRUCache(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := NewLRUCache[string, int](reg, 2)
+
+	c.Add("key1", 1)
+	c.Add("key2", 2)
+
+	v, ok := c.Get("key1")
+	if !ok || v != 1 {
+		t.Errorf("expected to get key1 = 1, got %v, %v", v, ok)
+	}
+
+	v, ok = c.Peek("key2")
+	if !ok || v != 2 {
+		t.Errorf("expected to peek key2 = 2, got %v, %v", v, ok)
+	}
+
+	c.Add("key3", 3)
+
+	_, ok = c.Get("key2")
+	if ok {
+		t.Errorf("expected key1 to be evicted, but was still present")
+	}
+
+	c.Remove("key1")
+	_, ok = c.Peek("key2")
+	if ok {
+		t.Errorf("expected key2 to be removed, but was still present")
+	}
+}
+
+func TestLRUCacheWithTTL(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := NewLRUCacheWithTTL[string, int](reg, 2, 1*time.Millisecond)
+
+	c.Add("key1", 1)
+	v, ok := c.Get("key1")
+	if !ok || v != 1 {
+		t.Errorf("expected value 1 for key1, got %v", v)
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	_, ok = c.Get("key1")
+	if ok {
+		t.Errorf("expected key1 to expire")
+	}
+
+	c.Add("key2", 2)
+	v, ok = c.Peek("key2")
+	if !ok || v != 2 {
+		t.Errorf("expected value 2 for key2, got %v", v)
+	}
+	v, ok = c.Get("key2")
+	if !ok || v != 2 {
+		t.Errorf("expected value 2 for key2, got %v", v)
+	}
+	c.Add("key3", 3)
+
+	v, ok = c.Peek("key2")
+	if !ok || v != 2 {
+		t.Errorf("expected value 2 for key2, got %v", v)
+	}
+
+	c.Remove("key2")
+	_, ok = c.Get("key2")
+	if ok {
+		t.Errorf("expected key2 to be removed")
+	}
+
+	c.Add("key4", 4)
+	c.Add("key5", 5)
+
+	_, ok = c.Get("key3")
+	if ok {
+		t.Errorf("expected key3 to be evicted, but was still present")
+	}
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cache
 
 import (

--- a/pkg/cache/lru/list.go
+++ b/pkg/cache/lru/list.go
@@ -1,0 +1,128 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_list file.
+
+package lru
+
+// entry is an LRU entry
+type entry[K comparable, V any] struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *entry[K, V]
+
+	// The list to which this element belongs.
+	list *lruList[K, V]
+
+	// The LRU key of this element.
+	key K
+
+	// The value stored with this element.
+	value V
+}
+
+// prevEntry returns the previous list element or nil.
+func (e *entry[K, V]) prevEntry() *entry[K, V] {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// lruList represents a doubly linked list.
+// The zero value for lruList is an empty list ready to use.
+type lruList[K comparable, V any] struct {
+	root entry[K, V] // sentinel list element, only &root, root.prev, and root.next are used
+	len  int         // current list length excluding (this) sentinel element
+}
+
+// init initializes or clears list l.
+func (l *lruList[K, V]) init() *lruList[K, V] {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// newList returns an initialized list.
+func newList[K comparable, V any]() *lruList[K, V] { return new(lruList[K, V]).init() }
+
+// length returns the number of elements of list l.
+// The complexity is O(1).
+func (l *lruList[K, V]) length() int { return l.len }
+
+// back returns the last element of list l or nil if the list is empty.
+func (l *lruList[K, V]) back() *entry[K, V] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *lruList[K, V]) lazyInit() {
+	if l.root.next == nil {
+		l.init()
+	}
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *lruList[K, V]) insert(e, at *entry[K, V]) *entry[K, V] {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	e.list = l
+	l.len++
+	return e
+}
+
+// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
+func (l *lruList[K, V]) insertValue(k K, v V, at *entry[K, V]) *entry[K, V] {
+	return l.insert(&entry[K, V]{value: v}, at)
+}
+
+// remove removes e from its list, decrements l.len
+func (l *lruList[K, V]) remove(e *entry[K, V]) V {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	e.list = nil
+	l.len--
+
+	return e.value
+}
+
+// move moves e to next to at.
+func (l *lruList[K, V]) move(e, at *entry[K, V]) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}
+
+// pushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *lruList[K, V]) pushFront(k K, v V) *entry[K, V] {
+	l.lazyInit()
+	return l.insertValue(k, v, &l.root)
+}
+
+// moveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *lruList[K, V]) moveToFront(e *entry[K, V]) {
+	if e.list != l || l.root.next == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, &l.root)
+}

--- a/pkg/cache/lru/list.go
+++ b/pkg/cache/lru/list.go
@@ -1,10 +1,23 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE_list file.
 
 package lru
 
-// entry is an LRU entry
+// entry is an LRU entry.
 type entry[K comparable, V any] struct {
 	// Next and previous pointers in the doubly-linked list of elements.
 	// To simplify the implementation, internally a list l is implemented
@@ -84,7 +97,7 @@ func (l *lruList[K, V]) insertValue(k K, v V, at *entry[K, V]) *entry[K, V] {
 	return l.insert(&entry[K, V]{value: v}, at)
 }
 
-// remove removes e from its list, decrements l.len
+// remove removes e from its list, decrements l.len.
 func (l *lruList[K, V]) remove(e *entry[K, V]) V {
 	e.prev.next = e.next
 	e.next.prev = e.prev

--- a/pkg/cache/lru/list.go
+++ b/pkg/cache/lru/list.go
@@ -36,14 +36,6 @@ type entry[K comparable, V any] struct {
 	value V
 }
 
-// prevEntry returns the previous list element or nil.
-func (e *entry[K, V]) prevEntry() *entry[K, V] {
-	if p := e.prev; e.list != nil && p != &e.list.root {
-		return p
-	}
-	return nil
-}
-
 // lruList represents a doubly linked list.
 // The zero value for lruList is an empty list ready to use.
 type lruList[K comparable, V any] struct {
@@ -94,7 +86,7 @@ func (l *lruList[K, V]) insert(e, at *entry[K, V]) *entry[K, V] {
 
 // insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
 func (l *lruList[K, V]) insertValue(k K, v V, at *entry[K, V]) *entry[K, V] {
-	return l.insert(&entry[K, V]{value: v}, at)
+	return l.insert(&entry[K, V]{value: v, key: k}, at)
 }
 
 // remove removes e from its list, decrements l.len.

--- a/pkg/cache/lru/lru.go
+++ b/pkg/cache/lru/lru.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package lru
 
 import (
@@ -81,7 +94,7 @@ func (c *LRU[K, V]) removeOldest() {
 	}
 }
 
-// removeElement is used to remove a given list element from the cache
+// removeElement is used to remove a given list element from the cache.
 func (c *LRU[K, V]) removeElement(e *entry[K, V]) {
 	c.evictList.remove(e)
 	delete(c.items, e.key)

--- a/pkg/cache/lru/lru.go
+++ b/pkg/cache/lru/lru.go
@@ -1,0 +1,88 @@
+package lru
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type LRU[K comparable, V any] struct {
+	hits, misses, evictions prometheus.Counter
+
+	maxEntries int
+	items      map[K]*entry[K, V]
+	evictList  *lruList[K, V]
+}
+
+func New[K comparable, V any](reg prometheus.Registerer, maxEntries int) *LRU[K, V] {
+	requests := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_requests_total",
+		Help: "Total number of cache requests.",
+	}, []string{"result"})
+
+	c := &LRU[K, V]{
+		hits:   requests.WithLabelValues("hit"),
+		misses: requests.WithLabelValues("miss"),
+		evictions: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cache_evictions_total",
+			Help: "Total number of cache evictions.",
+		}),
+
+		maxEntries: maxEntries,
+		evictList:  newList[K, V](),
+		items:      map[K]*entry[K, V]{},
+	}
+	return c
+}
+
+func (c *LRU[K, V]) Add(key K, value V) {
+	if entry, ok := c.items[key]; ok {
+		c.evictList.moveToFront(entry)
+		entry.value = value
+		return
+	}
+
+	entry := c.evictList.pushFront(key, value)
+	c.items[key] = entry
+
+	// Should evict?
+	if c.evictList.length() > c.maxEntries {
+		c.removeOldest()
+		c.evictions.Inc()
+	}
+}
+
+func (c *LRU[K, V]) Remove(key K) {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+	}
+}
+
+func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.moveToFront(ent)
+		c.hits.Inc()
+		return ent.value, true
+	}
+	c.misses.Inc()
+	return
+}
+
+func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		return ent.value, true
+	}
+	return
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU[K, V]) removeOldest() {
+	if ent := c.evictList.back(); ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU[K, V]) removeElement(e *entry[K, V]) {
+	c.evictList.remove(e)
+	delete(c.items, e.key)
+}

--- a/pkg/cache/lru/lru.go
+++ b/pkg/cache/lru/lru.go
@@ -70,7 +70,7 @@ func (c *LRU[K, V]) Remove(key K) {
 	}
 }
 
-func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
+func (c *LRU[K, V]) Get(key K) (value V, ok bool) { //nolint:nonamedreturns
 	if ent, ok := c.items[key]; ok {
 		c.evictList.moveToFront(ent)
 		c.hits.Inc()
@@ -80,7 +80,7 @@ func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
 	return
 }
 
-func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
+func (c *LRU[K, V]) Peek(key K) (value V, ok bool) { //nolint:nonamedreturns
 	if ent, ok := c.items[key]; ok {
 		return ent.value, true
 	}

--- a/pkg/cache/lru/lru_test.go
+++ b/pkg/cache/lru/lru_test.go
@@ -1,0 +1,103 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lru
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLRU(t *testing.T) {
+	l := New[int, int](prometheus.NewRegistry(), 128)
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	require.Equal(t, 128, len(l.items))
+	require.Equal(t, 128.0, testutil.ToFloat64(l.evictions))
+
+	for i, k := range keys(l.items) {
+		if v, ok := l.Get(k); !ok || v != k {
+			t.Fatalf("bad key: %v (value: %v, ok: %t), i: %d", k, v, ok, i)
+		}
+	}
+
+	for i := 0; i < 128; i++ {
+		v, ok := l.Get(i)
+		require.Zero(t, v)
+		require.False(t, ok)
+	}
+	for i := 128; i < 256; i++ {
+		v, ok := l.Get(i)
+		require.NotZero(t, v)
+		require.True(t, ok)
+	}
+
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		if _, ok := l.Get(i); ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	for i := 192; i < 256; i++ {
+		if v, ok := l.Get(i); !ok || v != i {
+			t.Fatalf("bad key: %v (value: %v, ok: %t)", i, v, ok)
+		}
+	}
+}
+
+func keys[K comparable, V any](m map[K]*entry[K, V]) []K {
+	ks := make([]K, len(m))
+	i := 0
+	for k := range m {
+		ks[i] = k
+		i++
+	}
+	return ks
+}
+
+func TestLRU_Add(t *testing.T) {
+	l := New[int, int](prometheus.NewRegistry(), 1)
+
+	l.Add(1, 1)
+	require.Equal(t, 0.0, testutil.ToFloat64(l.evictions))
+
+	l.Add(2, 2)
+	require.Equal(t, 1.0, testutil.ToFloat64(l.evictions))
+}
+
+func TestLRU_Peek(t *testing.T) {
+	l := New[int, int](prometheus.NewRegistry(), 2)
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+}
+
+func TestLRU_Remove(t *testing.T) {
+	l := New[int, int](prometheus.NewRegistry(), 2)
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	l.Remove(1)
+	if _, ok := l.Peek(1); ok {
+		t.Errorf("1 should be removed")
+	}
+}

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -15,32 +15,54 @@ package cache
 
 import burrow "github.com/goburrow/cache"
 
-var _ burrow.Cache = (*noopCache)(nil)
+type noopCache[K comparable, V any] struct{}
 
-// noopCache implements the burrow.Cache interface but does not cache anything.
-// It is useful for testing, so let's keep it around.
-type noopCache struct{}
-
-func NewNoopCache() *noopCache {
-	return &noopCache{}
+func NewNoopCache[K comparable, V any]() *noopCache[K, V] {
+	return &noopCache[K, V]{}
 }
 
-func (c *noopCache) GetIfPresent(burrow.Key) (burrow.Value, bool) {
+func (c *noopCache[K, V]) Add(key K, value V) {
+}
+
+func (c *noopCache[K, V]) Get(key K) (V, bool) {
+	var zero V
+	return zero, false
+}
+
+func (c *noopCache[K, V]) Peek(key K) (V, bool) {
+	var zero V
+	return zero, false
+}
+
+func (c *noopCache[K, V]) Remove(key K) {
+}
+
+var _ burrow.Cache = (*burrowNoopCache)(nil)
+
+// burrowNoopCache implements the burrow.Cache interface but does not cache anything.
+// It is useful for testing, so let's keep it around.
+type burrowNoopCache struct{}
+
+func NewBurrowNoopCache() *burrowNoopCache {
+	return &burrowNoopCache{}
+}
+
+func (c *burrowNoopCache) GetIfPresent(burrow.Key) (burrow.Value, bool) {
 	return nil, false
 }
 
-func (c *noopCache) Put(burrow.Key, burrow.Value) {
+func (c *burrowNoopCache) Put(burrow.Key, burrow.Value) {
 }
 
-func (c *noopCache) Invalidate(burrow.Key) {
+func (c *burrowNoopCache) Invalidate(burrow.Key) {
 }
 
-func (c *noopCache) InvalidateAll() {
+func (c *burrowNoopCache) InvalidateAll() {
 }
 
-func (c *noopCache) Stats(*burrow.Stats) {
+func (c *burrowNoopCache) Stats(*burrow.Stats) {
 }
 
-func (c *noopCache) Close() error {
+func (c *burrowNoopCache) Close() error {
 	return nil
 }

--- a/pkg/debuginfo/manager_test.go
+++ b/pkg/debuginfo/manager_test.go
@@ -74,7 +74,6 @@ func BenchmarkUploadInitiateUploadError(b *testing.B) {
 		25,
 		2*time.Minute,
 		false,
-		5*time.Minute,
 		[]string{"/usr/lib/debug"},
 		true,
 		"/tmp",
@@ -159,7 +158,6 @@ func TestUpload(t *testing.T) {
 		25,
 		2*time.Minute,
 		false,
-		5*time.Minute,
 		[]string{"/usr/lib/debug"},
 		true,
 		"/tmp",
@@ -213,7 +211,7 @@ func TestUpload(t *testing.T) {
 	// Assert metrics were incremented.
 	require.Equal(t, 5.0, testutil.ToFloat64(dim.metrics.uploadRequests))
 	// When the response is cached, the upload is not attempted.
-	require.Equal(t, 4.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
+	require.Equal(t, 5.0, testutil.ToFloat64(dim.metrics.uploadAttempts))
 	require.Equal(t, 2.0, testutil.ToFloat64(dim.metrics.uploaded.WithLabelValues(lvFail)))
 	require.Equal(t, 3.0, testutil.ToFloat64(dim.metrics.uploaded.WithLabelValues(lvSuccess)))
 }
@@ -282,7 +280,6 @@ func TestUploadSingleFlight(t *testing.T) {
 		5,
 		2*time.Minute,
 		false,
-		5*time.Minute,
 		[]string{"/usr/lib/debug"},
 		true,
 		"/tmp",

--- a/pkg/metadata/labels/manager.go
+++ b/pkg/metadata/labels/manager.go
@@ -60,8 +60,8 @@ func NewManager(
 	profilingDuration time.Duration,
 ) *Manager {
 	var (
-		labelCache    burrow.Cache = cache.NewNoopCache()
-		providerCache burrow.Cache = cache.NewNoopCache()
+		labelCache    burrow.Cache = cache.NewBurrowNoopCache()
+		providerCache burrow.Cache = cache.NewBurrowNoopCache()
 	)
 	if !cacheDisabled {
 		labelCache = burrow.New(

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -340,7 +340,7 @@ func (p *CPU) listenEvents(ctx context.Context, eventsChan <-chan []byte, lostCh
 }
 
 func (p *CPU) prefetchProcessInfo(ctx context.Context, pid int) {
-	if err := p.processInfoManager.Fetch(ctx, pid); err != nil {
+	if _, err := p.processInfoManager.Fetch(ctx, pid); err != nil {
 		level.Debug(p.logger).Log("msg", "failed to load process info", "pid", pid, "err", err)
 	}
 }

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -118,8 +118,8 @@ type Profile struct {
 
 // TODO: Unify PID types.
 type ProcessInfoManager interface {
-	Fetch(ctx context.Context, pid int) error
-	Info(ctx context.Context, pid int) (*process.Info, error)
+	Fetch(ctx context.Context, pid int) (process.Info, error)
+	Info(ctx context.Context, pid int) (process.Info, error)
 }
 
 type AddressNormalizer interface {

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -257,6 +257,7 @@ func prepareProfiler(t *testing.T, profileWriter profiler.ProfileWriter, logger 
 			dbginfo,
 			labelsManager,
 			loopDuration,
+			loopDuration,
 		),
 		address.NewNormalizer(logger, reg, normalizeAddresses),
 		vdsoCache,


### PR DESCRIPTION
### Why?
goburrow/cache has shown to be very inefficient in hotpaths due to its accounting overhead. This implements a lightweight LRU with Prometheus metrics and uses it in hotpaths. We should eventually replace all usages with this, but this should show whether we will get the improvements we're looking for (or revert if not).

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 127ce4e</samp>

This pull request improves the performance and reliability of the debuginfo cache and upload logic in the `parca-agent` by replacing the burrow cache library with a custom LRUCache type, simplifying the error handling and concurrency control, and fixing some bugs and redundancies. It also adds some prometheus metrics for the cache usage and evictions. The pull request affects the `cmd/parca-agent`, `pkg/debuginfo`, `pkg/process`, `pkg/cache`, `pkg/profiler/cpu`, and `pkg/profiler` packages.

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 127ce4e</samp>

*  Replace burrow cache library with generic LRUCache type using generics and prometheus metrics ([link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-964e351ee2375d359c78d69e514c4edc42577219761c4475f391ed2daf715e51R1-R46), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-9e40721bcad2bbdcc9e2b4b02892300ca79f12ead427bae0925fbd0fb2513531R1-R128), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-a9cd77a41a21033b47f09eaa18c7e763e74791e4ed5e2f6bb96b8110774a366eR1-R88))
*  Remove unused fields and arguments related to cache configuration from `run` function and `debuginfo.New` function call in `cmd/parca-agent/main.go` ([link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL636-L637), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eR657), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL853), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L92-R92))
*  Refactor `debuginfo` package to use LRUCache type and simplify logic for uploading debug information ([link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L21), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L31), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L63-R65), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L126-R112), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359R130-R134), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L220-R210), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L232), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L458-R444), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L474-R462), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L485), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-5c4a0ca9a2747c99b32f629099e552b2582da981ff90f6bcedd6044dbe11e359L576-R563))
*  Refactor `process` package to use LRUCache type and return Info value from `Fetch` and `Info` methods ([link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L27), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L112-R119), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L121-R157), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L159-R181), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L166-R204), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L204-R223), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L212-R238), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L226-R253), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L236-R264), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L262-L275), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L282-R295), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L301-R310), [link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-bc9c9211670f079eed672ee83ccef854706b1a639e4d9a0a28c92f5b4f5f0eb7L315-R322))
*  Modify `ProcessInfoManager` interface in `profiler` package to match the return types of `Fetch` and `Info` methods ([link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-38da4938004f35685ca8cb0368582c999d7db09d15a029522c945feff69e6ad5L121-R122))
*  Modify `prefetchProcessInfo` method in `cpu` package to ignore the returned info value from `Fetch` method ([link](https://github.com/parca-dev/parca-agent/pull/1732/files?diff=unified&w=0#diff-a3297cf4e3be27cabb198588463f4c04ca0f4aa5d81cbe206e467e1f1f7e772dL343-R343))

### Test Plan
Tested with local Parca server.