### PR TITLE
pkg/convert: fix locations

### DIFF
--- a/pkg/convert/jfr.go
+++ b/pkg/convert/jfr.go
@@ -239,7 +239,7 @@ func (b *builder) getFileName(s string) string {
 			s = s[:i]
 		}
 		res = s + ".java"
-		b.classNameCache[k] = s
+		b.classNameCache[k] = res
 	}
 	return res
 }


### PR DESCRIPTION
### Why?
have a bug in create sample locations.

### What?
it is not correct to range over []byte to get location id.

### How?
add field locations and reuse it, deep copy when create new sample.
