### PR TITLE
feat(snap): add config option for remote store token

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -47,3 +47,9 @@ remote_store_insecure="$(snapctl get remote-store-insecure)"
 if [[ -z "$remote_store_insecure" ]]; then
     snapctl set remote-store-insecure=false
 fi
+
+# Set the bearer token for the remote store
+remote_store_token="$(snapctl get remote-store-bearer-token)"
+if [[ -z "$remote_store_token" ]]; then
+    snapctl set remote-store-bearer-token=""
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -39,7 +39,7 @@ fi
 # gRPC address to send profiles and symbols to.
 remote_store="$(snapctl get remote-store-address)"
 if [[ -z "$remote_store" ]]; then
-    snapctl set remote-store-address="localhost:7070"
+    snapctl set remote-store-address="grpc.polarsignals.com:443"
 fi
 
 # Send gRPC requests via plaintext instead of TLS

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -24,6 +24,7 @@ node="$(snapctl get node)"
 http_address="$(snapctl get http-address)"
 store="$(snapctl get remote-store-address)"
 insecure="$(snapctl get remote-store-insecure)"
+token="$(snapctl get remote-store-bearer-token)"
 
 # Start building an array of command line options
 opts=(
@@ -33,6 +34,11 @@ opts=(
     "--remote-store-address=${store}"
     "--remote-store-insecure=${insecure}"
 )
+
+# If the token has been changed from empty, append it to the command line args
+if [[ -n "${token}" ]]; then
+    opts+=("--remote-store-bearer-token=${token}")
+fi
 
 # Run parca-agent with the gathered arguments
 exec "${SNAP}/parca-agent" "${opts[@]}"


### PR DESCRIPTION
### What / Why?
Add a config option to the Parca Agent snap to simplify the onboarding of agents to Parca Cloud.

This change introduces a new snap config option named `remote-store-bearer-token`, and changes the default store address to `grpc.polarsignals.com:443`. The change to default store address will only affect new installs.

### How?

```
sudo snap install --classic parca-agent
sudo snap set parca-agent remote-store-bearer-token=<token>
sudo snap start parca-agent
``` 

### Test Plan
- Download the snap artefact from the CI pipeline and install with `sudo snap install --classic --dangerous ./<path-to-snap`
- Generate a new Parca Cloud token
- Run `sudo snap set parca-agent remote-store-bearer-token=<token>`
- Run `sudo snap start parca-agent`
- Verify that profiles are arriving on Parca Cloud.

/cc: @brancz 