### PR TITLE
pkg/mapping: Add more patterns for mappings not to open

### DIFF
--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -266,7 +266,9 @@ func doesReferToFile(path string) bool {
 	return path != "" &&
 		path != "jit" &&
 		!strings.HasPrefix(path, "[") &&
-		!strings.HasPrefix(path, "anon_inode:[")
+		!strings.HasPrefix(path, "anon_inode:[") &&
+		!strings.Contains(path, "(deleted)") &&
+		!strings.Contains(path, "memfd:")
 	// NOTICE: Add more patterns when needed.
 }
 


### PR DESCRIPTION
These patterns are already used to prevent main binaries from being opened, but were forgotten for other object files of mappings.
