### PR TITLE
tests: Add integration tests for mixed-mode unwinding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,8 @@ jobs:
         # Make sometimes somehow resolves different Go. We need to specify explicitly.
         run: make GO=`which go` test ENABLE_RACE=yes
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Integration tests
         run: make GO=`which go` test/integration
 


### PR DESCRIPTION
aka JIT <-> DWARF unwinding. This also tests that the symbolization using
perfdump works.

Also changed the running time for the profiler during non-CI runs to
reduce feedback cycles.
