### PR TITLE
Add initial Ruby support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,8 +159,6 @@ jobs:
         # Make sometimes somehow resolves different Go. We need to specify explicitly.
         run: make GO=`which go` test ENABLE_RACE=yes
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Integration tests
         run: make GO=`which go` test/integration
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ BPF_ROOT := bpf
 BPF_SRC := $(BPF_ROOT)/cpu/cpu.bpf.c
 OUT_BPF_DIR := pkg/profiler/cpu/bpf/$(ARCH)
 OUT_BPF := $(OUT_BPF_DIR)/cpu.bpf.o
+OUT_RBPERF := $(OUT_BPF_DIR)/rbperf.bpf.o
 
 # CGO build flags:
 PKG_CONFIG ?= pkg-config
@@ -158,6 +159,7 @@ $(OUT_BPF): $(BPF_SRC) libbpf | $(OUT_DIR)
 	mkdir -p $(OUT_BPF_DIR)
 	$(MAKE) -C bpf build
 	cp bpf/out/$(ARCH)/cpu.bpf.o $(OUT_BPF)
+	cp bpf/out/$(ARCH)/rbperf.bpf.o $(OUT_RBPERF)
 else
 $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@)

--- a/bpf/.clang-format
+++ b/bpf/.clang-format
@@ -4,3 +4,4 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 ColumnLimit: 160
 AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: false

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -31,6 +31,7 @@ OUT_DIR ?= ../dist
 OUT_BPF_BASE_DIR := out
 OUT_BPF_DIR := $(OUT_BPF_BASE_DIR)/$(ARCH)
 OUT_BPF := $(OUT_BPF_DIR)/cpu.bpf.o
+OUT_RBPERF := $(OUT_BPF_DIR)/rbperf.bpf.o
 BPF_BUNDLE := $(OUT_DIR)/parca-agent.bpf.tar.gz
 
 # input:
@@ -38,11 +39,12 @@ LIBBPF_HEADERS := $(OUT_DIR)/libbpf/$(ARCH)/usr/include
 
 VMLINUX_INCLUDE_PATH := $(SHORT_ARCH)
 BPF_SRC := cpu/cpu.bpf.c
+RBPERF_SRC := cpu/rbperf.bpf.c
 BPF_INCLUDES := cpu/
 
 # tasks:
 .PHONY: clang
-clang: $(OUT_BPF)
+clang: $(OUT_BPF) $(OUT_RBPERF)
 
 bpf_bundle_dir := $(OUT_DIR)/parca-agent.bpf
 $(BPF_BUNDLE): $(BPF_SRC) $(LIBBPF_HEADERS)/bpf $(BPF_HEADERS)
@@ -50,6 +52,38 @@ $(BPF_BUNDLE): $(BPF_SRC) $(LIBBPF_HEADERS)/bpf $(BPF_HEADERS)
 	cp $$(find $^ -type f) $(bpf_bundle_dir)
 
 $(OUT_BPF): $(BPF_SRC) $(LIBBPF_HEADERS) $(BPF_HEADERS) | $(OUT_DIR)
+	mkdir -p $(OUT_BPF_DIR)
+	$(CMD_CC) -S \
+		-D__BPF_TRACING__ \
+		-D__KERNEL__ \
+		-D__TARGET_ARCH_$(SHORT_ARCH) \
+		-I $(VMLINUX_INCLUDE_PATH) \
+		-I $(LIBBPF_HEADERS) \
+		-I $(BPF_INCLUDES) \
+		-Wno-address-of-packed-member \
+		-Wno-compare-distinct-pointer-types \
+		-Wno-deprecated-declarations \
+		-Wno-gnu-variable-sized-type-not-at-end \
+		-Wno-pointer-sign \
+		-Wno-pragma-once-outside-header \
+		-Wno-unknown-warning-option \
+		-Wno-unused-value \
+		-Wdate-time \
+		-Wunused \
+		-Wall \
+		-fno-stack-protector \
+		-fno-jump-tables \
+		-fno-unwind-tables \
+		-fno-asynchronous-unwind-tables \
+		-xc \
+		-nostdinc \
+		-target bpf \
+		-O2 -emit-llvm -c -g $< -o $(@:.o=.ll)
+	$(CMD_LLC) -march=bpf -filetype=obj -o $@ $(@:.o=.ll)
+	rm $(@:.o=.ll)
+
+
+$(OUT_RBPERF): $(RBPERF_SRC) $(LIBBPF_HEADERS) $(BPF_HEADERS) | $(OUT_DIR)
 	mkdir -p $(OUT_BPF_DIR)
 	$(CMD_CC) -S \
 		-D__BPF_TRACING__ \

--- a/bpf/cpu/basic_types.h
+++ b/bpf/cpu/basic_types.h
@@ -1,0 +1,17 @@
+typedef signed char __s8;
+typedef unsigned char __u8;
+typedef short int __s16;
+typedef short unsigned int __u16;
+typedef int __s32;
+typedef unsigned int __u32;
+typedef long long int __s64;
+typedef long long unsigned int __u64;
+
+typedef __s8 s8;
+typedef __u8 u8;
+typedef __s16 s16;
+typedef __u16 u16;
+typedef __s32 s32;
+typedef __u32 u32;
+typedef __s64 s64;
+typedef __u64 u64;

--- a/bpf/cpu/common.h
+++ b/bpf/cpu/common.h
@@ -16,3 +16,17 @@
 #define EFAULT 14
 #define EEXIST 17
 #endif
+
+
+#ifndef __AGENT_STACK_TRACE_DEFINITION__
+#define __AGENT_STACK_TRACE_DEFINITION__
+
+#include "basic_types.h"
+#define MAX_STACK_DEPTH 127
+
+typedef struct {
+  u64 len;
+  u64 addresses[MAX_STACK_DEPTH];
+} stack_trace_t;
+
+#endif

--- a/bpf/cpu/rbperf.bpf.c
+++ b/bpf/cpu/rbperf.bpf.c
@@ -1,0 +1,436 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Copyright (c) 2022 The rbperf authors
+
+#include "rbperf.h"
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "hash.h"
+#include "shared.h"
+
+/* struct {
+    // This map's type is a placeholder, it's dynamically set
+    // in rbperf.rs to either perf/ring buffer depending on
+    // the configuration.
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+} events SEC(".maps"); */
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(max_entries, 3);
+    __type(key, u32);
+    __type(value, u32);
+} programs SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 4096);
+    __type(key, u32);
+    __type(value, ProcessData);
+} pid_to_rb_thread SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 64000);
+    __type(key, RubyFrame);
+    __type(value, u32);
+} frame_table SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 12);
+    __type(key, u32);
+    __type(value, RubyVersionOffsets);
+} version_specific_offsets SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, u64);
+} frame_index_storage SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, SampleState);
+} global_state SEC(".maps");
+
+const volatile bool verbose = false;
+const volatile int num_cpus = 200; // Hard-limit of 200 CPUs.
+const volatile bool use_ringbuf = false;
+const volatile bool enable_pid_race_detector = false;
+const volatile enum rbperf_event_type event_type = RBPERF_EVENT_UNKNOWN;
+
+#define LOG(fmt, ...)                       \
+    ({                                      \
+        if (verbose) {                      \
+            bpf_printk(fmt, ##__VA_ARGS__); \
+        }                                   \
+    })
+
+static inline_method int read_syscall_id(void *ctx, int *syscall_id) {
+    return bpf_probe_read_kernel(syscall_id, SYSCALL_NR_SIZE, ctx + SYSCALL_NR_OFFSET);
+}
+
+static inline_method u32 find_or_insert_frame(RubyFrame *frame) {
+    u32 *found_id = bpf_map_lookup_elem(&frame_table, frame);
+    if (found_id != NULL) {
+        return *found_id;
+    }
+
+    u32 zero = 0;
+    u64 *frame_index = bpf_map_lookup_elem(&frame_index_storage, &zero);
+    // Appease the verifier, this will never fail.
+    if (frame_index == NULL) {
+        return 0;
+    }
+
+    // The previous __sync_fetch_and_add does not seem to work in 5.4 and 5.10
+    //  > libbpf: prog 'walk_ruby_stack': -- BEGIN PROG LOAD LOG --\nBPF_STX uses reserved fields
+    //
+    // Checking for the version does not work as these branches are not pruned
+    // in older kernels, so we shard the id generation per CPU.
+    u64 idx = *frame_index * num_cpus + bpf_get_smp_processor_id();
+    *frame_index += 1;
+
+    int err;
+    err = bpf_map_update_elem(&frame_table, frame, &idx, BPF_ANY);
+    if (err) {
+        LOG("[error] frame_table failed with %d", err);
+    }
+    return idx;
+}
+
+static inline_method void read_ruby_string(RubyVersionOffsets *version_offsets, u64 label, char *buffer,
+                                           int buffer_len) {
+    u64 flags;
+    u64 char_ptr;
+
+    rbperf_read(&flags, 8, (void *)(label + 0 /* .basic */ + 0 /* .flags */));
+
+    if (STRING_ON_HEAP(flags)) {
+        rbperf_read(&char_ptr, 8,
+                    (void *)(label + as_offset + 8 /* .long len */));
+        int err = rbperf_read_str(buffer, buffer_len, (void *)(char_ptr));
+        if (err < 0) {
+            LOG("[warn] string @ 0x%llx [heap] failed with err=%d", char_ptr, err);
+        }
+    } else {
+        u64 c_string_address = label + as_offset;
+        if (version_offsets->major_version == 3 && version_offsets->minor_version >= 2) {
+            // Account for Variable Width Allocation https://bugs.ruby-lang.org/issues/18239.
+            c_string_address += sizeof(long);
+        }
+        int err = rbperf_read_str(buffer, buffer_len, (void *)(c_string_address));
+        if (err < 0) {
+            LOG("[warn] string @ 0x%llx [stack] failed with err=%d", c_string_address, err);
+        }
+    }
+}
+
+static inline_method int
+read_ruby_lineno(u64 pc, u64 body, RubyVersionOffsets *version_offsets) {
+    // This will only give accurate line number for Ruby 2.4
+
+    u64 pos_addr;
+    u64 pos;
+    u64 info_table;
+    u32 line_info_size;
+    u32 lineno;
+
+    // Native functions have 0 as pc
+    if (pc == 0) {
+        return 0;
+    }
+
+    rbperf_read(&pos_addr, 8, (void *)(pc - body + iseq_encoded_offset));
+    rbperf_read(&pos, 8, (void *)pos_addr);
+    rbperf_read(
+        &info_table, 8,
+        (void *)(body + version_offsets->line_info_table_offset));
+
+    if (pos != 0) {
+        pos -= rb_value_sizeof;
+    }
+
+    rbperf_read(&line_info_size, 4,
+                (void *)(body + version_offsets->line_info_size_offset));
+    if (line_info_size == 0) {
+        return 0;
+    } else if (line_info_size == 1) {
+        rbperf_read(&lineno, 4, (void *)(info_table + (0) * 0x8 + version_offsets->lineno_offset));
+        return lineno;
+    } else {
+        // Note: this is not fully correct as we don't implement get_insn_info_linear_search or
+        // get_insn_info_succinct_bitvector. Line numbers might be biased.
+        // See https://github.com/ruby/ruby/blob/7b2306a3ab2a7d33c5c5c8ac248447349874b258/.gdbinit#L1015
+        rbperf_read(&lineno, 4, (void *)(info_table + (line_info_size - 1) * 0x8 + version_offsets->lineno_offset));
+        return lineno;
+    }
+}
+
+static inline_method void
+read_frame(u64 pc, u64 body, RubyFrame *current_frame,
+           RubyVersionOffsets *version_offsets) {
+    u64 path_addr;
+    u64 path;
+    u64 label;
+    u64 flags;
+    int label_offset = version_offsets->label_offset;
+
+    LOG("[debug] reading stack");
+
+    rbperf_read(&path_addr, 8,
+                (void *)(body + ruby_location_offset + path_offset));
+    rbperf_read(&flags, 8, (void *)path_addr);
+    if ((flags & RUBY_T_MASK) == RUBY_T_STRING) {
+        path = path_addr;
+    } else if ((flags & RUBY_T_MASK) == RUBY_T_ARRAY) {
+        if (version_offsets->path_flavour == 1) {
+            // sizeof(struct RBasic)
+            path_addr = path_addr + 0x10 /* offset(..., as) */ + PATH_TYPE_OFFSET;
+            rbperf_read(&path, 8, (void *)path_addr);
+        } else {
+            path = path_addr;
+        }
+
+    } else {
+        LOG("[error] read_frame, wrong type");
+        // Skip as we don't have the data types we were looking for
+        return;
+    }
+
+    rbperf_read(&label, 8,
+                (void *)(body + ruby_location_offset + label_offset));
+
+    read_ruby_string(version_offsets, path, current_frame->path, sizeof(current_frame->path));
+    current_frame->lineno = read_ruby_lineno(pc, body, version_offsets);
+    read_ruby_string(version_offsets, label, current_frame->method_name,
+                     sizeof(current_frame->method_name));
+
+    LOG("[debug] method name=%s", current_frame->method_name);
+}
+
+SEC("perf_event")
+int walk_ruby_stack(struct bpf_perf_event_data *ctx) {
+    u64 iseq_addr;
+    u64 pc;
+    u64 pc_addr;
+    u64 body;
+
+    int zero = 0;
+    SampleState *state = bpf_map_lookup_elem(&global_state, &zero);
+    if (state == NULL) {
+        return 0;  // this should never happen
+    }
+
+    RubyVersionOffsets *version_offsets = bpf_map_lookup_elem(&version_specific_offsets, &state->rb_version);
+    if (version_offsets == NULL) {
+        return 0;  // this should not happen
+    }
+
+    RubyFrame current_frame = {};
+    u64 base_stack = state->base_stack;
+    u64 cfp = state->cfp;
+    state->ruby_stack_program_count += 1;
+    u64 control_frame_t_sizeof = version_offsets->control_frame_t_sizeof;
+
+#pragma unroll
+    for (int i = 0; i < MAX_STACKS_PER_PROGRAM; i++) {
+        rbperf_read(&iseq_addr, 8, (void *)(cfp + iseq_offset));
+        rbperf_read(&pc_addr, 8, (void *)(cfp + 0));
+        rbperf_read(&pc, 8, (void *)pc_addr);
+
+        if (cfp > state->base_stack) {
+            LOG("[debug] done reading stack");
+            break;
+        }
+
+        if ((void *)iseq_addr == NULL) {
+            // this could be a native frame, it's missing the check though
+            // https://github.com/ruby/ruby/blob/4ff3f20/.gdbinit#L1155
+            // TODO(javierhonduco): Fetch path for native stacks
+            bpf_probe_read_kernel_str(current_frame.method_name, sizeof(NATIVE_METHOD_NAME), NATIVE_METHOD_NAME);
+            bpf_probe_read_kernel_str(current_frame.path, sizeof(NATIVE_METHOD_PATH), NATIVE_METHOD_PATH);
+        } else {
+            rbperf_read(&body, 8, (void *)(iseq_addr + body_offset));
+            read_frame(pc, body, &current_frame, version_offsets);
+        }
+
+        long long int actual_index = state->stack.frames.len;
+        if (actual_index >= 0 && actual_index < MAX_STACK_DEPTH) {
+            state->stack.frames.addresses[actual_index] = find_or_insert_frame(&current_frame);
+            state->stack.frames.len += 1;
+        }
+
+        cfp += control_frame_t_sizeof;
+    }
+
+    state->cfp = cfp;
+    state->base_stack = base_stack;
+
+    if (cfp <= base_stack &&
+        state->ruby_stack_program_count < BPF_PROGRAMS_COUNT) {
+        LOG("[debug] traversing next chunk of the stack in a tail call");
+        bpf_tail_call(ctx, &programs, RBPERF_STACK_READING_PROGRAM_IDX);
+    }
+
+    state->stack.stack_status = cfp > state->base_stack ? STACK_COMPLETE : STACK_INCOMPLETE;
+
+    if (state->stack.frames.len != state->stack.expected_size) {
+        LOG("[error] stack size %d, expected %d", state->stack.frames.len, state->stack.expected_size);
+    }
+
+    // Hash stack.
+    int ruby_stack_hash = MurmurHash2((u32 *)state->stack.frames.addresses, MAX_STACK * sizeof(u64) / sizeof(u32), 0);
+    LOG("[debug] ruby stack hash: %d", ruby_stack_hash);
+
+    unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero);
+    if (unwind_state != NULL) {
+        unwind_state->stack_key.interpreter_stack_id = ruby_stack_hash;
+    }
+
+    // Insert stack.
+    int err = bpf_map_update_elem(&interpreter_stack_traces, &ruby_stack_hash, &state->stack.frames, BPF_ANY);
+    if (err != 0) {
+      LOG("[error] bpf_map_update_elem with ret: %d", err);
+    }
+
+    // We are done.
+    aggregate_stacks();
+    return 0;
+}
+
+SEC("perf_event")
+int unwind_ruby_stack(struct bpf_perf_event_data *ctx) {
+    u64 zero = 0;
+    unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero);
+    if (unwind_state == NULL) {
+        bpf_printk("[rbperf] unwind_state is NULL, should not happen");
+        return 1;
+    }
+    // bpf_printk("[rbperf] unwind_state->len = %d", unwind_state->stack.len);
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    // There's no point in checking for the swapper process.
+    if (pid == 0) {
+        return 0;
+    }
+
+    ProcessData *process_data = bpf_map_lookup_elem(&pid_to_rb_thread, &pid);
+
+    if (process_data != NULL && process_data->rb_frame_addr != 0) {
+        struct task_struct *task = (void *)bpf_get_current_task();
+        if (task == NULL) {
+            LOG("[error] task_struct was NULL");
+            return 0;
+        }
+
+        // PIDs in Linux are reused. To ensure that the process we are
+        // profiling is the one we expect, we check the pid + start_time
+        // of the process.
+        //
+        // When we start profiling, the start_time will be zero, so we set
+        // it to the actual start time. Otherwise, we check that the start_time
+        // of the process matches what we expect. If it's not the case, bail out
+        // early, to avoid profiling the wrong process.
+        if (enable_pid_race_detector) {
+            u64 process_start_time;
+            bpf_core_read(&process_start_time, 8, &task->start_time);
+
+            if (process_data->start_time == 0) {
+                // First time seeing this process
+                process_data->start_time = process_start_time;
+            } else {
+                // Let's check that the start time matches what we saw before
+                if (process_data->start_time != process_start_time) {
+                    LOG("[error] the process has probably changed...");
+                    return 0;
+                }
+            }
+        }
+
+        u64 ruby_current_thread_addr;
+        u64 main_thread_addr;
+        u64 ec_addr;
+        u64 thread_stack_content;
+        u64 thread_stack_size;
+        u64 cfp;
+        int control_frame_t_sizeof;
+        RubyVersionOffsets *version_offsets = bpf_map_lookup_elem(&version_specific_offsets, &process_data->rb_version);
+
+        if (version_offsets == NULL) {
+            LOG("[error] can't find offsets for version");
+            return 0;
+        }
+
+        rbperf_read(&ruby_current_thread_addr, 8,
+                    (void *)process_data->rb_frame_addr);
+
+        LOG("process_data->rb_frame_addr 0x%llx", process_data->rb_frame_addr);
+        LOG("ruby_current_thread_addr 0x%llx", ruby_current_thread_addr);
+
+        // Find the main thread and the ec
+        rbperf_read(&main_thread_addr, 8,
+                    (void *)ruby_current_thread_addr + version_offsets->main_thread_offset);
+        rbperf_read(&ec_addr, 8, (void *)main_thread_addr + version_offsets->ec_offset);
+
+        control_frame_t_sizeof = version_offsets->control_frame_t_sizeof;
+
+        rbperf_read(
+            &thread_stack_content, 8,
+            (void *)(ec_addr + version_offsets->vm_offset));
+        rbperf_read(
+            &thread_stack_size, 8,
+            (void *)(ec_addr + version_offsets->vm_size_offset));
+
+        u64 base_stack = thread_stack_content +
+                         rb_value_sizeof * thread_stack_size -
+                         2 * control_frame_t_sizeof /* skip dummy frames */;
+        rbperf_read(&cfp, 8, (void *)(ec_addr + version_offsets->cfp_offset));
+        int zero = 0;
+        SampleState *state = bpf_map_lookup_elem(&global_state, &zero);
+        if (state == NULL) {
+            return 0;  // this should never happen
+        }
+
+        // Set the global state, shared across bpf tail calls
+        state->stack.timestamp = bpf_ktime_get_ns();
+        state->stack.pid = pid;
+        state->stack.cpu = bpf_get_smp_processor_id();
+        if (event_type == RBPERF_EVENT_SYSCALL) {
+            read_syscall_id(ctx, &state->stack.syscall_id);
+        } else {
+            state->stack.syscall_id = 0;
+        }
+        state->stack.frames.len = 0;
+        state->stack.expected_size = (base_stack - cfp) / control_frame_t_sizeof;
+        bpf_get_current_comm(state->stack.comm, sizeof(state->stack.comm));
+        state->stack.stack_status = STACK_COMPLETE;
+
+        state->base_stack = base_stack;
+        state->cfp = cfp + version_offsets->control_frame_t_sizeof;
+        state->ruby_stack_program_count = 0;
+        state->rb_version = process_data->rb_version;
+
+        bpf_tail_call(ctx, &programs, RBPERF_STACK_READING_PROGRAM_IDX);
+        // This will never be executed
+        LOG("[error] after bpf_tail_call, this should not be reached");
+        return 0;
+    } else {
+        bpf_printk("[error] not a ruby proc");
+    }
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual MIT/GPL";

--- a/bpf/cpu/rbperf.h
+++ b/bpf/cpu/rbperf.h
@@ -1,0 +1,121 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Copyright (c) 2022 The rbperf authors
+
+#include "basic_types.h"
+#include "common.h"
+
+#define COMM_MAXLEN 25
+#define METHOD_MAXLEN 50
+#define PATH_MAXLEN 150
+
+#define MAX_STACKS_PER_PROGRAM 30
+#define BPF_PROGRAMS_COUNT 25
+#define MAX_STACK (MAX_STACKS_PER_PROGRAM * BPF_PROGRAMS_COUNT)
+#define RBPERF_STACK_READING_PROGRAM_IDX 0
+
+#define rbperf_read bpf_probe_read_user
+#define rbperf_read_str bpf_probe_read_user_str
+
+#ifdef USE_ABSOLUTE_PATH
+// TODO(javierhonduco): Add test for this
+#define PATH_TYPE_OFFSET 0x8  // ABSOLUTE_PATH_OFFSET
+#else
+#define PATH_TYPE_OFFSET 0x0  // RELATIVE_PATH_OFFSET
+#endif
+
+#define rb_value_sizeof 0x8  // sizeof(VALUE)
+
+#define iseq_offset 0x10      // offsetof(rb_control_frame_t, iseq)
+#define body_offset 0x10      // offsetof(struct rb_iseq_struct, body)
+#define ruby_location_offset 0x40  // offsetof(struct rb_iseq_constant_body, location)
+#define path_offset 0x0       // offsetof(struct rb_iseq_location_struct, path)
+#define iseq_encoded_offset \
+    0x8  // offsetof(struct rb_iseq_constant_body, iseq_encoded)
+
+#define as_offset 0x10
+
+#define STRING_ON_HEAP(flags) flags &(1 << 13)
+#define inline_method inline __attribute__((__always_inline__))
+
+// CRuby constants, from
+// https://github.com/ruby/ruby/blob/4ff3f20/include/ruby/3/value_type.h
+#define RUBY_T_MASK 0x1f
+#define RUBY_T_STRING 0x05
+#define RUBY_T_ARRAY 0x07
+
+// Offset and size for the the syscall number field in x86 [1]. Would be
+// best to fetch this offset from the machine where rbperf runs, but should
+// be the same offset for all the syscalls even across architectures.
+//
+// - [1] /sys/kernel/debug/tracing/events/syscalls/*/format
+#define SYSCALL_NR_OFFSET 8
+#define SYSCALL_NR_SIZE 4
+
+static char NATIVE_METHOD_NAME[] = "<native code>";
+static char NATIVE_METHOD_PATH[] = "<unknown>";
+
+enum ruby_stack_status {
+    STACK_COMPLETE = 0,
+    STACK_INCOMPLETE = 1,
+};
+
+enum rbperf_event_type {
+    RBPERF_EVENT_UNKNOWN = 0,
+    RBPERF_EVENT_ON_CPU_SAMPLING = 1,
+    RBPERF_EVENT_SYSCALL = 2,
+};
+
+typedef struct {
+    u32 lineno;
+    char method_name[METHOD_MAXLEN];
+    char path[PATH_MAXLEN];
+} RubyFrame;
+
+typedef struct {
+    u64 timestamp;
+    stack_trace_t frames;
+
+    u32 pid;
+    u32 cpu;
+    // Only set when tracing syscalls.
+    int syscall_id;
+    // long long int size;
+    long long int expected_size;
+    char comm[COMM_MAXLEN];
+    enum ruby_stack_status stack_status;
+} RubyStack;
+
+typedef struct {
+    RubyStack stack;
+    u64 base_stack;
+    u64 cfp;
+    int ruby_stack_program_count;
+    int rb_version;
+} SampleState;
+
+typedef struct {
+    u64 rb_frame_addr;
+    u32 rb_version;
+    u64 start_time;
+} ProcessData;
+
+typedef struct {
+    int major_version;
+    int minor_version;
+    int patch_version;
+    int vm_offset;
+    int vm_size_offset;
+    int control_frame_t_sizeof;
+    int cfp_offset;
+    int label_offset;
+    int path_flavour;
+    int line_info_size_offset;
+    int line_info_table_offset;
+    int lineno_offset;
+    int main_thread_offset;
+    int ec_offset;
+} RubyVersionOffsets;

--- a/bpf/cpu/shared.h
+++ b/bpf/cpu/shared.h
@@ -1,0 +1,85 @@
+
+#include "common.h"
+
+// This file contains shared structures, BPF maps, and other helpers
+// that every unwinder uses.
+
+// Number of items in the stack counts aggregation map.
+#define MAX_STACK_COUNTS_ENTRIES 10240
+// A different stack produced the same hash.
+#define STACK_COLLISION(err) (err == -EEXIST)
+
+typedef struct {
+  int pid;
+  int tgid;
+  int user_stack_id;
+  int kernel_stack_id;
+  int user_stack_id_dwarf_id;
+  int interpreter_stack_id;
+} stack_count_key_t;
+
+typedef struct {
+  u64 ip;
+  u64 sp;
+  u64 bp;
+  u32 tail_calls;
+  stack_trace_t stack;
+  bool unwinding_jit; // set to true during JITed unwinding; false unless mixed-mode unwinding is enabled
+
+  u64 interpreter_type;
+  stack_count_key_t stack_key;
+} unwind_state_t;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, 1);
+  __type(key, u32);
+  __type(value, unwind_state_t);
+} heap SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
+  __type(key, stack_count_key_t);
+  __type(value, u64);
+} stack_counts SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
+  __type(key, int);
+  __type(value, stack_trace_t);
+} interpreter_stack_traces SEC(".maps"); // TODO think about this.
+
+
+static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *key, const void *init) {
+  void *val;
+  long err;
+
+  val = bpf_map_lookup_elem(map, key);
+  if (val) {
+    return val;
+  }
+
+  err = bpf_map_update_elem(map, key, init, BPF_NOEXIST);
+  if (err && !STACK_COLLISION(err)) {
+    bpf_printk("[error] bpf_map_lookup_or_try_init with ret: %d", err);
+    return 0;
+  }
+
+  return bpf_map_lookup_elem(map, key);
+}
+
+// To be called once we are completely done walking stacks and we are ready to
+// aggregate them in the 'counts' map and end the execution of the BPF program(s).
+#define aggregate_stacks() \
+({ \
+  u64 zero = 0; \
+  unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero); \
+  if (unwind_state != NULL) { \
+    u64 *scount = bpf_map_lookup_or_try_init(&stack_counts, &unwind_state->stack_key, &zero); \
+    if (scount) { \
+        __sync_fetch_and_add(scount, 1); \
+    } \
+  } \
+})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.31.0-20230726221845-41588ce133c8.1
 	github.com/alecthomas/kong v0.8.0
-	github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0
+	github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0.0.20230817212518-21cf435d454e
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cilium/ebpf v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v13 v13.0.0-20230820205410-6357c9f2419d h1:qkzYYjz8XpLTY7N//pPlkFB9hOgiTLfNUEHuLEu7RfY=
 github.com/apache/arrow/go/v13 v13.0.0-20230820205410-6357c9f2419d/go.mod h1:W69eByFNO0ZR30q1/7Sr9d83zcVZmF2MiP3fFYAWJOc=
-github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0 h1:pk9L7I6wF1nTfO42+jjXhA8ozRjvtj2ZvHV/i/YC0dE=
-github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
+github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0.0.20230817212518-21cf435d454e h1:IwbtZSdyDxqUhIdu7R3OazVr+oHJetwrQzyaVcppFf0=
+github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0.0.20230817212518-21cf435d454e/go.mod h1:0rEApF1YBHGuZ4C8OYI9q5oDBVpgqtRqYATePl9mCDk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -26,7 +26,11 @@ type RawSample struct {
 	TID         PID
 	UserStack   []uint64
 	KernelStack []uint64
-	Value       uint64
+	// The interpreter stack is formed of the ids we need to fetch
+	// from the corresponding BPF map in order to fetch the interpreter
+	// frame.
+	InterpreterStack []uint64
+	Value            uint64
 }
 
 type RawData []ProcessRawData

--- a/pkg/profiler/cpu/bpf_metrics_collector.go
+++ b/pkg/profiler/cpu/bpf_metrics_collector.go
@@ -56,7 +56,7 @@ func (c *bpfMetricsCollector) getBPFMetrics() []*bpfMetrics {
 			continue
 		}
 
-		bpfMaxEntry := float64(bpfMap.GetMaxEntries())
+		bpfMaxEntry := float64(bpfMap.MaxEntries())
 		bpfMapKeySize := float64(bpfMap.KeySize())
 		bpfMapValueSize := float64(bpfMap.ValueSize())
 		bpfMapFd := fmt.Sprint(bpfMap.FileDescriptor())
@@ -100,7 +100,7 @@ func (c *bpfMetricsCollector) readCounters() (unwinderStats, error) {
 
 	valuesBytes := make([]byte, sizeOfUnwinderStats*numCpus)
 	key := uint32(0)
-	if err := statsMap.GetValueReadInto(unsafe.Pointer(&key), &valuesBytes); err != nil {
+	if err := statsMap.GetValueReadInto(unsafe.Pointer(&key), &valuesBytes); err != nil { // nolint:staticcheck
 		return unwinderStats{}, fmt.Errorf("get count values: %w", err)
 	}
 

--- a/pkg/profiler/cpu/cpu_test.go
+++ b/pkg/profiler/cpu/cpu_test.go
@@ -86,10 +86,10 @@ func hasBatchOperations(t *testing.T) bool {
 	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
-	keys := make([]stackCountKey, bpfMap.GetMaxEntries())
+	keys := make([]stackCountKey, bpfMap.MaxEntries())
 	countKeysPtr := unsafe.Pointer(&keys[0])
 	nextCountKey := uintptr(1)
-	batchSize := bpfMap.GetMaxEntries()
+	batchSize := bpfMap.MaxEntries()
 	_, err = bpfMap.GetValueAndDeleteBatch(countKeysPtr, nil, unsafe.Pointer(&nextCountKey), batchSize)
 
 	return err == nil
@@ -106,10 +106,10 @@ func TestGetValueAndDeleteBatchWithEmptyMap(t *testing.T) {
 	bpfMap, err := m.GetMap(stackCountsMapName)
 	require.NoError(t, err)
 
-	keys := make([]stackCountKey, bpfMap.GetMaxEntries())
+	keys := make([]stackCountKey, bpfMap.MaxEntries())
 	countKeysPtr := unsafe.Pointer(&keys[0])
 	nextCountKey := uintptr(1)
-	batchSize := bpfMap.GetMaxEntries()
+	batchSize := bpfMap.MaxEntries()
 	values, err := bpfMap.GetValueAndDeleteBatch(countKeysPtr, nil, unsafe.Pointer(&nextCountKey), batchSize)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(values))
@@ -134,10 +134,10 @@ func TestGetValueAndDeleteBatchFewerElementsThanCount(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request more elements than we have, this should return and delete everything.
-	keys := make([]stackCountKey, bpfMap.GetMaxEntries())
+	keys := make([]stackCountKey, bpfMap.MaxEntries())
 	countKeysPtr := unsafe.Pointer(&keys[0])
 	nextCountKey := uintptr(1)
-	batchSize := bpfMap.GetMaxEntries()
+	batchSize := bpfMap.MaxEntries()
 	values, err := bpfMap.GetValueAndDeleteBatch(countKeysPtr, nil, unsafe.Pointer(&nextCountKey), batchSize)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(values))

--- a/pkg/rbperf/headers.go
+++ b/pkg/rbperf/headers.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: unused
+package rbperf
+
+type (
+	s8  = int8
+	u8  = uint8
+	s16 = int16
+	u16 = uint16
+	s32 = int32
+	u32 = uint32
+	s64 = int64
+	u64 = uint64
+)
+
+type RubyFrame struct {
+	Lineno     u32
+	MethodName [50]uint8
+	Path       [150]uint8
+}
+
+type ProcessData struct {
+	RbFrameAddr u64
+	RbVersion   u32
+	Padding_    [4]byte
+	StartTime   u64
+}
+
+type RubyVersionOffsets struct {
+	MajorVersion        int32
+	MinorVersion        int32
+	PatchVersion        int32
+	VMOffset            int32
+	VMSizeOffset        int32
+	ControlFrameSizeof  int32
+	CfpOffset           int32
+	LabelOffset         int32
+	PathFlavour         int32
+	LineInfoSizeOffset  int32
+	LineInfoTableOffset int32
+	LinenoOffset        int32
+	MainThreadOffset    int32
+	EcOffset            int32
+}

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -186,7 +186,7 @@ func symbolizeProfile(t *testing.T, profile *pprofprofile.Profile, demangle bool
 			address := frame.Address
 			file := frame.Mapping.File
 
-			if file == "jit" || strings.HasPrefix(file, "[") {
+			if file == "jit" || strings.HasPrefix(file, "[") || file == "interpreter" {
 				continue
 			}
 


### PR DESCRIPTION
This commit adds initial Ruby support by integrating rbperf's unwinder
and adapting it to this Agent.

There is more work to do, but in the spirit of keeping this commit a bit
more contained, right now:
- only Ruby 3.0.4 is supported;
- no focus on efficiency;
- missing clean-ups (such as clearing the interpreter stack maps);
- the Ruby stack is fetched even if the Ruby thread is sleeping as long
  as the native stack is on-CPU. This shows up confusingly as the Ruby stack in
many native stacks that aren't actually running the Ruby code;
- there are no integration tests, this will change soon;

All the shortcomings above, and then some, will be addressed in
forthcoming commits.

Architecture
============

The current BPF unwinding architecture as well as the changes that this
commit makes can be seen here: https://excalidraw.com/#json=E-W6lSLZ8rTOcri7HZdAl,4AjIUmb-olsQkdbwCqyxqg

![image](https://github.com/parca-dev/parca-agent/assets/959128/1438c7ab-3c33-4b9f-9c63-6542f35d87dc)


Test Plan
=========

All current tests pass + running https://github.com/javierhonduco/rbperf/blob/main/tests/programs/simple_two_stacks.rb


![image](https://github.com/parca-dev/parca-agent/assets/959128/7b47d0e7-c529-450f-a7f5-59d93273388b)

    
Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>