### PR TITLE
*: Fix arm64 builds to choose correct BPF file

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -82,12 +82,14 @@ jobs:
         run: git submodule init && git submodule update
 
       - name: Build BPF
-        run: make bpf
+        run: |
+          make ARCH=amd64 bpf
+          make ARCH=arm64 bpf
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: ebpf-object-file-container
-          path: pkg/profiler/cpu/cpu-profiler.bpf.o
+          path: bpf/out
           if-no-files-found: error
 
       - name: Validate
@@ -140,7 +142,11 @@ jobs:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ebpf-object-file-container
-          path: pkg/profiler/cpu/cpu-profiler.bpf.o
+          path: bpf/out
+
+      - name: List downloaded files
+        shell: bash
+        run: ls -lR bpf
 
       - name: Run Goreleaser
         run: goreleaser release --clean --skip-validate --skip-publish --snapshot --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,14 @@ jobs:
         run: git submodule init && git submodule update
 
       - name: Build BPF
-        run: make bpf
+        run: |
+          make ARCH=amd64 bpf
+          make ARCH=arm64 bpf
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: ebpf-object-file-release
-          path: pkg/profiler/cpu/cpu-profiler.bpf.o
+          path: bpf/out
           if-no-files-found: error
 
   binaries:
@@ -86,7 +88,7 @@ jobs:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ebpf-object-file-release
-          path: pkg/profiler/cpu/cpu-profiler.bpf.o
+          path: bpf/out
 
       - name: Run Goreleaser
         run: goreleaser release --clean --debug

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -70,12 +70,14 @@ jobs:
         run: git submodule init && git submodule update
 
       - name: Build BPF
-        run: make bpf
+        run: |
+          make ARCH=amd64 bpf
+          make ARCH=arm64 bpf
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: ebpf-object-file-release
-          path: pkg/profiler/cpu/cpu-profiler.bpf.o
+          path: bpf/out
           if-no-files-found: error
 
   binaries:
@@ -120,7 +122,7 @@ jobs:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ebpf-object-file-release
-          path: pkg/profiler/cpu/cpu-profiler.bpf.o
+          path: bpf/out
 
       - name: Run Goreleaser
         run: goreleaser release --clean --debug --snapshot --skip-validate --skip-publish

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,8 @@ builds:
       - amd64
     hooks:
       pre:
-        - make libbpf
+        - make ARCH=amd64 libbpf
+        - cp bpf/out/amd64/cpu.bpf.o pkg/profiler/cpu/cpu-profiler.bpf.o
         - ./scripts/download-async-profiler.sh
     flags:
       - -mod=readonly
@@ -64,6 +65,7 @@ builds:
     hooks:
       pre:
         - make ARCH=arm64 libbpf
+        - cp bpf/out/arm64/cpu.bpf.o pkg/profiler/cpu/cpu-profiler.bpf.o
     flags:
       - -mod=readonly
       - -trimpath

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ ifndef DOCKER
 $(OUT_BPF): $(BPF_SRC) libbpf | $(OUT_DIR)
 	mkdir -p $(OUT_BPF_DIR)
 	$(MAKE) -C bpf build
-	cp bpf/cpu/cpu.bpf.o $(OUT_BPF)
+	cp bpf/out/$(ARCH)/cpu.bpf.o $(OUT_BPF)
 else
 $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@)

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@ build: clang
 
 .PHONY: clean
 clean:
-	rm -f $(OUT_BPF)
+	rm -rf $(OUT_BPF_BASE_DIR)
 	-rm -rf target/
 
 .PHONY: format
@@ -18,7 +18,7 @@ format-check:
 
 # environment:
 ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-SHORT_ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/')
+SHORT_ARCH ?= $(subst amd64,x86,$(ARCH))
 
 # tools:
 CLANG ?= clang
@@ -28,7 +28,8 @@ CMD_CC ?= $(CLANG)
 # output:
 OUT_DIR ?= ../dist
 
-OUT_BPF_DIR := cpu
+OUT_BPF_BASE_DIR := out
+OUT_BPF_DIR := $(OUT_BPF_BASE_DIR)/$(ARCH)
 OUT_BPF := $(OUT_BPF_DIR)/cpu.bpf.o
 BPF_BUNDLE := $(OUT_DIR)/parca-agent.bpf.tar.gz
 


### PR DESCRIPTION
### Why?

We want to publish arm64 images and they're currently broken.

### What?

Fix builds.

### How?

Always building BPF code for arm64 and amd64 and choosing the right one to include in the static binary.

### Test Plan

This fixes CI so the only way to test is to run CI.