### PR TITLE
pkg/cpu: Reduce .text section error spam

### DIFF
--- a/pkg/buildid/elf.go
+++ b/pkg/buildid/elf.go
@@ -26,6 +26,8 @@ import (
 
 const goBuildIDSectionName = ".note.go.buildid"
 
+var ErrTextSectionNotFound = errors.New("could not find .text section")
+
 // FromELF returns the build ID for an ELF binary.
 func FromELF(ef *elf.File) (string, error) {
 	// First, try fast methods.
@@ -63,7 +65,7 @@ func buildid(ef *elf.File) (string, error) {
 	// If we didn't find a GNU build ID, try hashing the .text section.
 	text := ef.Section(".text")
 	if text == nil {
-		return "", errors.New("could not find .text section")
+		return "", ErrTextSectionNotFound
 	}
 	h := xxhash.New()
 	if _, err := io.Copy(h, text.Open()); err != nil {


### PR DESCRIPTION
Fixes #1857

### Why?
User report that logs are being spammed with 

```
level=error name=parca-agent ts=2023-07-13T16:16:20.242517888Z caller=cpu.go:308 component=cpu_profiler msg="failed to add unwind table" pid=1890187 err="setUnwindTableForMapping for executable /root/.julia/artifacts/37805a06093bdc0d5938601719cf02fa0cf3aa68/lib/rr/librrpage.so starting at 0x6fffd000 failed: BuildID failed /proc/1890187/root/root/.julia/artifacts/37805a06093bdc0d5938601719cf02fa0cf3aa68/lib/rr/librrpage.so: could not find .text section"
```

in #1857

### What?
Add a counter to keep track of said error and only logs it once every 50 times we hit the error case to reduce spamming the logs in default logging mode.
 
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 502844c</samp>

> _We search for the text in the maps of the dead_
> _But sometimes we find nothing but `ErrTextSectionNotFound`_
> _We track the errors and we log the doom_
> _We need the unwind tables to escape the CPU's tomb_

-->
