### PR TITLE
pkg/stack/unwind: Handle undefined return addresses in arm64 compact unwind table

### DIFF
--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -201,11 +201,7 @@ func rowToCompactRow(row *UnwindTableRow, arch elf.Machine) (CompactUnwindTableR
 		// fmt.Println("Rule Unknown: RA")
 	case frame.RuleUndefined:
 		// fmt.Println("Rule Undefined: RA")
-		// TODO(sylfrena): Investigate what happens if we remove the condition below
-		// Why are we setting rbpType in RA Rule switch?
-		if arch == elf.EM_X86_64 {
-			rbpType = uint8(rbpTypeUndefinedReturnAddress)
-		}
+		rbpType = uint8(rbpTypeUndefinedReturnAddress)
 	}
 
 	return CompactUnwindTableRow{

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -128,6 +128,24 @@ func TestCompactUnwindTableX86(t *testing.T) {
 			},
 		},
 		{
+			name: "RA Rule undefined",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.X86_64StackPointer, Offset: 0},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleUndefined, Offset: 0},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   2,
+				cfaOffset: 0,
+				rbpType:   4,
+				rbpOffset: 0,
+			},
+		},
+		{
 			name: "RBP offset",
 			input: UnwindTableRow{
 				Loc: 123,
@@ -296,6 +314,24 @@ func TestCompactUnwindTableArm64(t *testing.T) {
 				cfaType:   3,
 				rbpType:   0,
 				cfaOffset: 0,
+				rbpOffset: 0,
+			},
+		},
+		{
+			name: "RA Rule undefined",
+			input: UnwindTableRow{
+				Loc: 123,
+				CFA: frame.DWRule{Rule: frame.RuleCFA, Reg: frame.Arm64StackPointer, Offset: 0},
+				RBP: frame.DWRule{Rule: frame.RuleUnknown},
+				RA:  frame.DWRule{Rule: frame.RuleUndefined, Offset: 0},
+			},
+
+			want: CompactUnwindTableRow{
+				pc:        123,
+				lrOffset:  0,
+				cfaType:   2,
+				cfaOffset: 0,
+				rbpType:   4,
 				rbpOffset: 0,
 			},
 		},


### PR DESCRIPTION

`rbpType` is not set correctly in case of Undefined Return Address in Link Register causing unwinding an extra frame despite reaching bottom frame(main()).

This was not caught by any tests in #1953(https://github.com/parca-dev/parca-agent/pull/1953) so add tests as well.

TEST PLAN
=========
Before:
```
=== RUN   TestCompactUnwindTableArm64/RA_Rule_undefined
compact_unwind_table_test.go:217:                                                                                        
                Error Trace:    /Users/icebear/Snow/polar/parca-agent/pkg/stack/unwind/compact_unwind_table_test.go:217      
                Error:          Not equal:                                                                                   
                                expected: unwind.CompactUnwindTable{unwind.CompactUnwindTableRow{pc:0x7b, lrOffset:0, cfaType
:0x1, rbpType:0x0, cfaOffset:0, rbpOffset:0}}                                                                                
                                actual  : unwind.CompactUnwindTable{unwind.CompactUnwindTableRow{pc:0x7b, lrOffset:0, cfaType
:0x2, rbpType:0x4, cfaOffset:0, rbpOffset:0}}
--- FAIL: TestCompactUnwindTableArm64/RA_Rule_undefined (0.00s)

=== RUN   TestCompactUnwindTableX86/RA_Rule_undefined
compact_unwind_table_test.go:407: 
Error Trace:    /Users/icebear/Snow/polar/parca-agent/pkg/stack/unwind/compact_unwind_table_test.go:407
Error:          Not equal: 
                expected: unwind.CompactUnwindTable{unwind.CompactUnwindTableRow{pc:0x7b, lrOffset:-16, cfaType
:0x2, rbpType:0x4, cfaOffset:0, rbpOffset:0}}
                actual  : unwind.CompactUnwindTable{unwind.CompactUnwindTableRow{pc:0x7b, lrOffset:0, cfaType
:0x1, rbpType:0x0, cfaOffset:0, rbpOffset:0}}
--- FAIL: TestCompactUnwindTableX86/RA_Rule_undefined (0.00s)  
```

After:
```
- PASS: TestCompactUnwindTableX86 (0.00s)                                                                                  
	- PASS: TestCompactUnwindTableX86/CFA_with_Offset_on_x86_64_stack_pointer (0.00s)
	- PASS: TestCompactUnwindTableX86/CFA_with_Offset_on_x86_64_frame_pointer (0.00s)
	- PASS: TestCompactUnwindTableX86/CFA_known_expression_PLT_1 (0.00s)
	- PASS: TestCompactUnwindTableX86/CFA_known_expression_PLT_2 (0.00s)
	- PASS: TestCompactUnwindTableX86/CFA_not_known_expression (0.00s)     
 	- PASS: TestCompactUnwindTableX86/RA_Rule_undefined (0.00s)            
 	- PASS: TestCompactUnwindTableX86/RBP_offset (0.00s)                   
 	- PASS: TestCompactUnwindTableX86/RBP_register (0.00s)                 
 	- PASS: TestCompactUnwindTableX86/RBP_expression (0.00s)               
 	- PASS: TestCompactUnwindTableX86/Invalid_CFA_rule_returns_error (0.00s)

-- PASS: TestCompactUnwindTableArm64 (0.00s)
	- PASS: TestCompactUnwindTableArm64/CFA_with_Offset_on_Arm64_stack_pointer (0.00s)
	- PASS: TestCompactUnwindTableArm64/CFA_with_Offset_on_Arm64_frame_pointer (0.00s)                       
	- PASS: TestCompactUnwindTableArm64/CFA_known_expression_PLT_1 (0.00s)                                   
	- PASS: TestCompactUnwindTableArm64/CFA_known_expression_PLT_2 (0.00s)                                   
	- PASS: TestCompactUnwindTableArm64/CFA_not_known_expression (0.00s)                                     
	- PASS: TestCompactUnwindTableArm64/RA_Rule_undefined (0.00s)                                            
	- PASS: TestCompactUnwindTableArm64/RBP_offset (0.00s)                                                   
	- PASS: TestCompactUnwindTableArm64/RBP_register (0.00s)
	- PASS: TestCompactUnwindTableArm64/RBP_expression (0.00s)
	- PASS: TestCompactUnwindTableArm64/Invalid_CFA_rule_returns_error (0.00s)
```


<!--

copilot:poem

-->
