### PR TITLE
Add govulncheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,6 @@ on:
       - release-*
 
 env:
-  # renovate: datasource=go depName=mvdan.cc/gofumpt
-  GOFUMPT_VERSION: v0.5.0
-  # renovate: datasource=go depName=github.com/golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: v1.53.3
   # renovate: datasource=go depName=github.com/florianl/bluebox
   BLUEBOX_VERSION: v0.0.1
 
@@ -100,6 +96,10 @@ jobs:
         with:
           go-version-file: .go-version
 
+      # Installs gofumpt, golangci-lint, and govulncheck.
+      - name: Set up environment
+        run: ./env.sh
+
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
         with:
@@ -110,9 +110,6 @@ jobs:
           clang -v
           ld --version
           ld.lld --version
-
-      - name: Set up gofumpt
-        run: go install "mvdan.cc/gofumpt@${GOFUMPT_VERSION}"
 
       - name: Install clang-format
         run: sudo apt-get install clang-format
@@ -127,6 +124,9 @@ jobs:
 
       - name: Initialize and update git submodules
         run: git submodule init && git submodule update
+
+      - name: Install Go dependencies
+        run: make go/deps
 
       - name: Build libbpf
         run: make libbpf
@@ -147,6 +147,12 @@ jobs:
           go env
           echo $PATH
 
+      - name: Format
+        run: make format-check
+
+      - name: Lint
+        run: make go/lint
+
       - name: Test
         # Some of the GH action CI machines have several versions of Go installed.
         # Make sometimes somehow resolves different Go. We need to specify explicitly.
@@ -157,15 +163,3 @@ jobs:
 
       - name: Test unwind tables
         run: make test-dwarf-unwind-tables
-
-      - name: Format
-        run: make format-check
-
-      - name: Install golangci-lint
-        run: go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
-
-      - name: Lint
-        run: make go/lint
-
-      - name: golang-govulncheck-action
-        uses: golang/govulncheck-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,12 @@ name: Build
 on:
   push:
     branches:
-    - main
-    - release-*
+      - main
+      - release-*
   pull_request:
     branches:
-    - main
-    - release-*
+      - main
+      - release-*
 
 env:
   # renovate: datasource=go depName=mvdan.cc/gofumpt
@@ -106,7 +106,7 @@ jobs:
           version: "14"
 
       - name: clang version
-        run:  |
+        run: |
           clang -v
           ld --version
           ld.lld --version
@@ -166,3 +166,6 @@ jobs:
 
       - name: Lint
         run: make go/lint
+
+      - name: golang-govulncheck-action
+        uses: golang/govulncheck-action@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,14 +14,14 @@ name: "CodeQL"
 on:
   push:
     branches:
-    - main
-    - release-*
+      - main
+      - release-*
   pull_request:
     branches:
-    - main
-    - release-*
+      - main
+      - release-*
   schedule:
-    - cron: '28 16 * * 3'
+    - cron: "28 16 * * 3"
 
 jobs:
   analyze:
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
@@ -82,6 +82,9 @@ jobs:
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
+
+      - name: Set up environment
+        run: ./env.sh
 
       - run: make build
 

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,12 @@ test-dwarf-unwind-tables: write-dwarf-unwind-tables
 	$(CMD_GIT) diff --exit-code testdata/
 
 .PHONY: go/deps
-go/deps:
+go/deps: $(GO_SRC)
 	$(GO) mod tidy
+
+.PHONY: go/deps-check
+go/deps-check: go/deps
+	$(GO_ENV) CGO_CFLAGS="$(CGO_CFLAGS_DYN)" CGO_LDFLAGS="$(CGO_LDFLAGS_DYN)" govulncheck ./...
 
 # bpf build:
 .PHONY: bpf
@@ -192,7 +196,7 @@ check-license:
 	./scripts/check-license.sh
 
 .PHONY: go/lint
-go/lint:
+go/lint: go/deps-check
 	mkdir -p $(OUT_BPF_DIR)
 	touch $(OUT_BPF)
 	$(GO_ENV) $(CGO_ENV) golangci-lint run

--- a/env.sh
+++ b/env.sh
@@ -29,3 +29,7 @@ go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_
 # renovate: datasource=go depName=github.com/florianl/bluebox
 BLUEBOX_VERSION='v0.0.1'
 go install "github.com/florianl/bluebox@${BLUEBOX_VERSION}"
+
+# renovate: datasource=go depName=golang.org/x/vuln
+GOVULNCHECK_VERSION='v1.0.0'
+go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Govulncheck provides a low-noise, reliable way for Go users to learn about known vulnerabilities that may affect their dependencies. 

See details on Go's support for vulnerability management:
https://go.dev/blog/govulncheck
https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
https://github.com/marketplace/actions/golang-govulncheck-action
