### PR TITLE
Reuse context in compact unwind table generation

### DIFF
--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -95,8 +95,9 @@ func (t CompactUnwindTable) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 // frame description entries.
 func BuildCompactUnwindTable(fdes frame.FrameDescriptionEntries, arch elf.Machine) (CompactUnwindTable, error) {
 	table := make(CompactUnwindTable, 0, 4*len(fdes)) // heuristic: we expect each function to have ~4 unwind entries.
+	context := frame.NewContext()
 	for _, fde := range fdes {
-		frameContext := frame.ExecuteDwarfProgram(fde, nil)
+		frameContext := frame.ExecuteDwarfProgram(fde, context)
 		for insCtx := frameContext.Next(); frameContext.HasNext(); insCtx = frameContext.Next() {
 			row := unwindTableRow(insCtx)
 			compactRow, err := rowToCompactRow(row, arch)


### PR DESCRIPTION
Rather than allocating new contexts.

```
$ go test -run=^$ -bench ^BenchmarkGenerateCompactUnwindTable$ github.com/parca-dev/parca-agent/pkg/stack/unwind -count=20 > new.txt
```
```
$ benchstat old.txt new.txt
name                           old time/op    new time/op    delta
GenerateCompactUnwindTable-12    23.4ms ±33%    17.2ms ±20%  -26.25%  (p=0.000 n=20+20)

name                           old alloc/op   new alloc/op   delta
GenerateCompactUnwindTable-12    12.9MB ± 0%     5.3MB ± 0%  -59.29%  (p=0.000 n=20+19)

name                           old allocs/op  new allocs/op  delta
GenerateCompactUnwindTable-12      108k ± 0%       66k ± 0%  -39.62%  (p=0.000 n=20+20)
```

**Before**

<img width="1139" alt="image" src="https://github.com/parca-dev/parca-agent/assets/959128/37704c19-77a5-4e2b-ac5e-ccea2935ffc8">


**After**

<img width="1139" alt="image" src="https://github.com/parca-dev/parca-agent/assets/959128/5caafcde-0342-451d-886c-e276548b174d">


Test Plan
=========

Snapshot tests and unit tests pass. We were already reusing the context in the snapshot tests for the non-compact unwind tables.