### PR TITLE
pkg/perf: Resolve perfmap conflicts

### DIFF
--- a/pkg/perf/map.go
+++ b/pkg/perf/map.go
@@ -30,6 +30,25 @@ type Map struct {
 	addrs []MapAddr
 }
 
+func (p *Map) Deduplicate() *Map {
+	newAddrs := make([]MapAddr, len(p.addrs))
+
+	j := len(p.addrs) - 1
+	for i := len(p.addrs) - 1; i >= 0; i-- {
+		// The last symbol is the most up to date one, so if any earlier ones
+		// intersect with it we only keep the latest one.
+		if i > 0 && p.addrs[i-1].End > p.addrs[i].Start {
+			continue
+		}
+		newAddrs[j] = p.addrs[i]
+		j--
+	}
+
+	return &Map{
+		addrs: newAddrs[j+1:],
+	}
+}
+
 func (p *Map) Lookup(addr uint64) (string, error) {
 	idx := sort.Search(len(p.addrs), func(i int) bool {
 		return addr < p.addrs[i].End

--- a/pkg/perf/perf_test.go
+++ b/pkg/perf/perf_test.go
@@ -25,7 +25,7 @@ func TestPerfMapParse(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res.addrs, 28)
 	// Check for 4edd3cca B0 LazyCompile:~Timeout internal/timers.js:55
-	require.Equal(t, res.addrs[12], MapAddr{0x4edd4f12, 0x4edd4f47, "LazyCompile:~remove internal/linkedlist.js:15"})
+	require.Equal(t, MapAddr{0x4edd4f12, 0x4edd4f47, "LazyCompile:~remove internal/linkedlist.js:15"}, res.addrs[12])
 
 	// Look-up a symbol.
 	sym, err := res.Lookup(0x4edd4f12 + 4)


### PR DESCRIPTION
### Why?

Some customers have reported some unexpected nodejs symbols.

### What & How?

Perfmaps are often append-only, therefore the most up to date entries are the ones later in the file. To resolve conflicts, we still sort the results, but resolve conflicts by reverse iterating over the entries and removing entries if they overlap with the "latest" entry.

### Test Plan

Unit tests continue to pass, but it's hard to test without a real environment.