### PR TITLE
pkg/profiler: Fix unwinder metrics

### DIFF
--- a/pkg/profiler/cpu/bpf_metrics.go
+++ b/pkg/profiler/cpu/bpf_metrics.go
@@ -136,10 +136,9 @@ func (c *bpfMetricsCollector) collectUnwinderStatistics(ch chan<- prometheus.Met
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorCatchall), "catchall")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorShouldNeverHappen), "should_never_happen")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorPcNotCovered), "pc_not_covered")
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorPcNotCoveredJit), "pc_not_covered_jit")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorJitUnupdatedMapping), "jit_unupdated_mapping")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorJitMixedModeDisabled), "jit_mixed_mode_disabled")
-	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorPcNotCoveredJit), "pc_not_covered_jit")
-	ch <- prometheus.MustNewConstMetric(descNativeUnwinderErrors, prometheus.CounterValue, float64(stats.ErrorJitUnwindingMachinery), "jit_unwnding_machinery")
 
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.SuccessJitFrame), "jit_frame")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.SuccessJitToDwarf), "jit_to_dwarf")

--- a/pkg/profiler/cpu/bpf_metrics_collector.go
+++ b/pkg/profiler/cpu/bpf_metrics_collector.go
@@ -123,10 +123,9 @@ func (c *bpfMetricsCollector) readCounters() (unwinderStats, error) {
 		total.ErrorCatchall += partial.ErrorCatchall
 		total.ErrorShouldNeverHappen += partial.ErrorShouldNeverHappen
 		total.ErrorPcNotCovered += partial.ErrorPcNotCovered
+		total.ErrorPcNotCoveredJit += partial.ErrorPcNotCoveredJit
 		total.ErrorJitUnupdatedMapping += partial.ErrorJitUnupdatedMapping
 		total.ErrorJitMixedModeDisabled += partial.ErrorJitMixedModeDisabled
-		total.ErrorPcNotCoveredJit += partial.ErrorPcNotCoveredJit
-		total.ErrorJitUnwindingMachinery += partial.ErrorJitUnwindingMachinery
 		total.SuccessJitFrame += partial.SuccessJitFrame
 		total.SuccessJitToDwarf += partial.SuccessJitToDwarf
 		total.SuccessDwarfToJit += partial.SuccessDwarfToJit

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -359,16 +359,16 @@ func (p *CPU) addUnwindTableForProcess(ctx context.Context, pid int) {
 
 	level.Debug(p.logger).Log("msg", "adding unwind tables", "pid", pid)
 
-	// @nocommit: Improve.
+	// TODO: Improve.
 	procInfo, err := p.processInfoManager.Fetch(ctx, pid)
 	if err != nil {
-		level.Error(p.logger).Log("msg", "failed to fetch process info", "pid", pid, "err", err)
+		level.Debug(p.logger).Log("msg", "failed to fetch process info", "pid", pid, "err", err)
 	}
 
 	if procInfo.Interpreter != nil {
 		err := p.bpfMaps.addInterpreter(pid, *procInfo.Interpreter)
 		if err != nil {
-			level.Error(p.logger).Log("msg", "failed to call addInterpreter", "pid", pid, "err", err)
+			level.Debug(p.logger).Log("msg", "failed to call addInterpreter", "pid", pid, "err", err)
 			return
 		}
 	}

--- a/pkg/profiler/cpu/maps.go
+++ b/pkg/profiler/cpu/maps.go
@@ -130,10 +130,9 @@ type unwinderStats struct {
 	ErrorCatchall               uint64
 	ErrorShouldNeverHappen      uint64
 	ErrorPcNotCovered           uint64
+	ErrorPcNotCoveredJit        uint64
 	ErrorJitUnupdatedMapping    uint64
 	ErrorJitMixedModeDisabled   uint64
-	ErrorPcNotCoveredJit        uint64
-	ErrorJitUnwindingMachinery  uint64
 	SuccessJitFrame             uint64
 	SuccessJitToDwarf           uint64
 	SuccessDwarfToJit           uint64


### PR DESCRIPTION
Currently the unwinder metrics are not being updated and remain zero throughout profiling. The error in question:

```
readPerCpuCounter failed" error="get count values: failed to lookup value 0xc002720a40 in map percpu_stats: invalid argument
```

Was due to a mismatch of the structure in C and Go. In particular the `ErrorJitUnwindingMachinery` field only existed in Go, causing the read to fail as there were 8 extra bytes that were not expected.

Additionally, some other field was in the wrong position, which would have caused wrong data had the read succeed.

In the future we will fix this with a more automated binding generation. We have evaluated some options here but we weren't satisfied with the outcomes so far, but this is something we really want to tackle once we have the bandwidth.

Test Plan
=========

Tested locally, it works. I've added some integration tests which is not fully done yet, because I can't seem to figure out why the counters aren't bumped during tests. Will fix this later on.

```
[javierhonduco@fedora parca-agent]$ curl --silent http://localhost:7071/metrics | grep native | grep dwarf
parca_agent_native_unwinder_samples_total{unwinder="dwarf"} 8
parca_agent_native_unwinder_success_total{unwinder="dwarf"} 8
parca_agent_native_unwinder_success_total{unwinder="dwarf_reach_bottom"} 8
parca_agent_native_unwinder_success_total{unwinder="dwarf_to_jit"} 0
parca_agent_native_unwinder_success_total{unwinder="jit_to_dwarf"} 0
```
