### PR TITLE
pkg/convert: reduce allocation

### DIFF
--- a/pkg/convert/jfr.go
+++ b/pkg/convert/jfr.go
@@ -294,7 +294,7 @@ func (b *builder) parseArgs(s string) string {
 			}
 			s = s[i:]
 		}
-		result = "(" + strings.Join(b.args, ",") + ")"
+		result = "(" + strings.Join(b.args, ", ") + ")"
 		b.argCache[k] = result
 	}
 	return result

--- a/pkg/convert/jfr.go
+++ b/pkg/convert/jfr.go
@@ -104,11 +104,11 @@ type label struct {
 	value string
 }
 
-func (b *builder) getPid(JavaThreadID int64) string {
-	result, ok := b.pidCache[JavaThreadID]
+func (b *builder) getPid(javaThreadID int64) string {
+	result, ok := b.pidCache[javaThreadID]
 	if !ok {
-		result = strconv.Itoa(int(JavaThreadID))
-		b.pidCache[JavaThreadID] = result
+		result = strconv.Itoa(int(javaThreadID))
+		b.pidCache[javaThreadID] = result
 	}
 	return result
 }
@@ -131,9 +131,9 @@ func (b *builder) getOrCreateSample(st *parser.StackTrace, thread *parser.Thread
 	for _, l := range labels {
 		b.locationKeys = append(b.locationKeys, l.value)
 	}
-	JavaThreadID := b.getPid(thread.JavaThreadID)
+	javaThreadID := b.getPid(thread.JavaThreadID)
 	javaName := thread.JavaName
-	b.locationKeys = append(b.locationKeys, BytesToString(b.locationIDBuf), JavaThreadID, javaName)
+	b.locationKeys = append(b.locationKeys, BytesToString(b.locationIDBuf), javaThreadID, javaName)
 
 	b.b.Reset()
 	for _, locationKey := range b.locationKeys {
@@ -153,7 +153,7 @@ func (b *builder) getOrCreateSample(st *parser.StackTrace, thread *parser.Thread
 			Label:    make(map[string][]string, len(labels)+2),
 		}
 
-		s.Label["java_thread_id"] = []string{JavaThreadID}
+		s.Label["java_thread_id"] = []string{javaThreadID}
 		s.Label["java_name"] = []string{javaName}
 		for _, l := range labels {
 			s.Label[l.key] = []string{l.value}

--- a/pkg/convert/jfr_test.go
+++ b/pkg/convert/jfr_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/pyroscope-io/jfr-parser/parser"
 )
 
 func TestJFRtoPprof(t *testing.T) {
@@ -50,8 +52,9 @@ func TestGetFileName(t *testing.T) {
 			"org/springframework/aop/framework/CglibAopProxy.java",
 		},
 	}
+	var b = newBuilder()
 	for _, test := range tests {
-		result := getFileName(test.input)
+		result := b.getFileName(test.input)
 		require.Equal(t, test.expected, result)
 	}
 }
@@ -106,8 +109,25 @@ func TestParseArgs(t *testing.T) {
 			expected: "(String[], String, ClassLoader)",
 		},
 	}
+	var b = newBuilder()
 	for _, testCase := range testCases {
-		got := parseArgs(testCase.in)
+		got := b.parseArgs(testCase.in)
 		require.Equal(t, testCase.expected, got)
+	}
+}
+
+func BenchmarkChunksToPprof(b *testing.B) {
+	f, err := os.Open("./testdata/prof.jfr")
+	if err != nil {
+		b.Error(err)
+	}
+	chunks, _ := parser.Parse(f)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err = chunksToPprof(chunks)
+		if err != nil {
+			b.Error(err)
+		}
 	}
 }

--- a/pkg/convert/jfr_test.go
+++ b/pkg/convert/jfr_test.go
@@ -52,7 +52,7 @@ func TestGetFileName(t *testing.T) {
 			"org/springframework/aop/framework/CglibAopProxy.java",
 		},
 	}
-	var b = newBuilder()
+	b := newBuilder()
 	for _, test := range tests {
 		result := b.getFileName(test.input)
 		require.Equal(t, test.expected, result)
@@ -109,7 +109,7 @@ func TestParseArgs(t *testing.T) {
 			expected: "(String[], String, ClassLoader)",
 		},
 	}
-	var b = newBuilder()
+	b := newBuilder()
 	for _, testCase := range testCases {
 		got := b.parseArgs(testCase.in)
 		require.Equal(t, testCase.expected, got)

--- a/pkg/convert/jfr_test.go
+++ b/pkg/convert/jfr_test.go
@@ -31,7 +31,7 @@ func TestJFRtoPprof(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(p.SampleType))
-	require.Equal(t, 248, len(p.Sample))
+	require.Equal(t, 260, len(p.Sample))
 }
 
 func TestGetFileName(t *testing.T) {


### PR DESCRIPTION
### Why?
in my company, the jfr to pprof allocate too much times of objects, and those cost most of cpu.
this is the allocation memory profile of my parca-agent:
![image](https://github.com/parca-dev/parca-agent/assets/52686065/5547cd77-4be0-47a9-a6d9-e7628237a9ad)


### What?
this pr reduce 99% percent of memory allocation and reduce 80% of cpu cost in jfr to pprof.
![image](https://github.com/parca-dev/parca-agent/assets/52686065/f6f860ce-ee0c-4c09-a94c-ebe4c95b050c)


### How?
1, cache parseArgs and getFileName and getPid and dimensions.
2, reuse slice as more as we can.
3, use bytes.buffer to build function key, and use unsafe string in map search to avoid memory allocation.
4, use unsafe string sample key in map search, only create locations when new sample created.
5, use uint64 as location key to avoid int to string convert.