### PR TITLE
Add analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Flags:
                                    pointers
       --otlp-address=STRING        The endpoint to send OTLP traces to.
       --otlp-exporter="grpc"       The OTLP exporter to use.
+      --analytics-opt-out          Opt out of sending anonymous usage
+                                   statistics.
       --verbose-bpf-logging        Enable verbose BPF logging.
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-kit/log v0.2.1
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0-rc.0.0.20230515140958-a18e1e2bacb2
@@ -34,6 +35,8 @@ require (
 	github.com/rzajac/flexbuf v0.14.0
 	github.com/stretchr/testify v1.8.4
 	github.com/xyproto/ainur v1.3.3-0.20230327065817-db855584e31b
+	github.com/zcalusic/sysinfo v1.0.0
+	go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.8
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.42.0
 	go.opentelemetry.io/otel v1.16.0
@@ -147,6 +150,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.40 // indirect
 	github.com/thanos-io/objstore v0.0.0-20230522103316-23ebe2eacadd // indirect
+	go.buf.build/protocolbuffers/go/gogo/protobuf v1.3.9 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/gnostic v0.6.9 h1:ZK/5VhkoX835RikCHpSUJV9a+S3e1zLh59YnyWeBW+0=
@@ -571,6 +572,12 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zcalusic/sysinfo v1.0.0 h1:z9V/+HCuMi+3jXT3RTvX6HOPpXIqwhGllN0yYmRUhpQ=
+github.com/zcalusic/sysinfo v1.0.0/go.mod h1:LxwKwtQdbTIQc65drhjQzYzt0o7jfB80LrrZm7SWn8o=
+go.buf.build/protocolbuffers/go/gogo/protobuf v1.3.9 h1:Gem1ArgYzrhdAuaORVqtvkT4WGPRiwFLXpTgRn+QLC8=
+go.buf.build/protocolbuffers/go/gogo/protobuf v1.3.9/go.mod h1:i2gBbO3BPCoVRjhpYl5wkyH+sQ8aZyE+ELx44rJm2/E=
+go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.8 h1:2LntQlPZuEgucC8Phqnirpj150+k1rNeCzoF9tCTJX0=
+go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.8/go.mod h1:MscLIBPVmRlS3Z4XijKkiqzOiBQaRFi1PqWt7KAzf9o=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -943,6 +950,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,146 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analytics
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/zcalusic/sysinfo"
+	"go.buf.build/protocolbuffers/go/prometheus/prometheus"
+)
+
+type AnalyticsSender struct {
+	logger log.Logger
+
+	client *Client
+
+	machineID   string
+	arch        string
+	cpuCores    float64
+	version     string
+	si          sysinfo.SysInfo
+	isContainer string
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	//nolint:gosec
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func NewSender(
+	logger log.Logger,
+	client *Client,
+	arch string,
+	cpuCores int,
+	version string,
+	si sysinfo.SysInfo,
+	isContainer bool,
+) *AnalyticsSender {
+	return &AnalyticsSender{
+		logger:      logger,
+		client:      client,
+		machineID:   randSeq(20),
+		arch:        arch,
+		cpuCores:    float64(cpuCores),
+		version:     version,
+		si:          si,
+		isContainer: strconv.FormatBool(isContainer),
+	}
+}
+
+func (s *AnalyticsSender) Run(ctx context.Context) {
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := FromTime(time.Now())
+			if err := s.client.Send(ctx, &prometheus.WriteRequest{
+				Timeseries: []*prometheus.TimeSeries{{
+					Labels: []*prometheus.Label{{
+						Name:  "__name__",
+						Value: "parca_agent_info",
+					}, {
+						Name:  "machine_id",
+						Value: s.machineID,
+					}, {
+						Name:  "arch",
+						Value: s.arch,
+					}, {
+						Name:  "version",
+						Value: s.version,
+					}, {
+						Name:  "kernel_version",
+						Value: s.si.Kernel.Version,
+					}, {
+						Name:  "kernel_osrelease",
+						Value: s.si.Kernel.Release,
+					}, {
+						Name:  "os_name",
+						Value: s.si.OS.Name,
+					}, {
+						Name:  "os_vendor",
+						Value: s.si.OS.Vendor,
+					}, {
+						Name:  "os_version",
+						Value: s.si.OS.Version,
+					}, {
+						Name:  "os_release",
+						Value: s.si.OS.Release,
+					}, {
+						Name:  "is_container",
+						Value: s.isContainer,
+					}},
+					Samples: []*prometheus.Sample{{
+						Value:     1,
+						Timestamp: now,
+					}},
+				}, {
+					Labels: []*prometheus.Label{{
+						Name:  "__name__",
+						Value: "parca_agent_cpu_cores",
+					}, {
+						Name:  "machine_id",
+						Value: s.machineID,
+					}},
+					Samples: []*prometheus.Sample{{
+						Value:     s.cpuCores,
+						Timestamp: now,
+					}},
+				}},
+			}); err != nil {
+				level.Debug(s.logger).Log("msg", "failed to send analytics", "err", err)
+			}
+		}
+	}
+}
+
+func FromTime(t time.Time) int64 {
+	return t.Unix()*1000 + int64(t.Nanosecond())/int64(time.Millisecond)
+}

--- a/pkg/analytics/remote_write.go
+++ b/pkg/analytics/remote_write.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analytics
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"go.buf.build/protocolbuffers/go/prometheus/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	maxErrMsgLen = 1024
+	defaultURL   = "https://analytics.parca.dev/api/v1/write"
+)
+
+type Client struct {
+	client    *http.Client
+	urlString string
+	userAgent string
+	timeout   time.Duration
+
+	buf  []byte
+	pBuf *proto.Buffer
+}
+
+func NewClient(
+	client *http.Client,
+	userAgent string,
+	timeout time.Duration,
+) *Client {
+	analyticsURL := defaultURL
+	customAnalyticsURL := os.Getenv("ANALYTICS_URL")
+	if customAnalyticsURL != "" {
+		analyticsURL = customAnalyticsURL
+	}
+
+	return &Client{
+		client: client,
+
+		urlString: analyticsURL,
+		userAgent: userAgent,
+		timeout:   timeout,
+
+		pBuf: proto.NewBuffer(nil),
+		buf:  make([]byte, 1024),
+	}
+}
+
+func (c *Client) Send(ctx context.Context, wreq *prometheus.WriteRequest) error {
+	c.pBuf.Reset()
+	err := c.pBuf.Marshal(wreq)
+	if err != nil {
+		return err
+	}
+
+	// snappy uses len() to see if it needs to allocate a new slice. Make the
+	// buffer as long as possible.
+	if c.buf != nil {
+		c.buf = c.buf[0:cap(c.buf)]
+	}
+	c.buf = snappy.Encode(c.buf, c.pBuf.Bytes())
+
+	return c.sendReq(ctx, c.buf)
+}
+
+// Store sends a batch of samples to the HTTP endpoint, the request is the proto marshaled
+// and encoded bytes from codec.go.
+func (c *Client) sendReq(ctx context.Context, req []byte) error {
+	httpReq, err := http.NewRequest(http.MethodPost, c.urlString, bytes.NewReader(req))
+	if err != nil {
+		// Errors from NewRequest are from unparsable URLs, so are not
+		// recoverable.
+		return err
+	}
+
+	httpReq.Header.Add("Content-Encoding", "snappy")
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("User-Agent", c.userAgent)
+	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx, span := otel.Tracer("").Start(ctx, "Remote Store", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	httpResp, err := c.client.Do(httpReq.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, httpResp.Body) //nolint:errcheck
+		httpResp.Body.Close()
+	}()
+
+	if httpResp.StatusCode/100 != 2 {
+		scanner := bufio.NewScanner(io.LimitReader(httpResp.Body, maxErrMsgLen))
+		line := ""
+		if scanner.Scan() {
+			line = scanner.Text()
+		}
+		err = fmt.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
+	}
+	return err
+}

--- a/pkg/cpuinfo/cpu.go
+++ b/pkg/cpuinfo/cpu.go
@@ -1,0 +1,20 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpuinfo
+
+import "runtime"
+
+func NumCPU() int {
+	return runtime.NumCPU()
+}

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -41,6 +40,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/parca-dev/parca-agent/pkg/byteorder"
+	"github.com/parca-dev/parca-agent/pkg/cpuinfo"
 	"github.com/parca-dev/parca-agent/pkg/metadata/labels"
 	"github.com/parca-dev/parca-agent/pkg/pprof"
 	"github.com/parca-dev/parca-agent/pkg/profile"
@@ -469,7 +469,7 @@ func (p *CPU) Run(ctx context.Context) error {
 	// By default we sample at 19Hz (19 times per second),
 	// which is every ~0.05s or 52,631,578 nanoseconds (1 Hz = 1e9 ns).
 	samplingPeriod := int64(1e9 / p.profilingSamplingFrequency)
-	cpus := runtime.NumCPU()
+	cpus := cpuinfo.NumCPU()
 
 	for i := 0; i < cpus; i++ {
 		fd, err := unix.PerfEventOpen(&unix.PerfEventAttr{


### PR DESCRIPTION
### Why?

We need to know what kind of work to prioritize, and that works best by having (anonymous) data of usage.

### What?

This patch adds anonymous usage data starting at 10 minutes of a parca-agent being up, that sends data to `analytics.parca.dev`. All Parca maintainers have access to this data.

The initial set of data includes:
* `architecture` to help us understand which architectures we should be working on
* `version` which versions are out there, which helps us understand when to deprecate/remote APIs from Parca
* `cpu_cores` which helps us prioritize work for either machines with high CPU count or low CPU count
* Kernel infos `kernel_version` and`kernel_osrelease` to help us understand which kernel versions its actively used on (maintaining old kernel support is tedious)
* OS infos `os_name`, `os_vendor", `os_version`, `os_release` to help us understand on which distros we should be testing Parca Agent
* `is_container` to understand whether or not parca agent is most popularly deployed as a container

### How?

Using Prometheus remote write, we send the anonymized data to a Prometheus server.

### Test Plan

Tested locally and will test on Polar Signals production once we have a container image.