### PR TITLE
use error.As()

### DIFF
--- a/pkg/objectfile/pool.go
+++ b/pkg/objectfile/pool.go
@@ -234,7 +234,8 @@ func (p *Pool) NewFile(f *os.File) (_ *ObjectFile, err error) { //nolint:nonamed
 	// > Clients of ReadAt can execute parallel ReadAt calls on the same input source.
 	ef, err := elfNewFile(f)
 	if err != nil {
-		if errors.Is(err, &elf.FormatError{}) {
+		var elfErr *elf.FormatError
+		if errors.As(err, &elfErr) {
 			p.metrics.openErrors.WithLabelValues(lvNotELF).Inc()
 		} else {
 			p.metrics.openErrors.WithLabelValues(lvOpenUnknown).Inc()

--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -135,7 +135,8 @@ func (mm *MapManager) MappingsForPID(pid int) (Mappings, error) {
 	for _, m := range maps {
 		mapping, err := mm.newUserMapping(m, pid)
 		if err != nil {
-			if errors.Is(err, &elf.FormatError{}) {
+			var elfErr *elf.FormatError
+			if errors.As(err, &elfErr) {
 				// We don't want to count these as errors. This just means the file
 				// is not an ELF file.
 				continue
@@ -205,7 +206,8 @@ func (mm *MapManager) newUserMapping(pm *procfs.ProcMap, pid int) (*Mapping, err
 
 	obj, err := m.mm.objFilePool.Open(m.AbsolutePath())
 	if err != nil {
-		if !errors.Is(err, &elf.FormatError{}) {
+		var elfErr *elf.FormatError
+		if !errors.As(err, &elfErr) {
 			m.containsDebuginfoToUpload = false
 		}
 		return nil, fmt.Errorf("failed to open mapped object file: %w", err)


### PR DESCRIPTION


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c9de4f</samp>

> _We're sailing on the Go-lang ship, with errors in our code_
> _We need to check them properly, or else we'll sink our load_
> _So grab your `errors.As` and heave away with me_
> _We'll refactor all the `elf.FormatError`s on the count of three_

-->
