### PR TITLE
BPF: Add DWARF Unwinding  for Arm64

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -195,7 +195,7 @@ typedef struct {
    // A row in the stack unwinding table for Arm64.
   typedef struct __attribute__((packed)) {
     u64 pc;
-    #if __TARGET_ARCH_arm64 
+    #if __TARGET_ARCH_arm64
       s16 lr_offset;
     #endif
     u8 cfa_type;
@@ -836,7 +836,7 @@ int walk_user_stacktrace_impl(struct bpf_perf_event_data *ctx) {
       return 1;
     }
 
-    // lr offset is only fetched from userspace and used as a field in unwind table for Arm64 
+    // lr offset is only fetched from userspace and used as a field in unwind table for Arm64
     #if __TARGET_ARCH_arm64
       s16 found_lr_offset = unwind_table->rows[table_idx].lr_offset;
     #else

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -302,8 +302,9 @@ func loadBPFModules(logger log.Logger, reg prometheus.Registerer, memlockRlimit 
 			pyperfModule: pyperf,
 		}
 
+		arch := getArch()
 		// Maps must be initialized before loading the BPF code.
-		bpfMaps, err := initializeMaps(logger, reg, binary.LittleEndian, modules)
+		bpfMaps, err := initializeMaps(logger, reg, binary.LittleEndian, arch, modules)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize eBPF maps: %w", err)
 		}
@@ -1173,4 +1174,15 @@ func preprocessRawData(rawData map[profileKey]map[combinedStack]uint64) profile.
 	}
 
 	return res
+}
+
+func getArch() elf.Machine {
+	switch runtime.GOARCH {
+	case "arm64":
+		return elf.EM_AARCH64
+	case "amd64":
+		return elf.EM_X86_64
+	default:
+		return elf.EM_NONE
+	}
 }

--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -236,13 +236,13 @@ func CompactUnwindTableRepresentation(unwindTable UnwindTable, arch elf.Machine)
 
 // GenerateCompactUnwindTable produces the compact unwind table for a given
 // executable.
-func GenerateCompactUnwindTable(fullExecutablePath, executable string) (CompactUnwindTable, error) {
+func GenerateCompactUnwindTable(fullExecutablePath, executable string) (CompactUnwindTable, elf.Machine, error) {
 	var ut CompactUnwindTable
 
 	// Fetch FDEs.
 	fdes, arch, err := ReadFDEs(fullExecutablePath)
 	if err != nil {
-		return ut, err
+		return ut, arch, err
 	}
 
 	// Sort them, as this will ensure that the generated table
@@ -252,7 +252,7 @@ func GenerateCompactUnwindTable(fullExecutablePath, executable string) (CompactU
 	// Generate the compact unwind table.
 	ut, err = BuildCompactUnwindTable(fdes, arch)
 	if err != nil {
-		return ut, err
+		return ut, arch, err
 	}
 
 	// This should not be necessary, as per the sorting above, but
@@ -261,5 +261,5 @@ func GenerateCompactUnwindTable(fullExecutablePath, executable string) (CompactU
 	// any improvements. See benchmark in the test file.
 	sort.Sort(ut)
 
-	return ut, nil
+	return ut, arch, nil
 }

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -417,7 +417,7 @@ func BenchmarkGenerateCompactUnwindTable(b *testing.B) {
 
 	var cut CompactUnwindTable
 	for n := 0; n < b.N; n++ {
-		cut, _ = GenerateCompactUnwindTable("../../../testdata/vendored/x86/libpython3.10.so.1.0", "test")
+		cut, _, _ = GenerateCompactUnwindTable("../../../testdata/vendored/x86/libpython3.10.so.1.0", "test")
 	}
 
 	cutResult = cut


### PR DESCRIPTION
- Pass `lr_offset` to the BPF unwinder
- Change size of `stack_unwind_row_t` to **16** for Arm64 stacks
- `MAX_STACK_DEPTH_PER_PROGRAM` and `MAX_TAIL_CALLS` have been changed to 8 and 16 for for Arm64 to make the verifier happy 

TEST PLAN
===========

- tested with `basic-cpp-no-fp` binary
- unwind tables tested with binaries in testdata, including `libc.so.6`
```
--- PASS: TestCompactUnwindTableX86 (0.00s)
   --- PASS: TestCompactUnwindTableX86/CFA_with_Offset_on_x86_64_stack_pointer (0.00s)            
   --- PASS: TestCompactUnwindTableX86/CFA_with_Offset_on_x86_64_frame_pointer (0.00s)            
   --- PASS: TestCompactUnwindTableX86/CFA_known_expression_PLT_1 (0.00s)                         
   --- PASS: TestCompactUnwindTableX86/CFA_known_expression_PLT_2 (0.00s)                         
   --- PASS: TestCompactUnwindTableX86/CFA_not_known_expression (0.00s)                           
   --- PASS: TestCompactUnwindTableX86/RA_Rule_undefined (0.00s)                                  
   --- PASS: TestCompactUnwindTableX86/RBP_offset (0.00s)                                         
   --- PASS: TestCompactUnwindTableX86/RBP_register (0.00s)                                       
   --- PASS: TestCompactUnwindTableX86/RBP_expression (0.00s)                                     
   --- PASS: TestCompactUnwindTableX86/Invalid_CFA_rule_returns_error (0.00s)

--- PASS: TestCompactUnwindTableArm64 (0.00s)                                                      --- PASS: TestCompactUnwindTableArm64/CFA_with_Offset_on_Arm64_stack_pointer (0.00s)           
   --- PASS: TestCompactUnwindTableArm64/CFA_with_Offset_on_Arm64_frame_pointer (0.00s)           
   --- PASS: TestCompactUnwindTableArm64/CFA_known_expression_PLT_1 (0.00s)                       
   --- PASS: TestCompactUnwindTableArm64/CFA_known_expression_PLT_2 (0.00s)                       
   --- PASS: TestCompactUnwindTableArm64/CFA_not_known_expression (0.00s)                         
   --- PASS: TestCompactUnwindTableArm64/RA_Rule_undefined (0.00s)                                
   --- PASS: TestCompactUnwindTableArm64/RBP_offset (0.00s)                                       
   --- PASS: TestCompactUnwindTableArm64/RBP_register (0.00s)                                     
   --- PASS: TestCompactUnwindTableArm64/RBP_expression (0.00s)
   
   --- PASS: TestCompactUnwindTableArm64/Invalid_CFA_rule_returns_error (0.00s)
```
- Integration tests
```
 make test/profiler GO=$(which go) | grep -a1 PASS             
=== RUN   TestEfficientBufferInvariants                                                                                      
--- PASS: TestEfficientBufferInvariants (0.00s)                                                                              
=== RUN   TestEfficientBufferInvariants2                                                                                     
--- PASS: TestEfficientBufferInvariants2 (0.00s)                                                                             
=== RUN   TestEfficientBufferInvariant3                                                                                      
--- PASS: TestEfficientBufferInvariant3 (0.00s)                                                                              
=== RUN   TestEfficientBufferAgainstBinaryWrite                                                                              
--- PASS: TestEfficientBufferAgainstBinaryWrite (0.00s)                                                                      
PASS                                                                                                                         
ok      github.com/parca-dev/parca-agent/pkg/profiler   0.012s
--
=== RUN   TestFdInfoMemlock
--- PASS: TestFdInfoMemlock (0.00s)
=== RUN   TestDeleteNonExistentKeyReturnsEnoent
--
level=debug name=parca-cpu-test ts=2023-09-20T05:29:28.777895349Z caller=cpu.go:379 msg="updating interpreter data"
--- PASS: TestDeleteNonExistentKeyReturnsEnoent (0.32s)
=== RUN   TestDeleteExistentKey 
--
level=debug name=parca-cpu-test ts=2023-09-20T05:29:29.102568996Z caller=cpu.go:379 msg="updating interpreter data"
--- PASS: TestDeleteExistentKey (0.32s)
=== RUN   TestGetValueAndDeleteBatchWithEmptyMap
--
level=debug name=parca-cpu-test ts=2023-09-20T05:29:29.744133257Z caller=cpu.go:379 msg="updating interpreter data"
--- PASS: TestGetValueAndDeleteBatchWithEmptyMap (0.64s)
=== RUN   TestGetValueAndDeleteBatchFewerElementsThanCount
--
level=debug name=parca-cpu-test ts=2023-09-20T05:29:30.408704168Z caller=cpu.go:379 msg="updating interpreter data"
--- PASS: TestGetValueAndDeleteBatchFewerElementsThanCount (0.66s)
=== RUN   TestGetValueAndDeleteBatchExactElements
--
level=debug name=parca-cpu-test ts=2023-09-20T05:29:31.061589124Z caller=cpu.go:379 msg="updating interpreter data"
--- PASS: TestGetValueAndDeleteBatchExactElements (0.65s)
PASS
ok      github.com/parca-dev/parca-agent/pkg/profiler/cpu  
```

![image](https://github.com/parca-dev/parca-agent/assets/35404119/8c8fd721-07b1-4e7f-8fe2-de6839b45841)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2307f85</samp>

> _Sing, O Muse, of the valiant deeds of the unwinders,_
> _Who traced the paths of the stack in the fiery BPF modules._
> _They faced the challenge of the mighty Arm64 binaries,_
> _Which stored the return address in a different register._

-->
