### PR TITLE
build: Do not run vulncheck on make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ check-license:
 	./scripts/check-license.sh
 
 .PHONY: go/lint
-go/lint: go/deps-check
+go/lint:
 	mkdir -p $(OUT_BPF_DIR)
 	touch $(OUT_BPF)
 	$(GO_ENV) $(CGO_ENV) golangci-lint run


### PR DESCRIPTION
As it's slow. We should run it in a CI job and report back via email.
