### PR TITLE
Js symbols continued (correctness and perf)

### DIFF
--- a/pkg/js/symbol.go
+++ b/pkg/js/symbol.go
@@ -48,20 +48,25 @@ func ParseJsSymbol(symbol string) (JsSymbol, error) {
 	functionName := parts[0]
 	location := parts[1]
 	parts = strings.Split(location, ":")
-
-	if len(parts) < 2 || len(parts) > 3 {
-		return JsSymbol{}, fmt.Errorf("invalid location, not made of 2 or 3 parts: %w", ErrInvalidJsSymbol)
+	expectedMaxParts := 3
+	file := parts[0]
+	if strings.HasPrefix(location, "node:") {
+		file += ":" + parts[1]
+		expectedMaxParts = 4
 	}
 
-	file := parts[0]
-	lineNumber, err := strconv.Atoi(parts[1])
+	if len(parts) < expectedMaxParts || len(parts) > expectedMaxParts {
+		return JsSymbol{}, fmt.Errorf("invalid location unexpected number of parts: %w", ErrInvalidJsSymbol)
+	}
+
+	lineNumber, err := strconv.Atoi(parts[len(parts)-2])
 	if err != nil {
 		return JsSymbol{}, fmt.Errorf("invalid line number: %w", ErrInvalidJsSymbol)
 	}
 
 	columnNumber := 0
-	if len(parts) == 3 {
-		columnNumber, err = strconv.Atoi(parts[2])
+	if len(parts) == expectedMaxParts {
+		columnNumber, err = strconv.Atoi(parts[len(parts)-1])
 		if err != nil {
 			return JsSymbol{}, fmt.Errorf("invalid column number: %w", ErrInvalidJsSymbol)
 		}

--- a/pkg/js/symbol_test.go
+++ b/pkg/js/symbol_test.go
@@ -69,6 +69,7 @@ func TestParseJsSymbol(t *testing.T) {
 var err error
 
 func BenchmarkParseJsSymbol(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_, err = ParseJsSymbol("JS:~Module.load node:internal/modules/cjs/loader:1079:33")
 	}

--- a/pkg/js/symbol_test.go
+++ b/pkg/js/symbol_test.go
@@ -20,18 +20,58 @@ import (
 )
 
 func TestParseJsSymbol(t *testing.T) {
-	symbol := "JS:*o.fib testdata/external-sourcemap/index.js:1:114"
-	jsSymbol, err := ParseJsSymbol(symbol)
-	require.NoError(t, err)
+	cases := []struct {
+		name     string
+		symbol   string
+		expected JsSymbol
+		err      error
+	}{{
+		name:   "internal",
+		symbol: "JS:~Module.load node:internal/modules/cjs/loader:1079:33",
+		expected: JsSymbol{
+			FunctionName: "JS:~Module.load",
+			JsLocation: JsLocation{
+				File:         "node:internal/modules/cjs/loader",
+				LineNumber:   1079,
+				ColumnNumber: 33,
+			},
+		},
+	}, {
+		name:   "user-symbol",
+		symbol: "JS:*o.fib testdata/external-sourcemap/index.js:1:114",
+		expected: JsSymbol{
+			FunctionName: "JS:*o.fib",
+			JsLocation: JsLocation{
+				File:         "testdata/external-sourcemap/index.js",
+				LineNumber:   1,
+				ColumnNumber: 114,
+			},
+		},
+	}, {
+		name:   "error",
+		symbol: "JS:*o.fib testdata/external-sourcemap/index.js",
+		err:    ErrInvalidJsSymbol,
+	}}
 
-	require.Equal(t, "JS:*o.fib", jsSymbol.FunctionName)
-	require.Equal(t, "testdata/external-sourcemap/index.js", jsSymbol.File)
-	require.Equal(t, 1, jsSymbol.LineNumber)
-	require.Equal(t, 114, jsSymbol.ColumnNumber)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			symbol, err := ParseJsSymbol(tc.symbol)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, symbol)
+		})
+	}
 }
 
-func TestParseJsSymbolError(t *testing.T) {
-	symbol := "JS:*o.fib testdata/external-sourcemap/index.js"
-	_, err := ParseJsSymbol(symbol)
-	require.ErrorIs(t, err, ErrInvalidJsSymbol)
+var err error
+
+func BenchmarkParseJsSymbol(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err = ParseJsSymbol("JS:~Module.load node:internal/modules/cjs/loader:1079:33")
+	}
+	// Prevent the compiler from optimizing away benchmark code.
+	_ = err
 }


### PR DESCRIPTION
### Why?

1) There were correctness issues in cases where the js symbol file name contained `node:` prefixes.
2) Perf was poor.

### What?

Fix correctness and improve perf.

```
$ benchstat old.txt new.txt
name              old time/op  new time/op  delta
ParseJsSymbol-10   164ns ± 1%    43ns ± 2%  -73.64%  (p=0.008 n=5+5)
```

### How?

Remove allocations from parsing and use base 10 specific parsing function.

### Test Plan

Benchmark and unit tests.