### PR TITLE
Do not cache process info if we failed to read a mapping

### DIFF
--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -155,8 +155,7 @@ func NewInfoManager(
 			1024,
 			12*profilingDuration,
 			cache.CacheWithTTLOptions{
-				UpdateDeadlineOnGet: true,
-				RemoveExpiredOnAdd:  true,
+				RemoveExpiredOnAdd: true,
 			},
 		),
 		shouldInitiateUploadCache: cache.NewLRUCacheWithTTL[string, struct{}](

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -97,9 +97,7 @@ type CPU struct {
 	lastSuccessfulProfileStartedAt time.Time
 	lastProfileStartedAt           time.Time
 
-	debugProcessNames      []string
-	isNormalizationEnabled bool
-
+	debugProcessNames     []string
 	dwarfUnwindingDisable bool
 
 	memlockRlimit     uint64


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

And expire the process info cache after-write to make sure we refresh.
