### PR TITLE
pkg/stack/unwind:  Add unwind tables support for Arm64

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -288,9 +288,10 @@ func main() {
 	intro := figure.NewColorFigure("Parca Agent ", "roman", "yellow", true)
 	intro.Print()
 
+	// TODO(sylfrena): Entirely remove once full support for DWARF Unwinding Arm64 is added and production tested for a few days
 	if runtime.GOARCH == "arm64" {
-		flags.DWARFUnwinding.Disable = true
-		level.Info(logger).Log("msg", "ARM64 support is currently in beta. DWARF-based unwinding is not supported yet, see https://github.com/parca-dev/parca-agent/discussions/1376 for more details")
+		flags.DWARFUnwinding.Disable = false
+		level.Info(logger).Log("msg", "ARM64 support is currently in beta. DWARF-based unwinding is not fully supported yet, see https://github.com/parca-dev/parca-agent/discussions/1376 for more details")
 	}
 
 	// Memlock rlimit 0 means no limit.

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -969,6 +970,37 @@ func (m *bpfMaps) addUnwindTableForProcess(pid int, interp *process.Interpreter,
 	}
 	m.processCache.Add(pid, mapsHash)
 	return nil
+}
+
+// generateCompactUnwindTable produces the compact unwind table for a given
+// executable.
+func (m *bpfMaps) generateCompactUnwindTable(fullExecutablePath string, mapping *unwind.ExecutableMapping) (unwind.CompactUnwindTable, error) {
+	var ut unwind.CompactUnwindTable
+
+	// Fetch FDEs.
+	fdes, arch, err := unwind.ReadFDEs(fullExecutablePath)
+	if err != nil {
+		return ut, err
+	}
+
+	// Sort them, as this will ensure that the generated table
+	// is also sorted. Sorting fewer elements will be faster.
+	sort.Sort(fdes)
+
+	// Generate the compact unwind table.
+	ut, err = unwind.BuildCompactUnwindTable(fdes, arch)
+	if err != nil {
+		return ut, err
+	}
+
+	// This should not be necessary, as per the sorting above, but
+	// just in case :).
+	sort.Sort(ut)
+
+	// Now we have a full compact unwind table that we have to split in different BPF maps.
+	level.Debug(m.logger).Log("msg", "found unwind entries", "executable", mapping.Executable, "len", len(ut))
+
+	return ut, nil
 }
 
 // writeUnwindTableRow writes a compact unwind table row to the provided slice.

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -15,6 +15,7 @@
 package unwind
 
 import (
+	"debug/elf"
 	"testing"
 
 	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
@@ -30,7 +31,7 @@ func TestIsEndOfFDEMarkerWorks(t *testing.T) {
 	require.True(t, row.IsEndOfFDEMarker())
 }
 
-func TestCompactUnwindTable(t *testing.T) {
+func TestCompactUnwindTableX86(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   UnwindTableRow
@@ -46,12 +47,12 @@ func TestCompactUnwindTable(t *testing.T) {
 				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
 			},
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           2,
-				rbpType:           0,
-				cfaOffset:         8,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   2,
+				rbpType:   0,
+				cfaOffset: 8,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -64,12 +65,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           1,
-				rbpType:           0,
-				cfaOffset:         8,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   1,
+				rbpType:   0,
+				cfaOffset: 8,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -82,12 +83,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           3,
-				rbpType:           0,
-				cfaOffset:         1,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   3,
+				rbpType:   0,
+				cfaOffset: 1,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -100,12 +101,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           3,
-				rbpType:           0,
-				cfaOffset:         2,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   3,
+				rbpType:   0,
+				cfaOffset: 2,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -118,12 +119,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           3,
-				rbpType:           0,
-				cfaOffset:         0,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   3,
+				rbpType:   0,
+				cfaOffset: 0,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -136,12 +137,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           2,
-				rbpType:           1,
-				cfaOffset:         8,
-				rbpOffset:         64,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   2,
+				rbpType:   1,
+				cfaOffset: 8,
+				rbpOffset: 64,
 			},
 		},
 		{
@@ -154,12 +155,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           2,
-				rbpType:           2,
-				cfaOffset:         8,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   2,
+				rbpType:   2,
+				cfaOffset: 8,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -172,12 +173,12 @@ func TestCompactUnwindTable(t *testing.T) {
 			},
 
 			want: CompactUnwindTableRow{
-				pc:                123,
-				_reservedDoNotUse: 0,
-				cfaType:           2,
-				rbpType:           3,
-				cfaOffset:         8,
-				rbpOffset:         0,
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   2,
+				rbpType:   3,
+				cfaOffset: 8,
+				rbpOffset: 0,
 			},
 		},
 		{
@@ -190,7 +191,179 @@ func TestCompactUnwindTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			have, err := compactUnwindTableRepresentation(UnwindTable{test.input})
+			have, err := CompactUnwindTableRepresentation(UnwindTable{test.input}, elf.EM_X86_64)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, CompactUnwindTable{test.want}, have)
+			}
+		})
+	}
+}
+
+func TestCompactUnwindTableArm64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   UnwindTableRow
+		want    CompactUnwindTableRow
+		wantErr bool
+	}{
+		{
+			name: "CFA with Offset on Arm64 stack pointer",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.Arm64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   2,
+				rbpType:   0,
+				cfaOffset: 8,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name: "CFA with Offset on Arm64 frame pointer",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.Arm64FramePointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   1,
+				rbpType:   0,
+				cfaOffset: 8,
+				rbpOffset: 0,
+			},
+		},
+		{
+			// TODO(sylfrena): modify for arm64
+			name: "CFA known expression PLT 1",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleExpression, Expression: Plt1[:]},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   3,
+				rbpType:   0,
+				cfaOffset: 1,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name: "CFA known expression PLT 2",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleExpression, Expression: Plt2[:]},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   3,
+				rbpType:   0,
+				cfaOffset: 2,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name: "CFA not known expression",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleExpression, Expression: []byte{'l', 'o', 'l'}},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   3,
+				rbpType:   0,
+				cfaOffset: 0,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name: "RBP offset",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.Arm64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleOffset, Offset: 64},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   2,
+				rbpType:   1,
+				cfaOffset: 8,
+				rbpOffset: 64,
+			},
+		},
+		{
+			name: "RBP register",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.Arm64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleRegister, Reg: 0xBAD},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   2,
+				rbpType:   2,
+				cfaOffset: 8,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name: "RBP expression",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.Arm64StackPointer, Offset: 8},
+				RBP: frame.DWRule{Rule: frame.RuleExpression, Expression: Plt1[:]},
+				RA:  frame.DWRule{Rule: frame.RuleOffset, Offset: -8},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  -8,
+				cfaType:   2,
+				rbpType:   3,
+				cfaOffset: 8,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name:    "Invalid CFA rule returns error",
+			input:   UnwindTableRow{},
+			want:    CompactUnwindTableRow{},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			have, err := CompactUnwindTableRepresentation(UnwindTable{test.input}, elf.EM_AARCH64)
 			if test.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -29,6 +29,7 @@ import (
 var (
 	ErrNoFDEsFound            = errors.New("no FDEs found")
 	ErrEhFrameSectionNotFound = errors.New("failed to find .eh_frame section")
+	ErrNoRegisterFound        = errors.New("architecture not supported")
 )
 
 type UnwindTableBuilder struct {
@@ -39,26 +40,47 @@ func NewUnwindTableBuilder(logger log.Logger) *UnwindTableBuilder {
 	return &UnwindTableBuilder{logger: logger}
 }
 
-func x64RegisterToString(reg uint64) string {
-	// TODO(javierhonduco):
-	// - add source for this table.
-	// - add other architectures.
-	x86_64Regs := []string{
-		"rax", "rdx", "rcx", "rbx", "rsi", "rdi", "rbp", "rsp", "r8", "r9", "r10", "r11",
-		"r12", "r13", "r14", "r15", "rip", "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5",
-		"xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",
-		"st0", "st1", "st2", "st3", "st4", "st5", "st6", "st7", "mm0", "mm1", "mm2", "mm3",
-		"mm4", "mm5", "mm6", "mm7", "rflags", "es", "cs", "ss", "ds", "fs", "gs",
-		"unused1", "unused2", "fs.base", "gs.base", "unused3", "unused4", "tr", "ldtr",
-		"mxcsr", "fcw", "fsw",
+// From 3.6.2 DWARF Register Number Mapping for x86_64, Fig 3.36
+// https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf
+var x86_64Regs = []string{
+	"rax", "rdx", "rcx", "rbx", "rsi", "rdi", "rbp", "rsp", "r8", "r9", "r10", "r11",
+	"r12", "r13", "r14", "r15", "rip", "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5",
+	"xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",
+	"st0", "st1", "st2", "st3", "st4", "st5", "st6", "st7", "mm0", "mm1", "mm2", "mm3",
+	"mm4", "mm5", "mm6", "mm7", "rflags", "es", "cs", "ss", "ds", "fs", "gs",
+	"unused1", "unused2", "fs.base", "gs.base", "unused3", "unused4", "tr", "ldtr",
+	"mxcsr", "fcw", "fsw",
+}
+
+// From 4.1 DWARF Register Names for Aarch64/Arm64
+// https://github.com/ARM-software/abi-aa/blob/2023q1-release/aadwarf64/aadwarf64.rst#dwarf-register-names
+// maybe r0...r30 will also work, but x0..x30 preferred for 64 bit archs and
+// what `gdb` shows on passing `info all-registers`:
+// x29 -> fp
+// x30 -> lr
+// x31 -> sp
+// x32 -> pc
+// x33 -> cpsr.
+var arm64Regs = []string{
+	"x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
+	"x12", "x13", "x14", "x15", "x16", "x17", "x18", "x18", "x19", "x20",
+	"x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29", "x30",
+	"sp", "pc", "cpsr",
+}
+
+func registerToString(reg uint64, arch elf.Machine) string {
+	if arch == elf.EM_X86_64 {
+		return x86_64Regs[reg]
+	} else if arch == elf.EM_AARCH64 {
+		return arm64Regs[reg]
 	}
 
-	return x86_64Regs[reg]
+	return ErrNoRegisterFound.Error()
 }
 
 // PrintTable is a debugging helper that prints the unwinding table to the given io.Writer.
 func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact bool, pc *uint64) error {
-	fdes, err := ReadFDEs(path)
+	fdes, arch, err := ReadFDEs(path)
 	if err != nil {
 		return err
 	}
@@ -89,7 +111,7 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 			}
 
 			if compact {
-				compactRow, err := rowToCompactRow(unwindRow)
+				compactRow, err := rowToCompactRow(unwindRow, arch)
 				if err != nil {
 					return err
 				}
@@ -100,13 +122,17 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 				fmt.Fprintf(writer, "rbp_type: %-2d ", compactRow.RbpType())
 				fmt.Fprintf(writer, "cfa_offset: %-4d ", compactRow.CfaOffset())
 				fmt.Fprintf(writer, "rbp_offset: %-4d", compactRow.RbpOffset())
+				if arch == elf.EM_AARCH64 {
+					fmt.Fprintf(writer, "lr_offset: %-4d", compactRow.LrOffset())
+				}
+
 				fmt.Fprintf(writer, "\n")
 			} else {
 				//nolint:exhaustive
 				switch unwindRow.CFA.Rule {
 				case frame.RuleCFA:
-					CFAReg := x64RegisterToString(unwindRow.CFA.Reg)
-					fmt.Fprintf(writer, "\tLoc: %x CFA: $%s=%-4d", unwindRow.Loc, CFAReg, unwindRow.CFA.Offset)
+					CFAReg := registerToString(unwindRow.CFA.Reg, arch)
+					fmt.Fprintf(writer, "\tLoc: %x CFA: $%s=%-4d", unwindRow.Loc, CFAReg, unwindRow.CFA.Offset) // TODO(Sylfrena): correct
 				case frame.RuleExpression:
 					expressionID := ExpressionIdentifier(unwindRow.CFA.Expression)
 					if expressionID == ExpressionUnknown {
@@ -124,14 +150,42 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 				case frame.RuleUndefined, frame.RuleUnknown:
 					fmt.Fprintf(writer, "\tRBP: u")
 				case frame.RuleRegister:
-					RBPReg := x64RegisterToString(unwindRow.RBP.Reg)
+					RBPReg := registerToString(unwindRow.RBP.Reg, arch)
 					fmt.Fprintf(writer, "\tRBP: $%s", RBPReg)
 				case frame.RuleOffset:
+					// Interesting we end up here and register is not assigned
+					// TODO(sylfrena): verify if this is expected
 					fmt.Fprintf(writer, "\tRBP: c%-4d", unwindRow.RBP.Offset)
 				case frame.RuleExpression:
 					fmt.Fprintf(writer, "\tRBP: exp")
 				default:
 					panic(fmt.Sprintf("Got rule %d for RBP, which wasn't expected", unwindRow.RBP.Rule))
+				}
+
+				//nolint:exhaustive
+				switch unwindRow.RA.Rule {
+				case frame.RuleUndefined, frame.RuleUnknown:
+					// RA is ideally always defined for arm64
+					if arch == elf.EM_AARCH64 {
+						fmt.Fprintf(writer, "\tRA($%s): u", arch.String())
+					}
+				case frame.RuleRegister:
+					RAReg := registerToString(unwindRow.RA.Reg, arch)
+					if arch == elf.EM_AARCH64 {
+						fmt.Fprintf(writer, "\tRA: $%s", RAReg)
+					}
+				case frame.RuleOffset:
+					// Note: This condition is also executed(with offset 0 -> c0) when it is the last frame for an FDE
+					// `readelf` shows RA as undefined here but clearly the offset is considered 0 here in arm64
+					if arch == elf.EM_AARCH64 {
+						fmt.Fprintf(writer, "\tRA: c%-4d", unwindRow.RA.Offset)
+					}
+				case frame.RuleExpression:
+					if arch == elf.EM_AARCH64 {
+						fmt.Fprintf(writer, "\tRA: exp")
+					}
+				default:
+					panic(fmt.Sprintf("Got rule %d for RA, which wasn't expected", unwindRow.RA.Rule))
 				}
 
 				fmt.Fprintf(writer, "\n")
@@ -142,37 +196,39 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 	return nil
 }
 
-func ReadFDEs(path string) (frame.FrameDescriptionEntries, error) {
+func ReadFDEs(path string) (frame.FrameDescriptionEntries, elf.Machine, error) {
 	// TODO(kakkoyun): Migrate objectfile and pool.
 	obj, err := elf.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open elf: %w", err)
+		return nil, elf.EM_NONE, fmt.Errorf("failed to open elf: %w", err)
 	}
 	defer obj.Close()
 
+	arch := obj.Machine
+
 	sec := obj.Section(".eh_frame")
 	if sec == nil {
-		return nil, ErrEhFrameSectionNotFound
+		return nil, arch, ErrEhFrameSectionNotFound
 	}
 
 	// TODO: Consider using the debug_frame section as a fallback.
 	// TODO: Needs to support DWARF64 as well.
 	ehFrame, err := sec.Data()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read .eh_frame section: %w", err)
+		return nil, arch, fmt.Errorf("failed to read .eh_frame section: %w", err)
 	}
 
 	// TODO: Byte order of a DWARF section can be different.
 	fdes, err := frame.Parse(ehFrame, obj.ByteOrder, 0, pointerSize(obj.Machine), sec.Addr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse frame data: %w", err)
+		return nil, arch, fmt.Errorf("failed to parse frame data: %w", err)
 	}
 
 	if len(fdes) == 0 {
-		return nil, ErrNoFDEsFound
+		return nil, arch, ErrNoFDEsFound
 	}
 
-	return fdes, nil
+	return fdes, arch, nil
 }
 
 func BuildUnwindTable(fdes frame.FrameDescriptionEntries) UnwindTable {
@@ -190,7 +246,7 @@ func BuildUnwindTable(fdes frame.FrameDescriptionEntries) UnwindTable {
 
 // UnwindTableRow represents a single row in the unwind table.
 // x86_64: rip (instruction pointer register), rsp (stack pointer register), rbp (base pointer/frame pointer register)
-// aarch64: lr, sp, fp
+// aarch64: lr(link register), sp(stack pointer register), fp(frame pointer register)
 type UnwindTableRow struct {
 	// The address of the machine instruction.
 	// Each row covers a range of machine instruction, from its address (Loc) to that of the row below.

--- a/pkg/stack/unwind/unwind_table_test.go
+++ b/pkg/stack/unwind/unwind_table_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestBuildUnwindTable(t *testing.T) {
-	fdes, err := ReadFDEs("../../../testdata/out/x86/basic-cpp")
+	fdes, _, err := ReadFDEs("../../../testdata/out/x86/basic-cpp")
 	require.NoError(t, err)
 
 	unwindTable := BuildUnwindTable(fdes)
@@ -46,7 +46,7 @@ func benchmarkParsingDwarfUnwindInformation(b *testing.B, executable string) {
 	var rbpOffset int64
 
 	for n := 0; n < b.N; n++ {
-		fdes, err := ReadFDEs(executable)
+		fdes, _, err := ReadFDEs(executable)
 		if err != nil {
 			panic("could not read FDEs")
 		}


### PR DESCRIPTION
### What?
Add support for extracting unwind table information from the ".eh-frame"
section of Arm64 binaries. So far, only X86 binaries were supported.
    
 - Arm64 majorly differs from X86 in having a "Link Register(x30)" which saves the Return Address
 - The changes are only limited to userspace to generate "compact-unwind-tables"; we do
 not send the content of the Link Register to the BPF side- this will be done in follow-ups.
 - Enable DWARF-unwinding for Arm64 in "main.go" to enable building unwind-tables.
 - `CompactUnwindTableRow` has a new field `lrOffset` which holds the offset for the Link Register.
    This is initiialised to 0 for X86 architectures.

### Test Plan

```
$ go test  ./pkg/stack/unwind -count=1
ok      github.com/parca-dev/parca-agent/pkg/stack/unwind       0.007s
```

- tested for `libc.so.6`, `basic-cpp-no-fp`, `systemd` on both Arm64 and X86
    using `make-test-dwarf-unwind-tables`

- tables generated using "dist/eh-frame" verified against `readelf -wF` output

``` 
 1. Run `make build` in `parca-agent/testdata`
    `cd testdata && make build`
 2. Run `make build && make-test-dwarf-unwind-tables` from parca-agent root on the main branch.
    `cd .. && make build && make-test-dwarf-unwind-tables`
 3. Copy the output in `testdata/tables` and `testdata/compact_tables` in a separate untracked folder
    `mkdir ~/testdata-arm64-main && cp -r testdata/tables testdata/compact_tables ~/testdata-arm64-main`
 4. Switch to current `dwarf-unwinding-arm64` branch
 5. Run `make build` in parca-agent root. (Make sure you don't do this in the `testdata` submodule)
 6. Run `make-test-dwarf-unwind-tables`.
 7. Compare the output in `testdata/tables` and `testdata/compact_tables` to the results saved earlier in
    `~/testdata-arm64-main`
 8. Verify all tables against `readelf -wF "required-binary"`
 9. Repeat above for x86 binaries.
```

Check #1797 for Arm64 support roadmap

<!--

copilot:poem

-->
