### PR TITLE
objectfile: Add RC to track ObjectFile life-cycle

### DIFF
--- a/pkg/objectfile/object_file.go
+++ b/pkg/objectfile/object_file.go
@@ -102,7 +102,6 @@ func (o *objectFile) close() error {
 
 	if o.closed.Load() {
 		return errors.Join(ErrAlreadyClosed, fmt.Errorf("file %s is already closed by: %s", o.Path, frames(o.closedBy)))
-
 	}
 	o.closed.Store(true)
 	// NOTICE: This close is a no-op. The elf.File is opened through elf.NewFile,

--- a/pkg/objectfile/reference.go
+++ b/pkg/objectfile/reference.go
@@ -1,0 +1,175 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package objectfile
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+// This component provides a mechanism for managing the life cycle of a resource manually using reference counting.
+// e.g. When a file is evicted from the memory, it ensures that the file isn't removed from disk until all active users have completed their operations.
+//
+// While similar functionality can be achieved using runtime.SetFinalizer (this component also use it as a fallback mechanism),
+// this component takes a more explicit approach towards handling references, which not only provides greater clarity,
+// but also gives ability to avoid the overhead of allocation/opening costly resources repeatedly.
+
+// This component also provides full concurrent safety. All operations are wait-free, ensuring smooth execution even with multiple concurrent accesses.
+// One of the key guarantees is that the closer/destructor, which handles the removal of references, is called only once, and that too only when no live references remain.
+// This is executed synchronously upon the release of the final reference.
+
+// Furthermore, it ensures that references can be released only once, preventing potential duplication errors.
+// Importantly, no new references can be created once the closer/destructor has run its course, preserving the integrity of the process.
+// Another feature is that if Clone function is called post the execution of Release function, the cloning process will fail.
+
+var (
+	ErrReferenceReleased     = errors.New("reference already released")
+	ErrResourceAlreadyClosed = errors.New("resource already closed")
+)
+
+type resource struct {
+	*objectFile
+
+	refCount *atomic.Int32
+	// This function intentionally excluded from the interface.
+	// The value type should not expose the closer/destructor except through the reference.
+	mtx    *sync.Mutex
+	closed bool
+	closer func() error
+}
+
+func newResource(val *objectFile, closer func() error) *resource {
+	res := &resource{val, atomic.NewInt32(0), &sync.Mutex{}, false, closer}
+	defer res.Inc()
+	// See https://pkg.go.dev/runtime#SetFinalizer.
+	runtime.SetFinalizer(res, func(res *resource) error {
+		// This is a fail-safe mechanism to ensure that the closer is called,
+		// even if the reference is not released manually.
+		return res.closer()
+	})
+	return res
+}
+
+func (r *resource) Inc() int32 {
+	return r.refCount.Inc()
+}
+
+func (r *resource) Dec() int32 {
+	return r.refCount.Dec()
+}
+
+func (r *resource) Value() *objectFile {
+	r.mtx.Lock()
+	if r.closed {
+		r.mtx.Unlock()
+		panic(ErrResourceAlreadyClosed)
+	}
+	r.mtx.Unlock()
+
+	return r.objectFile
+}
+
+func (r *resource) Close() error {
+	if r.closer == nil {
+		return nil
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	if err := r.closer(); err != nil {
+		return err
+	}
+	r.closed = true
+	return nil
+}
+
+type ObjectFile struct {
+	// The type should be a pointer type.
+	*resource
+	released *atomic.Bool
+}
+
+func NewReference(val *objectFile, closer func() error) *ObjectFile {
+	return newReference(newResource(val, closer))
+}
+
+func newReference(res *resource) *ObjectFile {
+	ref := &ObjectFile{res, atomic.NewBool(false)}
+	// See https://pkg.go.dev/runtime#SetFinalizer.
+	runtime.SetFinalizer(ref, func(ref *ObjectFile) error {
+		// This is a fail-safe mechanism to ensure that the closer/destructor is called,
+		// even if the reference is not released manually.
+		ref.MustRelease()
+		// return ref.Release()
+		return nil
+	})
+	return ref
+}
+
+func (r *ObjectFile) Clone() (*ObjectFile, error) {
+	if r.released.Load() {
+		return nil, ErrReferenceReleased
+	}
+	r.resource.Inc()
+	return newReference(r.resource), nil
+}
+
+func (r *ObjectFile) MustClone() *ObjectFile {
+	ref, err := r.Clone()
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
+func (r *ObjectFile) Release() error {
+	if !r.released.CompareAndSwap(false, true) {
+		return ErrReferenceReleased
+	}
+	if r.resource.Dec() == 0 {
+		return r.resource.Close()
+	}
+	return nil
+}
+
+func (r *ObjectFile) MustRelease() {
+	if !r.released.CompareAndSwap(false, true) {
+		panic(ErrReferenceReleased)
+	}
+	if r.resource.Dec() == 0 {
+		if err := r.resource.Close(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// Guard is a reference guard that to prevent actual reference to be released,
+// until the operation is complete with underlying value.
+type Guard struct {
+	*objectFile
+	ref *ObjectFile // Keeping a reference to the actual reference to prevent it from being GCed.
+}
+
+// Value intentionally panics to prevent accidental use of the value after the reference is released.
+func (r *ObjectFile) Value() Guard {
+	if r.released.Load() {
+		panic(ErrReferenceReleased)
+	}
+	return Guard{r.objectFile, r}
+}

--- a/pkg/objectfile/reference_test.go
+++ b/pkg/objectfile/reference_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package objectfile
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+var noopCloser = func() error { return nil }
+
+func TestReleaseOnce(t *testing.T) {
+	r := NewReference(&objectFile{}, noopCloser)
+
+	err := r.Release()
+	require.NoError(t, err)
+
+	err = r.Release()
+	require.Equalf(t, ErrReferenceReleased, err, "expected ErrReleased, actual: %s", err)
+
+	err = r.Release()
+	require.Equalf(t, ErrReferenceReleased, err, "expected ErrReleased, actual: %s", err)
+}
+
+func TestValue(t *testing.T) {
+	v := &objectFile{}
+	r := NewReference(v, noopCloser)
+
+	require.Equal(t, v, r.Value().objectFile)
+
+	// Release the reference and ensure that the value is no longer accessible.
+	require.NoError(t, r.Release())
+
+	func() {
+		defer func() {
+			require.Equalf(t, ErrReferenceReleased, recover(), "expected panic with ErrReleased, actual: %v", recover())
+		}()
+
+		r.Value()
+	}()
+}
+
+func TestClosedOnce(t *testing.T) {
+	callCount := atomic.NewInt32(0)
+	closer := func() error {
+		callCount.Inc()
+		return nil
+	}
+
+	root := NewReference(&objectFile{}, closer)
+
+	references := make([]*ObjectFile, 25)
+	for i := range references {
+		references[i] = root.MustClone()
+	}
+
+	err := root.Release()
+	require.NoErrorf(t, err, "unexpected error releasing root reference: %s", err)
+
+	require.Equalf(t, int32(0), callCount.Load(), "expected closer to not be called, actual: %d", callCount.Load())
+
+	var wg sync.WaitGroup
+	wg.Add(25)
+	for i := range references {
+		go func(idx int) {
+			defer wg.Done()
+			err := references[idx].Release()
+			require.NoErrorf(t, err, "unexpected error releasing reference #%d: %s", idx, err)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equalf(t, int32(1), callCount.Load(), "expected closer to be called 1 time, actual: %d", callCount.Load())
+}


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7f9d1c</samp>

Refactor the `objectfile` package to use reference-counting for managing `ObjectFile` resources. This simplifies the code, avoids leaks, and enables concurrent use of the same resource. Add new types and unit tests to support this change.

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7f9d1c</samp>

*  Rename `ObjectFile` type to `objectFile` and make it unexported, to avoid confusion with the new `ObjectFile` type that wraps a reference-counted resource ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L30-R32), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L51-R51), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L94-R94), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537L111-R112), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L317-R315))
*  Introduce a new `ObjectFile` type in `reference.go` that wraps a reference-counted `resource`, and provides methods for cloning, releasing, and accessing the underlying `objectFile` value ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-2ba5f4ca87a7baa7953d1c28c522a7f66d76b4f033fa24ec62816bdae86e191fR1-R175))
*  Implement reference-counting logic in the `resource` type, and a `Guard` type that prevents accidental use of the value after the reference is released ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-2ba5f4ca87a7baa7953d1c28c522a7f66d76b4f033fa24ec62816bdae86e191fR1-R175))
*  Update `Pool` methods to return cloned references of the `objectFile` resource, instead of the original one, and to keep the original reference until evicted ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L176-R173), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L201-R198), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L299-R298))
*  Update `Pool` methods to create and cache `objectFile` resources, instead of `ObjectFile` values ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L281-R278), [link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L317-R315))
*  Remove direct call to `close` method of the `objectFile` type from the `onEvicted` function of the `Pool` type, as it is handled by the reference-counting mechanism ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-092464fb7162e237d2388d6d49db571affbfb356a538c3490240cfc9ec581b95L156-L158))
*  Add unit tests for the new `ObjectFile` and `resource` types in `reference_test.go`, and verify their behavior and invariants ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-64fd1ae6dcbfcdc6607cbe1042034e683c8559c5725b7e138c27d5cc6279f86fR1-R89))
*  Add a blank line for formatting purposes in `object_file.go` ([link](https://github.com/parca-dev/parca-agent/pull/2045/files?diff=unified&w=0#diff-678278e8b8d78d40114e13df0e0e0033d0b9d5375d2e01e85ac0d05598fd9537R105))

### Test Plan
<!-- How did you test it? How can we test it? -->

<!--

copilot:poem

-->
