### PR TITLE
*: Remove 3rd-party multi-error packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,10 @@ linters-settings:
             desc: Use github.com/go-kit/log instead of github.com/go-kit/kit/log
           - pkg: github.com/pkg/errors
             desc: Use fmt.Errorf instead
+          - pkg: go.uber.org/multierr
+            desc: Use errors.Join instead
+          - pkg: github.com/hashicorp/go-multierror
+            desc: Use errors.Join instead
   errcheck:
     exclude: ./.errcheck_excludes.txt
   goimports:

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0-rc.0.0.20230515140958-a18e1e2bacb2
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.5
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/klauspost/compress v1.16.5
 	github.com/minio/highwayhash v1.0.2
@@ -47,7 +46,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.5.2
-	go.uber.org/multierr v1.11.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sync v0.2.0
 	golang.org/x/sys v0.8.0
@@ -114,7 +112,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,14 +328,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAsz
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -614,8 +610,6 @@ go.uber.org/automaxprocs v1.5.2/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnw
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/kconfig/kconfig.go
+++ b/pkg/kconfig/kconfig.go
@@ -21,8 +21,6 @@ import (
 	"io/fs"
 	"os"
 	"strings"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -68,13 +66,13 @@ func CheckBPFEnabled() error {
 		fmt.Sprintf("/boot/config-%s", uname),
 	}
 
-	var result *multierror.Error
+	var result error
 	for _, configPath := range configPaths {
 		if _, err := os.Stat(configPath); err != nil {
 			if os.IsNotExist(err) || errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 			continue
 		}
 		isBPFEnabled, err := checkBPFOptions(configPath)
@@ -87,8 +85,8 @@ func CheckBPFEnabled() error {
 		}
 	}
 
-	if result != nil && len(result.Errors) > 0 {
-		return result.ErrorOrNil()
+	if result != nil {
+		return result
 	}
 
 	// If we reach this point, either we have not found a config file or required options are not enabled.

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -35,7 +35,6 @@ import (
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
@@ -361,21 +360,21 @@ func onDemandUnwindInfoBatcher(ctx context.Context, eventsChannel <-chan int, du
 }
 
 func bpfCheck() error {
-	var result *multierror.Error
+	var result error
 
 	if support, err := bpf.BPFProgramTypeIsSupported(bpf.BPFProgTypePerfEvent); !support {
-		result = multierror.Append(result, fmt.Errorf("perf event program type not supported: %w", err))
+		result = errors.Join(result, fmt.Errorf("perf event program type not supported: %w", err))
 	}
 
 	if support, err := bpf.BPFMapTypeIsSupported(bpf.MapTypeStackTrace); !support {
-		result = multierror.Append(result, fmt.Errorf("stack trace map type not supported: %w", err))
+		result = errors.Join(result, fmt.Errorf("stack trace map type not supported: %w", err))
 	}
 
 	if support, err := bpf.BPFMapTypeIsSupported(bpf.MapTypeHash); !support {
-		result = multierror.Append(result, fmt.Errorf("hash map type not supported: %w", err))
+		result = errors.Join(result, fmt.Errorf("hash map type not supported: %w", err))
 	}
 
-	return result.ErrorOrNil()
+	return result
 }
 
 func (p *CPU) Run(ctx context.Context) error {

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -33,7 +33,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	burrow "github.com/goburrow/cache"
-	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
 	"golang.org/x/exp/constraints"
@@ -481,17 +480,17 @@ func (m *bpfMaps) cleanStacks() error {
 
 	// stackTraces
 	if err := clearBpfMap(m.stackTraces); err != nil {
-		result = multierror.Append(result, err)
+		result = errors.Join(result, err)
 	}
 
 	// dwarfStackTraces
 	if err := clearBpfMap(m.dwarfStackTraces); err != nil {
-		result = multierror.Append(result, err)
+		result = errors.Join(result, err)
 	}
 
 	// stackCounts
 	if err := clearBpfMap(m.stackCounts); err != nil {
-		result = multierror.Append(result, err)
+		result = errors.Join(result, err)
 	}
 
 	return result

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
 )
@@ -116,7 +115,7 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 						fmt.Fprintf(writer, "\tLoc: %x CFA: exp (plt %d)", unwindRow.Loc, expressionID)
 					}
 				default:
-					return multierror.Append(fmt.Errorf("CFA rule is not valid. This should never happen"))
+					return fmt.Errorf("CFA rule is not valid. This should never happen")
 				}
 
 				// RuleRegister

--- a/pkg/vdso/vdso.go
+++ b/pkg/vdso/vdso.go
@@ -17,8 +17,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.uber.org/multierr"
-
 	"github.com/parca-dev/parca/pkg/symbol/symbolsearcher"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -93,7 +91,7 @@ func NewCache(reg prometheus.Registerer, objFilePool *objectfile.Pool) (*Cache, 
 		path = fmt.Sprintf("/usr/lib/modules/%s/vdso/%s", kernelVersion, vdso)
 		obj, err = objFilePool.Open(path)
 		if err != nil {
-			merr = multierr.Append(merr, fmt.Errorf("failed to open elf file: %s, err: %w", path, err))
+			merr = errors.Join(merr, fmt.Errorf("failed to open elf file: %s, err: %w", path, err))
 			continue
 		}
 		defer obj.HoldOn()


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Why?
There's no need to use 3rd party libraries since the `errors.Join` added to the standard library recently.

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebc829e</samp>

This pull request removes the use of `multierror` packages from the codebase and replaces them with the `errors` package and the `errors.Join` function. This improves the error handling consistency and quality and complies with the `depguard` linter. The pull request also updates the `depguard` configuration to forbid the use of `multierror` packages.

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebc829e</samp>

*  Forbid the use of `go.uber.org/multierr` and `github.com/hashicorp/go-multierror` packages by adding them to the `depguard` linter configuration in `.golangci.yml` ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R69-R72))
* Remove the unused dependencies on `github.com/hashicorp/go-multierror` and `github.com/hashicorp/errwrap` from `go.mod` ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L22), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L117))
* Remove the dependency on `go.uber.org/multierr` from `go.mod` and use the `errors` package from `github.com/parca-dev/parca-agent/pkg/errors` instead, which wraps `go.uber.org/multierr` and provides a consistent error formatting and handling ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L50))
  * `debuginfo` package in `pkg/debuginfo/extract.go`, `ExtractAll` method of the `Extractor` type ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803R20), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803L27), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803L55-R60), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-447c43aa1b1bd3f3896570c8d55826301501d359871dfda8fdd5c1e1ed193803L69-R72))
  * `kconfig` package in `pkg/kconfig/kconfig.go`, `CheckBPFEnabled` function ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-70ed66e71793d4815279a416da0a34ef267f5e7f13018bcffb403e3fabb54870L24-L25), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-70ed66e71793d4815279a416da0a34ef267f5e7f13018bcffb403e3fabb54870L71-R69), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-70ed66e71793d4815279a416da0a34ef267f5e7f13018bcffb403e3fabb54870L77-R75), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-70ed66e71793d4815279a416da0a34ef267f5e7f13018bcffb403e3fabb54870L90-R89))
  * `cpu` package in `pkg/profiler/cpu/cpu.go`, `bpfCheck` function ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-a3297cf4e3be27cabb198588463f4c04ca0f4aa5d81cbe206e467e1f1f7e772dL38), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-a3297cf4e3be27cabb198588463f4c04ca0f4aa5d81cbe206e467e1f1f7e772dL364-R377))
  * `cpu` package in `pkg/profiler/cpu/maps.go`, `cleanStacks` method of the `Maps` type ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-1c1bf15e305b51045a2b4c72fc4c1a64fb73ed42c915ab8f0241143e4a76c307L36), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-1c1bf15e305b51045a2b4c72fc4c1a64fb73ed42c915ab8f0241143e4a76c307L484-R493))
  * `vdso` package in `pkg/vdso/vdso.go`, `NewCache` function ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-b3a7f294a0fa5a71ab06af71de938e5dfbc119109c6d13ce194e58efec847517L20-L21), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-b3a7f294a0fa5a71ab06af71de938e5dfbc119109c6d13ce194e58efec847517L96-R94))
  * `kconfig` package in `pkg/kconfig/kconfig.go`, `CheckBPFEnabled` function ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-70ed66e71793d4815279a416da0a34ef267f5e7f13018bcffb403e3fabb54870L71-R69))
  * `cpu` package in `pkg/profiler/cpu/cpu.go`, `bpfCheck` function ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-a3297cf4e3be27cabb198588463f4c04ca0f4aa5d81cbe206e467e1f1f7e772dL364-R377))
* Replace the use of `multierror.Append` with `fmt.Errorf` in the `unwind` package in `pkg/stack/unwind/unwind_table.go`, `PrintTable` function ([link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-5f5236d3183c945bde2bfe6dde18b0fd71cdccfe0a1247707100e5a2e3f71752L25), [link](https://github.com/parca-dev/parca-agent/pull/1755/files?diff=unified&w=0#diff-5f5236d3183c945bde2bfe6dde18b0fd71cdccfe0a1247707100e5a2e3f71752L119-R118))

### Test Plan

1. make ENABLE_RACE=yes test
2. make ENABLE_RACE=yes test/profiler
3. make go/lint
