### PR TITLE
deploy: Remove liveness probe

### DIFF
--- a/deploy/lib/parca-agent/parca-agent.libsonnet
+++ b/deploy/lib/parca-agent/parca-agent.libsonnet
@@ -204,12 +204,6 @@ function(params) {
           containerPort: pa.config.port,
         },
       ],
-      livenessProbe: {
-        httpGet: {
-          path: '/healthy',
-          port: 'http',
-        },
-      },
       readinessProbe: {
         httpGet: {
           path: '/ready',


### PR DESCRIPTION
Liveness probes are dangerous: https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html

