### PR TITLE
Detect the agent running in a non-root PID namespace

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -150,6 +150,10 @@ jobs:
           ls -lR bpf
           mkdir -p pkg/profiler/cpu/bpf
           cp -r bpf/out/* pkg/profiler/cpu/bpf
+          rm pkg/profiler/cpu/bpf/*/pid_namespace.bpf.o
+          mkdir -p pkg/contained/bpf
+          cp -r bpf/out/* pkg/contained/bpf
+          find pkg/contained/bpf/*/ -type f | grep -v "pid_namespace.bpf.o" | xargs -I{} bash -c "rm {}"
 
       - name: Run Goreleaser
         run: goreleaser release --clean --skip-validate --skip-publish --snapshot --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,10 @@ jobs:
           ls -lR bpf
           mkdir -p pkg/profiler/cpu/bpf
           cp -r bpf/out/* pkg/profiler/cpu/bpf
+          rm pkg/profiler/cpu/bpf/*/pid_namespace.bpf.o
+          mkdir -p pkg/contained/bpf
+          cp -r bpf/out/* pkg/contained/bpf
+          find pkg/contained/bpf/*/ -type f | grep -v "pid_namespace.bpf.o" | xargs -I{} bash -c "rm {}"
 
       - name: Run Goreleaser
         run: goreleaser release --clean --debug

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -130,6 +130,10 @@ jobs:
           ls -lR bpf
           mkdir -p pkg/profiler/cpu/bpf
           cp -r bpf/out/* pkg/profiler/cpu/bpf
+          rm pkg/profiler/cpu/bpf/*/pid_namespace.bpf.o
+          mkdir -p pkg/contained/bpf
+          cp -r bpf/out/* pkg/contained/bpf
+          find pkg/contained/bpf/*/ -type f | grep -v "pid_namespace.bpf.o" | xargs -I{} bash -c "rm {}"
 
       - name: Run Goreleaser
         run: goreleaser release --clean --debug --snapshot --skip-validate --skip-publish

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -25,6 +25,27 @@ CLANG ?= clang
 CMD_LLC ?= llc
 CMD_CC ?= $(CLANG)
 
+# compilation options:
+BPF_CFLAGS = -Wno-address-of-packed-member \
+		-Wno-compare-distinct-pointer-types \
+		-Wno-deprecated-declarations \
+		-Wno-gnu-variable-sized-type-not-at-end \
+		-Wno-pointer-sign \
+		-Wno-pragma-once-outside-header \
+		-Wno-unknown-warning-option \
+		-Wno-unused-value \
+		-Wdate-time \
+		-Wunused \
+		-Wall \
+		-fno-stack-protector \
+		-fno-jump-tables \
+		-fno-unwind-tables \
+		-fno-asynchronous-unwind-tables \
+		-xc \
+		-nostdinc \
+		-target bpf \
+		-O2
+
 # output:
 OUT_DIR ?= ../dist
 
@@ -32,6 +53,7 @@ OUT_BPF_BASE_DIR := out
 OUT_BPF_DIR := $(OUT_BPF_BASE_DIR)/$(ARCH)
 OUT_BPF := $(OUT_BPF_DIR)/cpu.bpf.o
 OUT_RBPERF := $(OUT_BPF_DIR)/rbperf.bpf.o
+OUT_PID_NAMESPACE_DETECTOR := $(OUT_BPF_DIR)/pid_namespace.bpf.o
 BPF_BUNDLE := $(OUT_DIR)/parca-agent.bpf.tar.gz
 
 # input:
@@ -40,11 +62,12 @@ LIBBPF_HEADERS := $(OUT_DIR)/libbpf/$(ARCH)/usr/include
 VMLINUX_INCLUDE_PATH := $(SHORT_ARCH)
 BPF_SRC := cpu/cpu.bpf.c
 RBPERF_SRC := cpu/rbperf.bpf.c
+OUT_PID_NAMESPACE_DETECTOR_SRC := pid_namespace.bpf.c
 BPF_INCLUDES := cpu/
 
 # tasks:
 .PHONY: clang
-clang: $(OUT_BPF) $(OUT_RBPERF)
+clang: $(OUT_BPF) $(OUT_RBPERF) $(OUT_PID_NAMESPACE_DETECTOR)
 
 bpf_bundle_dir := $(OUT_DIR)/parca-agent.bpf
 $(BPF_BUNDLE): $(BPF_SRC) $(LIBBPF_HEADERS)/bpf $(BPF_HEADERS)
@@ -60,25 +83,8 @@ $(OUT_BPF): $(BPF_SRC) $(LIBBPF_HEADERS) $(BPF_HEADERS) | $(OUT_DIR)
 		-I $(VMLINUX_INCLUDE_PATH) \
 		-I $(LIBBPF_HEADERS) \
 		-I $(BPF_INCLUDES) \
-		-Wno-address-of-packed-member \
-		-Wno-compare-distinct-pointer-types \
-		-Wno-deprecated-declarations \
-		-Wno-gnu-variable-sized-type-not-at-end \
-		-Wno-pointer-sign \
-		-Wno-pragma-once-outside-header \
-		-Wno-unknown-warning-option \
-		-Wno-unused-value \
-		-Wdate-time \
-		-Wunused \
-		-Wall \
-		-fno-stack-protector \
-		-fno-jump-tables \
-		-fno-unwind-tables \
-		-fno-asynchronous-unwind-tables \
-		-xc \
-		-nostdinc \
-		-target bpf \
-		-O2 -emit-llvm -c -g $< -o $(@:.o=.ll)
+		$(BPF_CFLAGS) \
+		-emit-llvm -c -g $< -o $(@:.o=.ll)
 	$(CMD_LLC) -march=bpf -filetype=obj -o $@ $(@:.o=.ll)
 	rm $(@:.o=.ll)
 
@@ -92,24 +98,21 @@ $(OUT_RBPERF): $(RBPERF_SRC) $(LIBBPF_HEADERS) $(BPF_HEADERS) | $(OUT_DIR)
 		-I $(VMLINUX_INCLUDE_PATH) \
 		-I $(LIBBPF_HEADERS) \
 		-I $(BPF_INCLUDES) \
-		-Wno-address-of-packed-member \
-		-Wno-compare-distinct-pointer-types \
-		-Wno-deprecated-declarations \
-		-Wno-gnu-variable-sized-type-not-at-end \
-		-Wno-pointer-sign \
-		-Wno-pragma-once-outside-header \
-		-Wno-unknown-warning-option \
-		-Wno-unused-value \
-		-Wdate-time \
-		-Wunused \
-		-Wall \
-		-fno-stack-protector \
-		-fno-jump-tables \
-		-fno-unwind-tables \
-		-fno-asynchronous-unwind-tables \
-		-xc \
-		-nostdinc \
-		-target bpf \
-		-O2 -emit-llvm -c -g $< -o $(@:.o=.ll)
+		$(BPF_CFLAGS) \
+		-emit-llvm -c -g $< -o $(@:.o=.ll)
+	$(CMD_LLC) -march=bpf -filetype=obj -o $@ $(@:.o=.ll)
+	rm $(@:.o=.ll)
+
+$(OUT_PID_NAMESPACE_DETECTOR): $(OUT_PID_NAMESPACE_DETECTOR_SRC) $(LIBBPF_HEADERS) $(BPF_HEADERS) | $(OUT_DIR)
+	mkdir -p $(OUT_BPF_DIR)
+	$(CMD_CC) -S \
+		-D__BPF_TRACING__ \
+		-D__KERNEL__ \
+		-D__TARGET_ARCH_$(SHORT_ARCH) \
+		-I $(VMLINUX_INCLUDE_PATH) \
+		-I $(LIBBPF_HEADERS) \
+		-I $(BPF_INCLUDES) \
+		$(BPF_CFLAGS) \
+		-emit-llvm -c -g $< -o $(@:.o=.ll)
 	$(CMD_LLC) -march=bpf -filetype=obj -o $@ $(@:.o=.ll)
 	rm $(@:.o=.ll)

--- a/bpf/pid_namespace.bpf.c
+++ b/bpf/pid_namespace.bpf.c
@@ -1,0 +1,23 @@
+//+build ignore
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+ struct {
+  __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+  __uint(key_size, sizeof(u32));
+  __uint(value_size, sizeof(u32));
+  __uint(max_entries, 4096);
+} events SEC(".maps");
+
+SEC("uprobe/test_function")
+int uprobe__test_function(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    int pid = pid_tgid >> 32;
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &pid, sizeof(pid));
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.31.0-20230726221845-41588ce133c8.1
 	github.com/alecthomas/kong v0.8.0
 	github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0.0.20230817212518-21cf435d454e
+	github.com/aquasecurity/libbpfgo/helpers v0.4.5
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cilium/ebpf v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/apache/arrow/go/v14 v14.0.0-20230831153504-d7b4d2d5f749 h1:D5HVTZNQNt
 github.com/apache/arrow/go/v14 v14.0.0-20230831153504-d7b4d2d5f749/go.mod h1:QQ18IZU2Y3BFqHtF2HyvrjEEmk8TyzzmXgUVjep3bCw=
 github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0.0.20230817212518-21cf435d454e h1:IwbtZSdyDxqUhIdu7R3OazVr+oHJetwrQzyaVcppFf0=
 github.com/aquasecurity/libbpfgo v0.4.9-libbpf-1.2.0.0.20230817212518-21cf435d454e/go.mod h1:0rEApF1YBHGuZ4C8OYI9q5oDBVpgqtRqYATePl9mCDk=
+github.com/aquasecurity/libbpfgo/helpers v0.4.5 h1:eCoLclL3yqv4N9jqGL3T/ckrLPms2r13C4V2xtU75yc=
+github.com/aquasecurity/libbpfgo/helpers v0.4.5/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/pkg/contained/contained.go
+++ b/pkg/contained/contained.go
@@ -1,0 +1,122 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contained
+
+import (
+	"embed"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	"go.uber.org/atomic"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/libbpfgo/helpers"
+)
+
+//go:embed bpf/*
+var bpfObjects embed.FS
+
+const (
+	maxEvents      = 25
+	pollIntervalMs = 50
+	binaryPath     = "/proc/self/exe"
+	symbolName     = "github.com/parca-dev/parca-agent/pkg/contained.testFunction"
+)
+
+//go:noinline
+func testFunction() {
+	fmt.Fprintf(io.Discard, "Side-effect to avoid the compiler to optimize it out.")
+}
+
+func IsRootPIDNamespace() (bool, error) {
+	f, err := bpfObjects.Open(fmt.Sprintf("bpf/%s/pid_namespace.bpf.o", runtime.GOARCH))
+	if err != nil {
+		return false, fmt.Errorf("failed to open BPF object: %w", err)
+	}
+	defer f.Close()
+
+	bpfObj, err := io.ReadAll(f)
+	if err != nil {
+		return false, fmt.Errorf("failed to read BPF object: %w", err)
+	}
+
+	bpfModule, err := bpf.NewModuleFromBufferArgs(bpf.NewModuleArgs{
+		BPFObjBuff: bpfObj,
+		BPFObjName: "pid-namespace",
+	})
+	if err != nil {
+		return false, fmt.Errorf("new bpf module: %w", err)
+	}
+
+	err = bpfModule.BPFLoadObject()
+	if err != nil {
+		return false, fmt.Errorf("new bpf module: %w", err)
+	}
+
+	prog, err := bpfModule.GetProgram("uprobe__test_function")
+	if err != nil {
+		return false, fmt.Errorf("failed to get program: %w", err)
+	}
+
+	offset, err := helpers.SymbolToOffset(binaryPath, symbolName)
+	if err != nil {
+		return false, fmt.Errorf("failed to compute function offset: %w", err)
+	}
+
+	_, err = prog.AttachUprobe(-1, binaryPath, offset)
+	if err != nil {
+		return false, fmt.Errorf("failed to attach uprobe: %w", err)
+	}
+
+	eventsChannel := make(chan []byte)
+	lostChannel := make(chan uint64)
+
+	perfBuf, err := bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 64)
+	if err != nil {
+		return false, fmt.Errorf("failed to init perf buffer: %w", err)
+	}
+	defer perfBuf.Stop()
+	defer perfBuf.Close()
+
+	perfBuf.Poll(int(pollIntervalMs))
+
+	var shouldRun atomic.Bool
+	shouldRun.Store(true)
+	defer func() {
+		shouldRun.Store(false)
+	}()
+
+	go func() {
+		for {
+			if !shouldRun.Load() {
+				break
+			}
+			testFunction()
+		}
+	}()
+
+	for i := 0; i < maxEvents; i++ {
+		b := <-eventsChannel
+		val := int(binary.LittleEndian.Uint32(b))
+
+		if val == os.Getpid() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -213,12 +213,6 @@ func loadBpfProgram(logger log.Logger, reg prometheus.Registerer, mixedUnwinding
 	maxLoadAttempts := 10
 	unwindShards := uint32(maxUnwindShards)
 
-	bpf.SetLoggerCbs(bpf.Callbacks{
-		Log: func(_ int, msg string) {
-			level.Debug(logger).Log("msg", msg)
-		},
-	})
-
 	f, err := bpfObjects.Open(fmt.Sprintf("bpf/%s/cpu.bpf.o", runtime.GOARCH))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open BPF object: %w", err)


### PR DESCRIPTION
In Linux resources such as users, processes, mounts, time, etc. can be isolated with namespaces [0]. They are used in tamden with cgroups to implement resource control in containers.

Both namespaces and cgroups are conceptually a hierarchy, where the first namespace is the root of the tree and the common ancestor for all the other slices of the machine.

The Agent requires to be run in the 'root' (this has nothing to do with permissions or users, necessarily) PID namespace, where all the other processes for every single namespace can be queried.

While the kernel does not provide a facility for this check, this commit aims to bring a reliable check to see whether we are inside of a PID namespace or not. It does it with a BPF program that retrieves the pid of the Agent and then we compare it with the pid that the OS gives us in userspace via `getpid(2)`. As the BPF program always gives the PID from the PoV of the root PID namespace, we can tell if we are in the root namespace or not.

This uses code from this PoC [1].

Test Plan
=========

**running the Agent normally, in the root PID namespace**

```
[root@fedora parca-agent]# dist/parca-agent
[works]
```

**under a non-root PID namespace**

```
[javierhonduco@fedora parca-agent]$ sudo unshare --fork --pid --mount-proc
[root@fedora parca-agent]# dist/parca-agent
ooooooooo.                                                  .o.                                            .
`888   `Y88.                                               .888.                                         .o8
 888   .d88'  .oooo.   oooo d8b  .ooooo.   .oooo.         .8"888.      .oooooooo  .ooooo.  ooo. .oo.   .o888oo
 888ooo88P'  `P  )88b  `888""8P d88' `"Y8 `P  )88b       .8' `888.    888' `88b  d88' `88b `888P"Y88b    888
 888          .oP"888   888     888        .oP"888      .88ooo8888.   888   888  888ooo888  888   888    888
 888         d8(  888   888     888   .o8 d8(  888     .8'     `888.  `88bod8P'  888    .o  888   888    888 .
o888o        `Y888""8o d888b    `Y8bod8P' `Y888""8o   o88o     o8888o `8oooooo.  `Y8bod8P' o888o o888o   "888"
                                                                      d"     YD
                                                                      "Y88888P'

level=info name=parca-agent ts=2023-09-07T10:42:25.892675407Z caller=main.go:345 msg="maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined"
level=error name=parca-agent ts=2023-09-07T10:42:25.925707031Z caller=main.go:374 msg="the agent must be run in the 'root' PID namespace"
```

[0]: https://man7.org/linux/man-pages/man7/namespaces.7.html
[1]: https://github.com/javierhonduco/am-i-contained/tree/main
