### PR TITLE
pkg/runtime: Prevent allocations from searching symbol tables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/parca-dev/parca-agent
 go 1.20
 
 require (
+	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.31.0-20230726221845-41588ce133c8.1
 	github.com/alecthomas/kong v0.8.0
 	github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0
 	github.com/cenkalti/backoff/v4 v4.2.1
@@ -36,7 +37,6 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/xyproto/ainur v1.3.3-0.20230327065817-db855584e31b
 	github.com/zcalusic/sysinfo v1.0.1
-	go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.9
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
@@ -62,6 +62,7 @@ require (
 )
 
 require (
+	buf.build/gen/go/gogo/protobuf/protocolbuffers/go v1.31.0-20210810001428-4df00b267f94.1 // indirect
 	cloud.google.com/go v0.110.4 // indirect
 	cloud.google.com/go/compute v1.22.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -154,7 +155,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.40 // indirect
 	github.com/thanos-io/objstore v0.0.0-20230522103316-23ebe2eacadd // indirect
-	go.buf.build/protocolbuffers/go/gogo/protobuf v1.3.9 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+buf.build/gen/go/gogo/protobuf/protocolbuffers/go v1.31.0-20210810001428-4df00b267f94.1 h1:IpfoSUtXcmtXmL672yCeHx96evE7Z4AyWo8R2lVBU3o=
+buf.build/gen/go/gogo/protobuf/protocolbuffers/go v1.31.0-20210810001428-4df00b267f94.1/go.mod h1:Az9fvKFYQGtiDa7cPW9T3Nbw8u3hpmD6wG15RsbQlA0=
+buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.31.0-20230726221845-41588ce133c8.1 h1:mRyuf+GC3pVl1ZT99Gil177yCFqkXq0F+fJMD3duLXE=
+buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.31.0-20230726221845-41588ce133c8.1/go.mod h1:iqW5nSujn3ZJ9ISZQX3K/uWwjckAp8hz0J4/wNgFBZo=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -539,10 +543,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zcalusic/sysinfo v1.0.1 h1:cVh8q3codjh43AGRTa54dJ2Zq+qPejv8n2VWpxKViwc=
 github.com/zcalusic/sysinfo v1.0.1/go.mod h1:LxwKwtQdbTIQc65drhjQzYzt0o7jfB80LrrZm7SWn8o=
-go.buf.build/protocolbuffers/go/gogo/protobuf v1.3.9 h1:Gem1ArgYzrhdAuaORVqtvkT4WGPRiwFLXpTgRn+QLC8=
-go.buf.build/protocolbuffers/go/gogo/protobuf v1.3.9/go.mod h1:i2gBbO3BPCoVRjhpYl5wkyH+sQ8aZyE+ELx44rJm2/E=
-go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.9 h1:rvgxIDVC6JD6uoKKWwEdPi/Dkxwm+0nq6iSKpOeiuDA=
-go.buf.build/protocolbuffers/go/prometheus/prometheus v1.3.9/go.mod h1:MscLIBPVmRlS3Z4XijKkiqzOiBQaRFi1PqWt7KAzf9o=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -803,7 +803,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -19,10 +19,10 @@ import (
 	"strconv"
 	"time"
 
+	prometheus "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/zcalusic/sysinfo"
-	"go.buf.build/protocolbuffers/go/prometheus/prometheus"
 )
 
 type AnalyticsSender struct {

--- a/pkg/analytics/remote_write.go
+++ b/pkg/analytics/remote_write.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"time"
 
+	prometheus "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"go.buf.build/protocolbuffers/go/prometheus/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/pkg/runtime/elf_symbols.go
+++ b/pkg/runtime/elf_symbols.go
@@ -1,0 +1,76 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"bytes"
+	"debug/elf"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/xyproto/ainur"
+)
+
+// ForEachElfSymbolNameInSymbols iterates over the symbols in the symbol table
+// of the given elf file. It calls the given function for each symbol name. The
+// value is only valid for the iteration, it must not be saved unless copied.
+func IsSymbolNameInSymbols(f *elf.File, matches [][]byte) (bool, error) {
+	return isSymbolNameInSection(f, elf.SHT_SYMTAB, matches)
+}
+
+// ForEachElfSymbolNameInSymbols iterates over the symbols in the dynamic
+// symbol table of the given elf file. It calls the given function for each
+// symbol name. The value is only valid for the iteration, it must not be saved
+// unless copied.
+func IsSymbolNameInDynamicSymbols(f *elf.File, matches [][]byte) (bool, error) {
+	return isSymbolNameInSection(f, elf.SHT_DYNSYM, matches)
+}
+
+func isSymbolNameInSection(f *elf.File, t elf.SectionType, matches [][]byte) (bool, error) {
+	symtabSection := f.SectionByType(t)
+	if symtabSection == nil {
+		return false, elf.ErrNoSymbols
+	}
+
+	if symtabSection.Link <= 0 || symtabSection.Link >= uint32(len(f.Sections)) {
+		return false, errors.New("section has invalid string table link")
+	}
+
+	s := f.Sections[symtabSection.Link].Open()
+
+	sr, err := ainur.NewStreamReader(s, 8192)
+	if err != nil {
+		return false, fmt.Errorf("create stream reader: %w", err)
+	}
+
+	for {
+		b, err := sr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return false, fmt.Errorf("read next: %w", err)
+		}
+
+		// Look for the DMD marker
+		for _, match := range matches {
+			if bytes.Contains(b, match) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/runtime/v8.go
+++ b/pkg/runtime/v8.go
@@ -1,0 +1,38 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"debug/elf"
+	"errors"
+	"fmt"
+)
+
+var v8IdentifyingSymbols = [][]byte{
+	[]byte("InterpreterEntryTrampoline"),
+}
+
+// HACK: This is a somewhat a brittle check.
+func IsV8(f *elf.File) (bool, error) {
+	var (
+		isV8 bool
+		err  error
+	)
+
+	if isV8, err = IsSymbolNameInSymbols(f, v8IdentifyingSymbols); err != nil && !errors.Is(err, elf.ErrNoSymbols) {
+		return isV8, fmt.Errorf("search symbols: %w", err)
+	}
+
+	return isV8, nil
+}


### PR DESCRIPTION


### Why?
Before this patch searching symbol tables allocated a lot of memory in one allocation which caused heap to spike dramatically at the start.

### What? / How?

Same strategy as in https://github.com/xyproto/ainur/pull/5

Remove big bulk allocation. 

### Test Plan

Haven't tested other than compiling.