### PR TITLE
Always include all architectures of BPF programs

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -146,7 +146,10 @@ jobs:
 
       - name: List downloaded files
         shell: bash
-        run: ls -lR bpf
+        run: |
+          ls -lR bpf
+          mkdir -p pkg/profiler/cpu/bpf
+          cp -r bpf/out/* pkg/profiler/cpu/bpf
 
       - name: Run Goreleaser
         run: goreleaser release --clean --skip-validate --skip-publish --snapshot --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,13 @@ jobs:
           name: ebpf-object-file-release
           path: bpf/out
 
+      - name: List downloaded files
+        shell: bash
+        run: |
+          ls -lR bpf
+          mkdir -p pkg/profiler/cpu/bpf
+          cp -r bpf/out/* pkg/profiler/cpu/bpf
+
       - name: Run Goreleaser
         run: goreleaser release --clean --debug
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -124,6 +124,13 @@ jobs:
           name: ebpf-object-file-release
           path: bpf/out
 
+      - name: List downloaded files
+        shell: bash
+        run: |
+          ls -lR bpf
+          mkdir -p pkg/profiler/cpu/bpf
+          cp -r bpf/out/* pkg/profiler/cpu/bpf
+
       - name: Run Goreleaser
         run: goreleaser release --clean --debug --snapshot --skip-validate --skip-publish
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,6 @@ builds:
     hooks:
       pre:
         - make ARCH=amd64 libbpf
-        - cp bpf/out/amd64/cpu.bpf.o pkg/profiler/cpu/cpu-profiler.bpf.o
         - ./scripts/download-async-profiler.sh
     flags:
       - -mod=readonly
@@ -65,7 +64,6 @@ builds:
     hooks:
       pre:
         - make ARCH=arm64 libbpf
-        - cp bpf/out/arm64/cpu.bpf.o pkg/profiler/cpu/cpu-profiler.bpf.o
     flags:
       - -mod=readonly
       - -trimpath

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ LIBBPF_OBJ := $(LIBBPF_DIR)/libbpf.a
 VMLINUX := vmlinux.h
 BPF_ROOT := bpf
 BPF_SRC := $(BPF_ROOT)/cpu/cpu.bpf.c
-OUT_BPF_DIR := pkg/profiler/cpu
-OUT_BPF := $(OUT_BPF_DIR)/cpu-profiler.bpf.o
+OUT_BPF_DIR := pkg/profiler/cpu/bpf/$(ARCH)
+OUT_BPF := $(OUT_BPF_DIR)/cpu.bpf.o
 
 # CGO build flags:
 PKG_CONFIG ?= pkg-config
@@ -193,11 +193,13 @@ check-license:
 
 .PHONY: go/lint
 go/lint:
+	mkdir -p $(OUT_BPF_DIR)
 	touch $(OUT_BPF)
 	$(GO_ENV) $(CGO_ENV) golangci-lint run
 
 .PHONY: go/lint-fix
 go/lint-fix:
+	mkdir -p $(OUT_BPF_DIR)
 	touch $(OUT_BPF)
 	$(GO_ENV) $(CGO_ENV) golangci-lint run --fix
 

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -324,7 +324,7 @@ func TestAnyStackContains(t *testing.T) {
 // is correct.
 func TestCPUProfilerWorks(t *testing.T) {
 	profileStore := NewTestProfileStore()
-	profileDuration := 4 * time.Second
+	profileDuration := 20 * time.Second
 	tempDir := t.TempDir()
 	logger := logger.NewLogger("error", logger.LogFormatLogfmt, "parca-agent-tests")
 


### PR DESCRIPTION
They are small so it doesn't make much of a difference and unfortunately the build tooling otherwise keeps overriding the compiled BPF programs.
