### PR TITLE
fix(cache): ensure LoadingOnceCache can only load once

### DIFF
--- a/pkg/cache/loading.go
+++ b/pkg/cache/loading.go
@@ -71,7 +71,7 @@ func NewLoadingLRUCacheWithTTL[K comparable, V any](reg prometheus.Registerer, m
 	}
 }
 
-func (c *LoadingLRUCacheWithTTL[K, V]) Get(key K) (V, error) {
+func (c *LoadingLRUCacheWithTTL[K, V]) getOrLoad(key K) (V, error) {
 	v, ok := c.lru.Get(key)
 	if ok {
 		return v, nil
@@ -86,11 +86,21 @@ func (c *LoadingLRUCacheWithTTL[K, V]) Get(key K) (V, error) {
 	return v, nil
 }
 
+func (c *LoadingLRUCacheWithTTL[K, V]) Get(key K) (V, error) {
+	return c.getOrLoad(key)
+}
+
 func (c *LoadingLRUCacheWithTTL[K, V]) Close() error {
 	var err error
 	err = errors.Join(err, c.closer())
 	err = errors.Join(err, c.lru.Close())
 	return err
+}
+
+type LoadingOnceCache[K comparable, V any] struct {
+	*LoadingLRUCacheWithTTL[K, V]
+
+	sfg *singleflight.Group
 }
 
 // NewLoadingOnceCache creates a LoadingCache that allows only one loading operation at a time.
@@ -100,22 +110,24 @@ func (c *LoadingLRUCacheWithTTL[K, V]) Close() error {
 // one concurrent call to the loader is made for a given key. This can be used
 // to prevent redundant loading of data on cache misses when multiple concurrent
 // requests are made for the same key.
-func NewLoadingOnceCache[K comparable, V any](reg prometheus.Registerer, maxEntries int, ttl time.Duration, loader LoaderFunc[K, V]) *LoadingLRUCacheWithTTL[K, V] {
-	sfg := &singleflight.Group{}
-	onceLoader := func(k K) (V, error) {
-		// Singleflight key must be string.
-		key := fmt.Sprintf("%v", k)
-		// singleflight.Group memoizes the return value of the first call and returns it.
-		// The 3rd return value is true if multiple calls happens simultaneously,
-		// and the caller received the value from the first call.
-		val, err, _ := sfg.Do(key, func() (interface{}, error) {
-			return loader(k)
-		})
-		if err != nil {
-			var zero V
-			return zero, err
-		}
-		return val.(V), nil //nolint:forcetypeassert
+func NewLoadingOnceCache[K comparable, V any](reg prometheus.Registerer, maxEntries int, ttl time.Duration, loader LoaderFunc[K, V]) *LoadingOnceCache[K, V] {
+	c := &LoadingOnceCache[K, V]{
+		NewLoadingLRUCacheWithTTL(reg, maxEntries, ttl, loader),
+		&singleflight.Group{},
 	}
-	return NewLoadingLRUCacheWithTTL[K, V](reg, maxEntries, ttl, onceLoader)
+	return c
+}
+
+func (c *LoadingOnceCache[K, V]) Get(key K) (V, error) {
+	// singleflight.Group memoizes the return value of the first call and returns it.
+	// The 3rd return value is true if multiple calls happens simultaneously,
+	// and the caller received the value from the first call.
+	val, err, _ := c.sfg.Do(fmt.Sprintf("%v", key), func() (interface{}, error) {
+		return c.getOrLoad(key)
+	})
+	if err != nil {
+		var zero V
+		return zero, err
+	}
+	return val.(V), nil //nolint:forcetypeassert
 }


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

Same as parca-dev/parca#3768

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68d934c</samp>

Introduced a new cache type to prevent duplicate loading of data and improved cache interface naming in `pkg/cache/loading.go`.

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68d934c</samp>

*  Rename `Get` method of `LoadingLRUCacheWithTTL` to `getOrLoad` and add a wrapper `Get` method to preserve original interface ([link](https://github.com/parca-dev/parca-agent/pull/1998/files?diff=unified&w=0#diff-806bf3c2a3965a4be36cb79b92285463155a402671ab831791c9d8a743ed2484L74-R74), [link](https://github.com/parca-dev/parca-agent/pull/1998/files?diff=unified&w=0#diff-806bf3c2a3965a4be36cb79b92285463155a402671ab831791c9d8a743ed2484R89-R92))
*  Add `LoadingOnceCache` type that embeds `LoadingLRUCacheWithTTL` and adds singleflight logic to coordinate concurrent requests for the same key ([link](https://github.com/parca-dev/parca-agent/pull/1998/files?diff=unified&w=0#diff-806bf3c2a3965a4be36cb79b92285463155a402671ab831791c9d8a743ed2484R100-R105))
*  Modify `NewLoadingOnceCache` function to return a pointer to `LoadingOnceCache` and initialize embedded cache and singleflight group ([link](https://github.com/parca-dev/parca-agent/pull/1998/files?diff=unified&w=0#diff-806bf3c2a3965a4be36cb79b92285463155a402671ab831791c9d8a743ed2484L103-R133))
*  Add `Get` method to `LoadingOnceCache` that overrides embedded cache's `Get` method and uses singleflight group to memoize and return the value of the first call for the same key ([link](https://github.com/parca-dev/parca-agent/pull/1998/files?diff=unified&w=0#diff-806bf3c2a3965a4be36cb79b92285463155a402671ab831791c9d8a743ed2484L103-R133))

### Test Plan
<!-- How did you test it? How can we test it? -->

Unit tests

<!--

copilot:poem

-->
