### PR TITLE
pkg/process: Filter mappings to only consider executable sections

### DIFF
--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -99,13 +99,23 @@ func (ms Mappings) ConvertToPprof() []*profile.Mapping {
 	// value aka unset).
 	i := uint64(1)
 	for _, m := range ms {
+		pprofMapping := m.ConvertToPprof()
+		pprofMapping.ID = i
+		res = append(res, pprofMapping)
+		i++
+	}
+	return res
+}
+
+func (ms Mappings) ExecutableSections() []*Mapping {
+	res := make([]*Mapping, 0, len(ms))
+
+	for _, m := range ms {
 		if m.isExecutable() {
-			pprofMapping := m.ConvertToPprof()
-			pprofMapping.ID = i
-			res = append(res, pprofMapping)
-			i++
+			res = append(res, m)
 		}
 	}
+
 	return res
 }
 

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -563,7 +563,7 @@ func (p *CPU) Run(ctx context.Context) error {
 
 			pprof, err := p.profileConverter.NewConverter(
 				pid,
-				pi.Mappings,
+				pi.Mappings.ExecutableSections(),
 				p.LastProfileStartedAt(),
 				samplingPeriod,
 			).Convert(ctx, perProcessRawData.RawSamples)


### PR DESCRIPTION
### Why?

We were not filtering out non-executable sections from mappings which ultimately resulted in being unable to normalize addresses.

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
copilot:summary

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
copilot:walkthrough

### Test Plan

Tested locally and already seeing far less normalization issues.