### PR TITLE
*: Add support for parsing v8 symbols

### DIFF
--- a/pkg/js/symbol.go
+++ b/pkg/js/symbol.go
@@ -1,0 +1,78 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package js
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var ErrInvalidJsSymbol = errors.New("invalid JS symbol")
+
+func IsJsSymbol(symbol string) bool {
+	return strings.HasPrefix(symbol, "JS:") ||
+		strings.HasPrefix(symbol, "Function:") ||
+		strings.HasPrefix(symbol, "LazyCompile:")
+}
+
+type JsSymbol struct {
+	FunctionName string
+	JsLocation
+}
+
+type JsLocation struct {
+	File         string
+	LineNumber   int
+	ColumnNumber int
+}
+
+func ParseJsSymbol(symbol string) (JsSymbol, error) {
+	parts := strings.Split(symbol, " ")
+	if len(parts) != 2 {
+		return JsSymbol{}, fmt.Errorf("invalid symbol not made of two parts: %w", ErrInvalidJsSymbol)
+	}
+
+	functionName := parts[0]
+	location := parts[1]
+	parts = strings.Split(location, ":")
+
+	if len(parts) < 2 || len(parts) > 3 {
+		return JsSymbol{}, fmt.Errorf("invalid location, not made of 2 or 3 parts: %w", ErrInvalidJsSymbol)
+	}
+
+	file := parts[0]
+	lineNumber, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return JsSymbol{}, fmt.Errorf("invalid line number: %w", ErrInvalidJsSymbol)
+	}
+
+	columnNumber := 0
+	if len(parts) == 3 {
+		columnNumber, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return JsSymbol{}, fmt.Errorf("invalid column number: %w", ErrInvalidJsSymbol)
+		}
+	}
+
+	return JsSymbol{
+		FunctionName: functionName,
+		JsLocation: JsLocation{
+			File:         file,
+			LineNumber:   lineNumber,
+			ColumnNumber: columnNumber,
+		},
+	}, nil
+}

--- a/pkg/js/symbol_test.go
+++ b/pkg/js/symbol_test.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJsSymbol(t *testing.T) {
+	symbol := "JS:*o.fib testdata/external-sourcemap/index.js:1:114"
+	jsSymbol, err := ParseJsSymbol(symbol)
+	require.NoError(t, err)
+
+	require.Equal(t, "JS:*o.fib", jsSymbol.FunctionName)
+	require.Equal(t, "testdata/external-sourcemap/index.js", jsSymbol.File)
+	require.Equal(t, 1, jsSymbol.LineNumber)
+	require.Equal(t, 114, jsSymbol.ColumnNumber)
+}
+
+func TestParseJsSymbolError(t *testing.T) {
+	symbol := "JS:*o.fib testdata/external-sourcemap/index.js"
+	_, err := ParseJsSymbol(symbol)
+	require.ErrorIs(t, err, ErrInvalidJsSymbol)
+}


### PR DESCRIPTION
### Why?

When profiling v8 today, symbols look like this

```
JS:*o.fib testdata/external-sourcemap/index.js:1:114
```

All shoved into the function name, which prevents pprof's deduplication and ultimately makes profiling data much harder to read.

### What?

Parse JS symbols.

### How?

First split by space, then by colon `:` to separate function name, filename, line number and column number.

### Test Plan

Wrote unit tests.