### PR TITLE
build: Clean generated BPF object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,7 @@ clean: mostlyclean
 	-rm -f kerneltest/cpu.test
 	-rm -f kerneltest/logs/vm_log_*.txt
 	-rm -f kerneltest/kernels/linux-*.bz
+	-rm -rf pkg/profiler/cpu/bpf/
 
 # container:
 .PHONY: container


### PR DESCRIPTION
As the wrong arch will result in broken builds until these files are removed

Test Plan
=========

**before**

```
export ARCH=LOL
make
make clean
make
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="clang" CGO_CFLAGS="-I/home/javierhonduco/code/parca-agent/dist/libbpf/amd64/usr/include" CGO_LDFLAGS="-fuse-ld=ld -lzstd /home/javierhonduco/code/parca-agent/dist/libbpf/amd64/libbpf.a" go build  -tags osusergo,netgo -mod=readonly -trimpath -v --ldflags="-extldflags=-static" -o dist/parca-agent ./cmd/parca-agent
pkg/profiler/cpu/cpu.go:55:13: pattern bpf/*: cannot embed directory bpf/LOL: contains no embeddable files
```
