### PR TITLE
cmd/parca-agent: Bind debug endpoint to localhost only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Flags:
       --log-level="info"           Log level.
       --log-format="logfmt"        Configure if structured logging as JSON or as
                                    logfmt
-      --http-address=":7071"       Address to bind HTTP server to.
+      --http-address="127.0.0.1:7071"
+                                   Address to bind HTTP server to.
       --version                    Show application version.
       --node="hostname"           The name of the node that the process is
                                    running on. If on Kubernetes, this must match

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -109,7 +109,7 @@ const (
 
 type flags struct {
 	Log         FlagsLogs `embed:""                         prefix:"log-"`
-	HTTPAddress string    `default:":7071"                  help:"Address to bind HTTP server to."`
+	HTTPAddress string    `default:"127.0.0.1:7071"         help:"Address to bind HTTP server to."`
 	Version     bool      `help:"Show application version."`
 
 	Node               string `default:"${hostname}"               help:"The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name."`


### PR DESCRIPTION
Fixes https://github.com/parca-dev/parca-agent/issues/1854