### PR TITLE
Add profile store client that was removed by accident

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -40,6 +40,7 @@ import (
 
 	okrun "github.com/oklog/run"
 	debuginfopb "github.com/parca-dev/parca/gen/proto/go/parca/debuginfo/v1alpha1"
+	profilestorepb "github.com/parca-dev/parca/gen/proto/go/parca/profilestore/v1alpha1"
 	telemetrypb "github.com/parca-dev/parca/gen/proto/go/parca/telemetry/v1alpha1"
 
 	"github.com/armon/circbuf"
@@ -581,6 +582,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		}
 		defer conn.Close()
 
+		profileStoreClient = profilestorepb.NewProfileStoreServiceClient(conn)
 		if !flags.Debuginfo.UploadDisable {
 			debuginfoClient = debuginfopb.NewDebuginfoServiceClient(conn)
 		} else {


### PR DESCRIPTION
Add profile store client that was removed by accident in https://github.com/parca-dev/parca-agent/commit/28f5ed1a298a0e5a3ee1e5eec9a1b25f60d46a7b

Test Plan
=========

Can see profiles now

<img width="1391" alt="image" src="https://github.com/parca-dev/parca-agent/assets/959128/4554a379-19bc-4200-a6b8-91e626088748">
