### PR TITLE
deploy: Remove liveness and readiness probes

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -204,12 +204,6 @@ function(params) {
           containerPort: pa.config.port,
         },
       ],
-      livenessProbe: {
-        httpGet: {
-          path: '/healthy',
-          port: 'http',
-        },
-      },
       readinessProbe: {
         httpGet: {
           path: '/ready',


### PR DESCRIPTION
Parca-Agent no longer listens on all interfaces by default, therefore this doesn't work anymore.
