### PR TITLE
added VDSO unit tests

### DIFF
--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -133,7 +133,7 @@ func (mm *MapManager) MappingsForPID(pid int) (Mappings, error) {
 	res := make([]*Mapping, 0, len(maps))
 	var errs error
 	for _, m := range maps {
-		mapping, err := mm.newUserMapping(m, pid)
+		mapping, err := mm.NewUserMapping(m, pid)
 		if err != nil {
 			var elfErr *elf.FormatError
 			if errors.As(err, &elfErr) {
@@ -195,7 +195,7 @@ type Mapping struct {
 }
 
 // newUserMapping makes sure the mapped file is open and computes the kernel offset.
-func (mm *MapManager) newUserMapping(pm *procfs.ProcMap, pid int) (*Mapping, error) {
+func (mm *MapManager) NewUserMapping(pm *procfs.ProcMap, pid int) (*Mapping, error) {
 	m := &Mapping{
 		mm:      mm,
 		ProcMap: pm,

--- a/pkg/process/maps_test.go
+++ b/pkg/process/maps_test.go
@@ -191,7 +191,7 @@ func TestELFObjAddr(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m, err := mm.newUserMapping(
+			m, err := mm.NewUserMapping(
 				&procfs.ProcMap{
 					StartAddr: uintptr(tc.start),
 					EndAddr:   uintptr(tc.limit),
@@ -264,7 +264,7 @@ func TestELFObjAddrNoPIE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := mm.newUserMapping(
+	m, err := mm.NewUserMapping(
 		&procfs.ProcMap{
 			StartAddr: mappingStart,
 			EndAddr:   mappingLimit,
@@ -353,7 +353,7 @@ func TestELFObjAddrPIE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := mm.newUserMapping(
+	m, err := mm.NewUserMapping(
 		&procfs.ProcMap{
 			StartAddr: mappingStart,
 			EndAddr:   mappingLimit,

--- a/pkg/vdso/vdso_test.go
+++ b/pkg/vdso/vdso_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdso
+
+import (
+	"debug/elf"
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/parca-dev/parca/pkg/symbol/symbolsearcher"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca-agent/pkg/objectfile"
+	"github.com/parca-dev/parca-agent/pkg/process"
+)
+
+func TestCache_Resolve(t *testing.T) {
+	symbols := []elf.Symbol{
+		{
+			Name:    "clock_gettime@@LINUX_2.6",
+			Value:   uint64(0x5400000),
+			Size:    1389,
+			Info:    byte(elf.STT_FUNC),
+			Section: 13,
+		},
+		{
+			Name:    "__vdso_gettimeofday@@LINUX_2.6",
+			Value:   uint64(0x5402000),
+			Size:    734,
+			Info:    byte(elf.STT_FUNC),
+			Section: 13,
+		},
+	}
+
+	cache := &Cache{
+		searcher: symbolsearcher.New(symbols),
+		metrics:  newMetrics(prometheus.NewRegistry()),
+	}
+
+	fs, err := procfs.NewDefaultFS()
+	require.NoError(t, err, "Expected no error")
+
+	ofp := objectfile.NewPool(log.NewNopLogger(), prometheus.NewRegistry(), 10, 1)
+	mm := process.NewMapManager(prometheus.NewRegistry(), fs, ofp, false)
+	m, err := mm.NewUserMapping(&procfs.ProcMap{}, os.Getpid())
+	require.NoError(t, err, "Expected no error")
+
+	// addr is smaller than the smallest symbol's value, symbol not found
+	addr := uint64(0x2000000)
+	symbol, err := cache.Resolve(m, addr)
+	require.Error(t, err, "Expected an error for symbol not found")
+	require.Empty(t, symbol, "Expected empty symbol")
+
+	// addr in range, check symbol with value just less than addr
+	addr = uint64(0x5401000)
+	symbol, err = cache.Resolve(m, addr)
+	require.NoError(t, err, "Expected no error")
+	require.Equal(t, "clock_gettime@@LINUX_2.6", symbol, "Expected symbol 'clock_gettime@@LINUX_2.6'")
+
+	// addr is larger than the largest symbol's value, check for symbol with largest value
+	addr = uint64(0x6000000)
+	symbol, err = cache.Resolve(m, addr)
+	require.NoError(t, err, "Expected no error")
+	require.Equal(t, "__vdso_gettimeofday@@LINUX_2.6", symbol, "Expected symbol '__vdso_gettimeofday@@LINUX_2.6'")
+}


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

Fixes #1559 

Added tests for `Resolve()` for addresses in and out of the defined range

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at badbf70</samp>

Exported `NewUserMapping` method from `MapManager` and added tests for `vdso` package. The changes enable symbol resolution from the vdso library, which is used by the Linux kernel to provide fast system calls. The tests verify the correctness of the `Cache` struct, which implements the `SymbolResolver` interface for the vdso library.

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at badbf70</samp>

*  Rename `newUserMapping` method to `NewUserMapping` to export it and allow other packages to use it ([link](https://github.com/parca-dev/parca-agent/pull/1916/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL136-R136), [link](https://github.com/parca-dev/parca-agent/pull/1916/files?diff=unified&w=0#diff-531c87f587fd53526fd4780bd78b14affdc797b4687500fc66cfea88f929957dL198-R198))
* Update test functions in `maps_test.go` to use the renamed `NewUserMapping` method instead of the unexported `newUserMapping` method ([link](https://github.com/parca-dev/parca-agent/pull/1916/files?diff=unified&w=0#diff-2fbc63cb8ebb2eae13c9bd2ff211fe4abf8a4a939fe97b804012f013d9a1a6eaL194-R194), [link](https://github.com/parca-dev/parca-agent/pull/1916/files?diff=unified&w=0#diff-2fbc63cb8ebb2eae13c9bd2ff211fe4abf8a4a939fe97b804012f013d9a1a6eaL267-R267), [link](https://github.com/parca-dev/parca-agent/pull/1916/files?diff=unified&w=0#diff-2fbc63cb8ebb2eae13c9bd2ff211fe4abf8a4a939fe97b804012f013d9a1a6eaL356-R356))
* Add a new test file `vdso_test.go` to test the `Cache` struct, which resolves symbols from the vdso library using the `MapManager` ([link](https://github.com/parca-dev/parca-agent/pull/1916/files?diff=unified&w=0#diff-fc7a95967d110e1d23d2023d4b2f909497404f31a4e392a3c19556e31d9a2062R1-R78))

### Test Plan
<!-- How did you test it? How can we test it? -->

<!--

copilot:poem

-->
