### PR TITLE
ci: Run `vmtests` before `go-build` tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,45 @@ jobs:
             ]
           skip_after_successful_duplicate: false
 
+  vmtest:
+    name: kernel tests
+    runs-on: ubuntu-latest
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: .go-version
+
+      - name: Set up Clang
+        uses: KyleMayes/install-llvm-action@f8f2154d96f018dcb600739c4978bfc35f435422 # v1.8.1
+        with:
+          version: "14"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt -y install qemu-system-x86 curl
+          sudo apt-get install -yq libelf-dev zlib1g-dev
+
+      - name: Initialize and update git submodules
+        run: git submodule init && git submodule update
+
+      - name: Build libbpf
+        run: make libbpf
+
+      - name: Build initramfs
+        run: |
+          go install "github.com/florianl/bluebox@${BLUEBOX_VERSION}"
+          make initramfs
+
+      - name: Run vmtests
+        run: ./kerneltest/vmtest.sh
+
   go-build-test:
     name: Go Build
     runs-on: ubuntu-latest
@@ -127,38 +166,3 @@ jobs:
 
       - name: Lint
         run: make go/lint
-
-      - name: Build initramfs
-        run: |
-          go install "github.com/florianl/bluebox@${BLUEBOX_VERSION}"
-          make initramfs
-
-      - name: Upload initramfs
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: initramfs
-          path: |
-            kerneltest/initramfs.cpio
-
-  vmtest:
-    name: kernel tests
-    runs-on: ubuntu-latest
-    needs: go-build-test
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt -y install qemu-system-x86 curl
-
-      - name: Download previously generated initramfs
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: initramfs
-          path: kerneltest/
-
-      - name: Run vmtests
-        run: ./kerneltest/vmtest.sh


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->
The issue explained clearly in the description: https://github.com/parca-dev/parca-agent/issues/1707

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
a) moved the `vmtests` job above `go-build-test`
b) removed the following steps entirely as they are not required now
- `Upload initramfs`
- `Download previously generated initramfs`


### How?


### Test Plan
<!-- How did you test it? How can we test it? -->
Tested in fork: https://github.com/Namanl2001/parca-agent/actions/runs/5424646940
GH action link: https://github.com/parca-dev/parca-agent/actions/runs/5426919153
<!--

copilot:poem

-->


cc: @javierhonduco @kakkoyun @Sylfrena 
