### PR TITLE
Increase default object file pool size and improve error

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Flags:
                                    of memory that may be locked into RAM. It is
                                    used to ensure the agent can lock memory for
                                    eBPF maps. 0 means no limit.
-      --object-file-pool-size=128
+      --object-file-pool-size=512
                                    The maximum number of object files to keep in
                                    the pool. This is used to avoid re-reading
                                    object files from disk. It keeps FDs open,

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -112,7 +112,7 @@ type flags struct {
 	Node               string `default:"${hostname}"               help:"The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name."`
 	ConfigPath         string `default:""                          help:"Path to config file."`
 	MemlockRlimit      uint64 `default:"${default_memlock_rlimit}" help:"The value for the maximum number of bytes of memory that may be locked into RAM. It is used to ensure the agent can lock memory for eBPF maps. 0 means no limit."`
-	ObjectFilePoolSize int    `default:"128"                       help:"The maximum number of object files to keep in the pool. This is used to avoid re-reading object files from disk. It keeps FDs open, so it should be kept in sync with ulimits. 0 means no limit."`
+	ObjectFilePoolSize int    `default:"512"                       help:"The maximum number of object files to keep in the pool. This is used to avoid re-reading object files from disk. It keeps FDs open, so it should be kept in sync with ulimits. 0 means no limit."`
 
 	// pprof.
 	MutexProfileFraction int `default:"0" help:"Fraction of mutex profile samples to collect."`

--- a/pkg/objectfile/object_file.go
+++ b/pkg/objectfile/object_file.go
@@ -68,7 +68,7 @@ func (o *ObjectFile) Reader() (*io.SectionReader, func(), error) {
 	if o.closed {
 		o.mtx.RUnlock()
 		// @norelease: Should never happen!
-		panic(errors.Join(ErrAlreadyClosed, fmt.Errorf("file %s is already closed by: %s", o.Path, frames(o.closedBy))))
+		panic(errors.Join(ErrAlreadyClosed, fmt.Errorf("file %s is already closed (try increasing `--object-file-pool-size`) it was closed by: %s", o.Path, frames(o.closedBy))))
 	}
 
 	r := io.NewSectionReader(o.file, 0, o.Size)
@@ -89,7 +89,7 @@ func (o *ObjectFile) ELF() (*elf.File, func(), error) {
 	if o.closed {
 		o.mtx.RUnlock()
 		// @norelease: Should never happen!
-		panic(errors.Join(ErrAlreadyClosed, fmt.Errorf("file %s is already closed by: %s", o.Path, frames(o.closedBy))))
+		panic(errors.Join(ErrAlreadyClosed, fmt.Errorf("file %s is already closed (try increasing `--object-file-pool-size`) it was closed by: %s", o.Path, frames(o.closedBy))))
 	}
 
 	return o.elf, func() {


### PR DESCRIPTION
It's possible on machines that create a lot of very short lived processes to evict an object file from the pool before it was possible to be used. In these cases the best solution is to increase the object pool size since not increasing it would lead to extremely high cache misses which would also be very bad.

### Why?

#1798 

### What?

Increase the default object file pool (128 seemed extraordinarily low) and add instructions to the panic output what to do in this case.

### Alternative

We could also return an error, however, it is likely that incorrect data would be produced, so I felt it is better to fail and be a bit more forcing to the user to update the value to something better that will work for their environment.

### Test Plan
n/a