### PR TITLE
pkg/profiler/cpu: Fix noop due to value struct

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -629,7 +629,11 @@ func (p *CPU) Run(ctx context.Context) error {
 				}
 				continue
 			}
-			data.RawSamples = append(data.RawSamples, perThreadRawData.RawSamples...)
+
+			groupedRawData[pid] = profile.ProcessRawData{
+				PID:        perThreadRawData.PID,
+				RawSamples: append(data.RawSamples, perThreadRawData.RawSamples...),
+			}
 		}
 
 		processLastErrors := map[int]error{}


### PR DESCRIPTION
This caused any process to only report on a single thread per profile cycle, which resulted in incorrect profiling data.

### Test

Main (only single thread stack traces per profile) :

![CleanShot_2023-07-20_at_09 55 21](https://github.com/parca-dev/parca-agent/assets/536449/8ea317d2-981f-4d7e-b137-b1c4ed3acf83)

![CleanShot_2023-07-20_at_09 55 44](https://github.com/parca-dev/parca-agent/assets/536449/a8e9aa03-ffe7-4ecd-b975-d1dd8d3804b3)

Patch (multiple thread stack traces per profile):


![CleanShot_2023-07-20_at_09 57 42](https://github.com/parca-dev/parca-agent/assets/536449/d9be5b5c-efaf-401a-b001-a3e5abed4c5b)
![CleanShot_2023-07-20_at_09 57 29](https://github.com/parca-dev/parca-agent/assets/536449/2b1617f3-dbb0-4846-8d47-2e94164bb3a7)
