### PR TITLE
pkg/process: Ensure debuginfo is uploaded

### DIFF
--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -191,6 +191,7 @@ func (im *InfoManager) fetch(ctx context.Context, pid int, async bool) (info Inf
 	// See the cache initialization for the eviction policy and the eviction TTL.
 	info, exists := im.cache.Peek(pid)
 	if exists {
+		im.ensureDebuginfoUploaded(ctx, pid, info.Mappings)
 		return info, nil
 	}
 


### PR DESCRIPTION

### Why?
Previously we missed uploading debuginfo if it failed on the first attempt but gathering process info succeeded, which happens quite a lot in practice.

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
copilot:summary

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
copilot:walkthrough

### Test Plan

Tested locally.