### PR TITLE
pkg/perf: More robust perf map parsing

### DIFF
--- a/pkg/perf/perf.go
+++ b/pkg/perf/perf.go
@@ -54,7 +54,10 @@ var (
 
 // TODO(kakkoyun): Add Parser type to wrap: fs and logger.
 
-func ReadPerfMap(fileName string) (Map, error) {
+func ReadPerfMap(
+	logger log.Logger,
+	fileName string,
+) (Map, error) {
 	fd, err := os.Open(fileName)
 	if err != nil {
 		return Map{}, err
@@ -82,21 +85,28 @@ func ReadPerfMap(fileName string) (Map, error) {
 	r := bufio.NewReader(fd)
 	addrs := make([]MapAddr, 0, linesCount)
 	conv := newStringConverter(convBufSize)
+	i := 0
+	var multiError error
 	for {
 		b, err := r.ReadSlice('\n')
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return Map{}, err
+			return Map{}, fmt.Errorf("read perf map line: %w", err)
 		}
 
 		line, err := parsePerfMapLine(b, conv)
 		if err != nil {
-			return Map{}, err
+			multiError = errors.Join(multiError, fmt.Errorf("parse perf map line %d: %w", i, err))
 		}
 
 		addrs = append(addrs, line)
+		i++
+	}
+
+	if multiError != nil {
+		level.Debug(logger).Log("msg", "some perf map lines failed to be parsed, this is somewhat expected, but this log line exists for potential troubleshooting", "err", multiError)
 	}
 	// Sorted by end address to allow binary search during look-up. End to find
 	// the (closest) address _before_ the end. This could be an inlined instruction
@@ -110,20 +120,24 @@ func ReadPerfMap(fileName string) (Map, error) {
 func parsePerfMapLine(b []byte, conv *stringConverter) (MapAddr, error) {
 	firstSpace := bytes.Index(b, []byte(" "))
 	if firstSpace == -1 {
-		return MapAddr{}, fmt.Errorf("invalid line: %s", b)
+		return MapAddr{}, errors.New("invalid line")
 	}
 
 	secondSpace := bytes.Index(b[firstSpace+1:], []byte(" "))
 	if secondSpace == -1 {
-		return MapAddr{}, fmt.Errorf("invalid line: %s", b)
+		return MapAddr{}, errors.New("invalid line")
 	}
 
 	addrBytes := b[:firstSpace]
 
 	// Some runtimes that produce perf maps optionally start memory
 	// addresses with "0x".
-	if addrBytes[0] == '0' && addrBytes[1] == 'x' {
+	if len(addrBytes) >= 2 && addrBytes[0] == '0' && addrBytes[1] == 'x' {
 		addrBytes = addrBytes[2:]
+	}
+
+	if len(b) < firstSpace+secondSpace+2 {
+		return MapAddr{}, errors.New("invalid line")
 	}
 
 	sizeBytes := b[firstSpace+1 : firstSpace+1+secondSpace]
@@ -131,14 +145,14 @@ func parsePerfMapLine(b []byte, conv *stringConverter) (MapAddr, error) {
 
 	start, err := parseHexToUint64(addrBytes)
 	if err != nil {
-		return MapAddr{}, fmt.Errorf("parsing start failed on %v: %w", string(b), err)
+		return MapAddr{}, fmt.Errorf("parsing start: %w", err)
 	}
 	size, err := parseHexToUint64(sizeBytes)
 	if err != nil {
-		return MapAddr{}, fmt.Errorf("parsing end failed on %v: %w", string(b), err)
+		return MapAddr{}, fmt.Errorf("parsing end: %w", err)
 	}
 	if start+size < start {
-		return MapAddr{}, fmt.Errorf("overflowed mapping: %v", string(b))
+		return MapAddr{}, errors.New("overflowed mapping")
 	}
 
 	if symbolBytes[len(symbolBytes)-1] == '\n' {
@@ -195,7 +209,7 @@ func (p *PerfMapCache) PerfMapForPID(pid int) (*Map, error) {
 		level.Debug(p.logger).Log("msg", "cached value is outdated", "pid", pid)
 	}
 
-	m, err := ReadPerfMap(perfFile)
+	m, err := ReadPerfMap(p.logger, perfFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/perf/testdata/nodejs-perf-map-regression
+++ b/pkg/perf/testdata/nodejs-perf-map-regression
@@ -1,0 +1,3 @@
+7235dc0 338 LazyCompile:*getPotentialParent /usr/src/app/node_modules/heap-js/dist/heap-js.umd.js:764
+ Script:~ evalmachine.<anonymous>:1
+d63be533e90 19 Script:~ evalmachine.<anonymous>:1


### PR DESCRIPTION
Perf map files have fundamental race conditions between the producer and consumer and it's never guaranteed for lines to be complete or correct. Therefore we need to be more rigorous about validating lines and expecting the worst. This patch was originally triggered by a customer seeing panics with out of bounds accesses, which have been simulated in the added regression tests.