### PR TITLE
chore(nix): update go to 1.21

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -17,13 +17,11 @@ in
     go-jsonnet
     goTools.bluebox
     goTools.embedmd
-    go_1_20
+    go_1_21
     gofumpt
     gojsontoyaml
-    # Build with Go 1.20
-    # https://github.com/golangci/golangci-lint/issues/3565
     (golangci-lint.override {
-      buildGoModule = buildGo120Module;
+      buildGoModule = buildGo121Module;
     })
     jsonnet-bundler
     kubectl


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

Because

https://github.com/parca-dev/parca-agent/blob/6952a9d49533239bc6633ba1f9ce287b7841290c/go.mod#L3

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
copilot:summary

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
copilot:walkthrough

### Test Plan
<!-- How did you test it? How can we test it? -->

`make build` :heavy_check_mark:

<!--

copilot:poem

-->
