### PR TITLE
pkg/cache: Fix data races

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -40,8 +40,8 @@ func (c *LRUCache[K, V]) Add(key K, value V) {
 }
 
 func (c *LRUCache[K, V]) Get(key K) (V, bool) {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	return c.lru.Get(key)
 }
 

--- a/pkg/cache/cache_with_ttl.go
+++ b/pkg/cache/cache_with_ttl.go
@@ -82,9 +82,9 @@ func (c *LRUCacheWithTTL[K, V]) Add(key K, value V) {
 }
 
 func (c *LRUCacheWithTTL[K, V]) Get(key K) (V, bool) {
-	c.mtx.RLock()
+	c.mtx.Lock()
 	v, ok := c.lru.Get(key)
-	c.mtx.RUnlock()
+	c.mtx.Unlock()
 	if !ok {
 		return v.value, false
 	}
@@ -127,7 +127,6 @@ func (c *LRUCacheWithTTL[K, V]) Purge() {
 func (c *LRUCacheWithTTL[K, V]) Close() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
-
 	return c.lru.Close()
 }
 
@@ -162,9 +161,9 @@ func (c *LRUCacheWithEvictionTTL[K, V]) Add(key K, value V) {
 }
 
 func (c *LRUCacheWithEvictionTTL[K, V]) Get(key K) (V, bool) {
-	c.mtx.RLock()
+	c.mtx.Lock()
 	v, ok := c.lru.Get(key)
-	c.mtx.RUnlock()
+	c.mtx.Unlock()
 	if !ok {
 		var zero V
 		return zero, false

--- a/pkg/cache/lru/lru.go
+++ b/pkg/cache/lru/lru.go
@@ -113,10 +113,10 @@ func (c *LRU[K, V]) removeOldest() {
 func (c *LRU[K, V]) removeElement(e *list.Element) {
 	c.evictList.Remove(e)
 	kv := e.Value.(entry[K, V])
-	delete(c.items, kv.key)
 	if c.onEvicted != nil {
 		c.onEvicted(kv.key, kv.value)
 	}
+	delete(c.items, kv.key)
 	c.metrics.evictions.Inc()
 }
 


### PR DESCRIPTION
Get() modify state, for LRU bookkeeping purposes, hence we need to use a writer lock.

Stop spawning goroutines for every callback as this introduces another data race.

Test Plan
=========

The data races reported by tsan (make ENABLE_RACE=yes) are gone!

Both Kemal and myself have ran this code with a very small object pool
over night without any issues

