### PR TITLE
deploy/jsonnet: Make PSP optional

### DIFF
--- a/deploy/dev.jsonnet
+++ b/deploy/dev.jsonnet
@@ -32,6 +32,7 @@ function(serverVersion='v0.4.2')
     profilingCPUSamplingFrequency: 97,  // Better it to be a prime number.
     podMonitor: true,
     debuginfoUploadTimeout: '2m',
+    // podSecurityPolicy: true,
     // config: {
     //   relabel_configs: [
     //     {

--- a/deploy/e2e.jsonnet
+++ b/deploy/e2e.jsonnet
@@ -12,7 +12,7 @@ function(version='v0.0.1-alpha.3', serverVersion='v0.0.3-alpha.2')
     },
   };
 
-  local server = (import 'github.com/parca-dev/parca/deploy/lib/parca/parca.libsonnet')({
+  local server = (import 'parca/parca.libsonnet')({
     name: 'parca',
     namespace: ns.metadata.name,
     image: 'ghcr.io/parca-dev/parca:' + self.version,

--- a/deploy/jsonnetfile.lock.json
+++ b/deploy/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "deploy/lib/parca"
         }
       },
-      "version": "b0ecf6ca2c703eae92890dc9a70793983d52b00d",
-      "sum": "ZXNpGdPKzX/21aYERpHiy2ifa83P6Q6D3IRPmq/wWNw="
+      "version": "b1422a81d21c4b1adaa40e46bb03c531a4e5c1d9",
+      "sum": "UbLswOrUOs31ScvgTRgrN8SKi9ufqNZYeOwkbLOXiOQ="
     },
     {
       "source": {

--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -44,12 +44,16 @@ local defaults = {
 
   externalLabels:: {},
 
+  // Pod level security context.
   securityContext:: {
-    privileged: true,
-    readOnlyRootFilesystem: true,
+    runAsNonRoot: false,
+    seccompProfile: {
+      type: 'RuntimeDefault',
+    },
   },
 
   podMonitor: false,
+  podSecurityPolicy: false,
 };
 
 function(params) {
@@ -103,98 +107,6 @@ function(params) {
         apiGroups: [''],
         resources: ['nodes'],
         verbs: ['get'],
-      },
-    ],
-  },
-
-  podSecurityPolicy: {
-    apiVersion: 'policy/v1beta1',
-    kind: 'PodSecurityPolicy',
-    metadata: pa.metadata,
-    spec: {
-      allowPrivilegeEscalation: true,
-      allowedCapabilities: ['*'],
-      fsGroup: {
-        rule: 'RunAsAny',
-      },
-      runAsUser: {
-        rule: 'RunAsAny',
-      },
-      seLinux: {
-        rule: 'RunAsAny',
-      },
-      supplementalGroups: {
-        rule: 'RunAsAny',
-      },
-      privileged: true,
-      hostIPC: true,
-      hostNetwork: true,
-      hostPID: true,
-      readOnlyRootFilesystem: true,
-      volumes: [
-        'configMap',
-        'emptyDir',
-        'projected',
-        'secret',
-        'downwardAPI',
-        'persistentVolumeClaim',
-        'hostPath',
-      ],
-      allowedHostPaths+: [
-        {
-          pathPrefix: '/sys',
-        },
-        {
-          pathPrefix: '/boot',
-        },
-        {
-          pathPrefix: '/var/run/dbus',
-        },
-        {
-          pathPrefix: '/run',
-        },
-        {
-          pathPrefix: '/lib/modules',
-        },
-      ],
-    },
-  },
-
-  role: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'Role',
-    metadata: pa.metadata,
-    rules: [
-      {
-        apiGroups: [
-          'policy',
-        ],
-        resourceNames: [
-          pa.config.name,
-        ],
-        resources: [
-          'podsecuritypolicies',
-        ],
-        verbs: [
-          'use',
-        ],
-      },
-    ],
-  },
-
-  roleBinding: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'RoleBinding',
-    metadata: pa.metadata,
-    roleRef: {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'Role',
-      name: pa.role.metadata.name,
-    },
-    subjects: [
-      {
-        kind: 'ServiceAccount',
-        name: pa.serviceAccount.metadata.name,
       },
     ],
   },
@@ -283,7 +195,14 @@ function(params) {
           '--metadata-disable-caching',
         ] else []
       ),
-      securityContext: pa.config.securityContext,
+      // Container level security context.
+      securityContext: {
+        privileged: true,
+        allowPrivilegeEscalation: true,
+        capabilities: {
+          add: ['BPF', 'PERFMON'],  // SYS_ADMIN
+        },
+      },
       ports: [
         {
           name: 'http',
@@ -376,6 +295,7 @@ function(params) {
             containers: [c],
             hostPID: true,
             serviceAccountName: pa.serviceAccount.metadata.name,
+            securityContext: pa.config.securityContext,
             nodeSelector: {
               'kubernetes.io/os': 'linux',
             },
@@ -464,5 +384,97 @@ function(params) {
         matchLabels: pa.daemonSet.spec.template.metadata.labels,
       },
     },
+  },
+
+  [if std.objectHas(params, 'podSecurityPolicy') && params.podSecurityPolicy then 'podSecurityPolicy']: {
+    apiVersion: 'policy/v1',
+    kind: 'PodSecurityPolicy',
+    metadata: pa.metadata,
+    spec: {
+      allowPrivilegeEscalation: true,
+      allowedCapabilities: ['*'],
+      fsGroup: {
+        rule: 'RunAsAny',
+      },
+      runAsUser: {
+        rule: 'RunAsAny',
+      },
+      seLinux: {
+        rule: 'RunAsAny',
+      },
+      supplementalGroups: {
+        rule: 'RunAsAny',
+      },
+      privileged: true,
+      hostIPC: true,
+      hostNetwork: true,
+      hostPID: true,
+      readOnlyRootFilesystem: true,
+      volumes: [
+        'configMap',
+        'emptyDir',
+        'projected',
+        'secret',
+        'downwardAPI',
+        'persistentVolumeClaim',
+        'hostPath',
+      ],
+      allowedHostPaths+: [
+        {
+          pathPrefix: '/sys',
+        },
+        {
+          pathPrefix: '/boot',
+        },
+        {
+          pathPrefix: '/var/run/dbus',
+        },
+        {
+          pathPrefix: '/run',
+        },
+        {
+          pathPrefix: '/lib/modules',
+        },
+      ],
+    },
+  },
+
+  [if std.objectHas(params, 'podSecurityPolicy') && params.podSecurityPolicy then 'role']: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'Role',
+    metadata: pa.metadata,
+    rules: [
+      {
+        apiGroups: [
+          'policy',
+        ],
+        resourceNames: [
+          pa.config.name,
+        ],
+        resources: [
+          'podsecuritypolicies',
+        ],
+        verbs: [
+          'use',
+        ],
+      },
+    ],
+  },
+
+  [if std.objectHas(params, 'podSecurityPolicy') && params.podSecurityPolicy then 'roleBinding']: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'RoleBinding',
+    metadata: pa.metadata,
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Role',
+      name: pa.role.metadata.name,
+    },
+    subjects: [
+      {
+        kind: 'ServiceAccount',
+        name: pa.serviceAccount.metadata.name,
+      },
+    ],
   },
 }

--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -49,7 +49,7 @@ local defaults = {
     privileged: true,
     allowPrivilegeEscalation: true,
     capabilities: {
-      add: ['BPF', 'PERFMON'],  // SYS_ADMIN
+      add: ['SYS_ADMIN'],  // 'BPF', 'PERFMON'
     },
   },
 

--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -44,11 +44,12 @@ local defaults = {
 
   externalLabels:: {},
 
-  // Pod level security context.
-  securityContext:: {
-    runAsNonRoot: false,
-    seccompProfile: {
-      type: 'RuntimeDefault',
+  // Container level security context.
+  securityContext: {
+    privileged: true,
+    allowPrivilegeEscalation: true,
+    capabilities: {
+      add: ['BPF', 'PERFMON'],  // SYS_ADMIN
     },
   },
 
@@ -196,13 +197,7 @@ function(params) {
         ] else []
       ),
       // Container level security context.
-      securityContext: {
-        privileged: true,
-        allowPrivilegeEscalation: true,
-        capabilities: {
-          add: ['BPF', 'PERFMON'],  // SYS_ADMIN
-        },
-      },
+      securityContext: pa.config.securityContext,
       ports: [
         {
           name: 'http',
@@ -295,7 +290,12 @@ function(params) {
             containers: [c],
             hostPID: true,
             serviceAccountName: pa.serviceAccount.metadata.name,
-            securityContext: pa.config.securityContext,
+            // Pod level security context.
+            securityContext: {
+              seccompProfile: {
+                type: 'RuntimeDefault',
+              },
+            },
             nodeSelector: {
               'kubernetes.io/os': 'linux',
             },


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Make PSP optional and disable it by default `Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+`

For PSP:
- I have followed https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/ as much as possible.
- Also adds a namespace with admission control for development: https://kubernetes.io/docs/tutorials/security/cluster-level-pss/
- https://jamesdefabia.github.io/docs/user-guide/security-context/

For Capabilites:
- https://man7.org/linux/man-pages/man7/capabilities.7.html
- https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities

ref: https://github.com/parca-dev/parca/pull/3142
