### PR TITLE
grpc/conn: Introduce exponential backoff retry with jitter for unary requests

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -207,17 +207,21 @@ jobs:
           [[ -n "$(podman image list --filter=reference=ghcr.io/parca-dev/parca-agent --quiet)" ]]
 
       - name: Install cosign
+        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
 
       - name: Login to registry
+        if: github.event_name != 'pull_request'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
           echo "${{ secrets.QUAY_PASSWORD }}" | cosign login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
 
       - name: Install crane
+        if: github.event_name != 'pull_request'
         uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
 
       - name: Push and sign container (when merged)
+        if: github.event_name != 'pull_request'
         run: |
           make push-container
           make sign-container

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -207,21 +207,17 @@ jobs:
           [[ -n "$(podman image list --filter=reference=ghcr.io/parca-dev/parca-agent --quiet)" ]]
 
       - name: Install cosign
-        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
 
       - name: Login to registry
-        if: github.event_name != 'pull_request'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u parca-dev --password-stdin ghcr.io
           echo "${{ secrets.QUAY_PASSWORD }}" | cosign login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
 
       - name: Install crane
-        if: github.event_name != 'pull_request'
         uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
 
       - name: Push and sign container (when merged)
-        if: github.event_name != 'pull_request'
         run: |
           make push-container
           make sign-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 ARG TARGETVARIANT
 
+RUN echo "Building for ${TARGETOS}/${TARGETARCH}/${TARGETVARIANT:-v1}"
+
 WORKDIR /app
 COPY goreleaser/dist dist
 
@@ -24,10 +26,10 @@ RUN chmod +x parca-agent
 FROM --platform="${TARGETPLATFORM:-linux/amd64}" gcr.io/distroless/static@sha256:7198a357ff3a8ef750b041324873960cf2153c11cc50abb9d8d5f8bb089f6b4e
 
 LABEL \
-  org.opencontainers.image.source="https://github.com/parca-dev/parca-agent" \
-  org.opencontainers.image.url="https://github.com/parca-dev/parca-agent" \
-  org.opencontainers.image.description="eBPF based always-on profiler auto-discovering targets in Kubernetes and systemd, zero code changes or restarts needed!" \
-  org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.source="https://github.com/parca-dev/parca-agent" \
+    org.opencontainers.image.url="https://github.com/parca-dev/parca-agent" \
+    org.opencontainers.image.description="eBPF based always-on profiler auto-discovering targets in Kubernetes and systemd, zero code changes or restarts needed!" \
+    org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --chown=0:0 --from=builder /app/parca-agent /bin/parca-agent
 COPY --chown=0:0 parca-agent.yaml /bin/parca-agent.yaml

--- a/Dockerfile.cross-builder
+++ b/Dockerfile.cross-builder
@@ -5,7 +5,8 @@ FROM --platform="${BUILDPLATFORM:-linux/amd64}" docker.io/goreleaser/goreleaser-
 # hadolint ignore=DL3008
 RUN apt-get update -y --no-install-recommends && \
     apt-get install -yq --no-install-recommends \
+        lld \
         libelf-dev zlib1g-dev libzstd-dev \
         libelf-dev:arm64 zlib1g-dev:arm64 libzstd-dev:arm64 \
-        lld \
+        pkg-config \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,7 +28,7 @@ RUN goreleaser build --clean --skip-validate --snapshot --debug --id parca-agent
 
 # NOTICE: See goreleaser.yml for the build paths.
 RUN mkdir -p /app && \
-   if [ "${TARGETARCH}" = 'amd64' ]; then \
+    if [ "${TARGETARCH}" = 'amd64' ]; then \
         cp "goreleaser/dist/parca-agent-${TARGETARCH}_${TARGETOS}_${TARGETARCH}_${TARGETVARIANT:-v1}/parca-agent" /app/ ; \
     elif [ "${TARGETARCH}" = 'arm' ]; then \
         cp "goreleaser/dist/parca-agent-${TARGETARCH}_${TARGETOS}_${TARGETARCH}_${TARGETVARIANT##v}/parca-agent" /app/ ; \

--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,6 @@ endef
 # test cross-compile release pipeline:
 .PHONY: release-dry-run
 release-dry-run: $(DOCKER_BUILDER) bpf libbpf
-	$(MAKE) ARCH=amd64 bpf && $(MAKE) ARCH=arm64 bpf
 	$(CMD_DOCKER) run \
 		--rm \
 		--privileged \
@@ -390,7 +389,6 @@ release-dry-run: $(DOCKER_BUILDER) bpf libbpf
 
 .PHONY: release-build
 release-build: $(DOCKER_BUILDER) bpf libbpf
-	$(MAKE) ARCH=amd64 bpf && $(MAKE) ARCH=arm64 bpf
 	$(CMD_DOCKER) run \
 		--rm \
 		--privileged \

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,8 @@ clean: mostlyclean
 	-rm -f kerneltest/logs/vm_log_*.txt
 	-rm -f kerneltest/kernels/linux-*.bz
 	-rm -rf pkg/profiler/cpu/bpf/
+	-rm -rf dist/
+	-rm -rf goreleaser/dist/
 
 # container:
 .PHONY: container
@@ -375,6 +377,7 @@ endef
 # test cross-compile release pipeline:
 .PHONY: release-dry-run
 release-dry-run: $(DOCKER_BUILDER) bpf libbpf
+	$(MAKE) ARCH=amd64 bpf && $(MAKE) ARCH=arm64 bpf
 	$(CMD_DOCKER) run \
 		--rm \
 		--privileged \
@@ -387,6 +390,7 @@ release-dry-run: $(DOCKER_BUILDER) bpf libbpf
 
 .PHONY: release-build
 release-build: $(DOCKER_BUILDER) bpf libbpf
+	$(MAKE) ARCH=amd64 bpf && $(MAKE) ARCH=arm64 bpf
 	$(CMD_DOCKER) run \
 		--rm \
 		--privileged \

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ Flags:
                                    10s.
       --remote-store-rpc-logging-enable
                                    Enable gRPC logging.
-      --remote-store-rpc-unary-timeout=1m
-                                   Timeout for unary gRPC requests.
+      --remote-store-rpc-unary-timeout=5m
+                                   Maximum timeout window for unary gRPC
+                                   requests including retries.
       --debuginfo-directories=/usr/lib/debug,...
                                    Ordered list of local directories to search
                                    for debuginfo files.

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -183,7 +183,7 @@ type FlagsRemoteStore struct {
 
 	BatchWriteInterval time.Duration `default:"10s"   help:"Interval between batch remote client writes. Leave this empty to use the default value of 10s."`
 	RPCLoggingEnable   bool          `default:"false" help:"Enable gRPC logging."`
-	RPCUnaryTimeout    time.Duration `default:"1m"    help:"Timeout for unary gRPC requests."`
+	RPCUnaryTimeout    time.Duration `default:"5m"    help:"Maximum timeout window for unary gRPC requests including retries."`
 }
 
 // FlagsDebuginfo contains flags to configure debuginfo.

--- a/pkg/grpc/conn.go
+++ b/pkg/grpc/conn.go
@@ -93,7 +93,18 @@ func Conn(logger log.Logger, reg prometheus.Registerer, tp trace.TracerProvider,
 		grpc.WithChainUnaryInterceptor(
 			timeout.UnaryClientInterceptor(unaryTimeout), // 5m by default.
 			retry.UnaryClientInterceptor(
-				retry.WithBackoff(retry.BackoffExponentialWithJitter(5*time.Second, 0.1)),
+				// Back-off with Jitter: scalar: 1s, jitterFraction: 0,1, 10 runs
+				// i: 1		t:969.91774ms		total:969.91774ms
+				// i: 2		t:1.914221005s		total:2.884138745s
+				// i: 3		t:3.788704363s		total:6.672843108s
+				// i: 4		t:8.285062088s		total:14.957905196s
+				// i: 5		t:14.480256611s		total:29.438161807s
+				// i: 6		t:32.586249789s		total:1m2.024411596s
+				// i: 7		t:1m6.755804584s	total:2m8.78021618s
+				// i: 8		t:2m3.116345957s	total:4m11.896562137s
+				// i: 9		t:4m3.895083732s	total:8m15.791645869s
+				// i: 10	t:9m19.350609671s	total:17m35.14225554s
+				retry.WithBackoff(retry.BackoffExponentialWithJitter(time.Second, 0.1)),
 				retry.WithMax(10),
 				// The passed in context has a `5m` timeout (see above), the whole invocation should finish within that time.
 				// However, by default all retried calls will use the parent context for their deadlines.


### PR DESCRIPTION
Extend maximum timeout per request

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Why?
When agent first start running it discovers all the binaries on the host and checks if the debuginfo exists on the server using grpc unary requests.
This could create thundering herd problem and makes most of the requests to timeout. With this PR, we attempt to exponentially backoff with a maximum timeout value.
This should ease out the context cancellation RPC errors.

This is not a huge problem because debuginfo uploads are eventually consistent. However, the logs could create false alarms.

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ddb451</samp>

Added gRPC retry logic and increased timeout for parca-agent. This improves the reliability and performance of profile data transmission from the `parca-agent` to the `parca` server.

### How?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ddb451</samp>

* Increase the maximum timeout window for unary gRPC requests from 1 minute to 5 minutes ([link](https://github.com/parca-dev/parca-agent/pull/1826/files?diff=unified&w=0#diff-57833d176ed681886b67a7fa2e4dc2f68d5e00cb1db269e7854fb3dafb45f54eL186-R186))
* Import the retry package to enable gRPC retry logic for the parca-agent ([link](https://github.com/parca-dev/parca-agent/pull/1826/files?diff=unified&w=0#diff-9da81253369258488eba5d4542b624d7a307f23184ee5205fd37f4cd8ced68a1R25))
* Add the retry.UnaryClientInterceptor to the chain of unary gRPC interceptors for the parca-agent ([link](https://github.com/parca-dev/parca-agent/pull/1826/files?diff=unified&w=0#diff-9da81253369258488eba5d4542b624d7a307f23184ee5205fd37f4cd8ced68a1L93-R103))

### Test Plan
1. Test on local cluster
