### PR TITLE
[do not merge] bpf: Reduce iteration size by 1

### DIFF
--- a/bpf/cpu/cpu.bpf.c
+++ b/bpf/cpu/cpu.bpf.c
@@ -21,19 +21,10 @@
 #define RUBY_UNWINDER_PROGRAM_ID 1
 #define PYTHON_UNWINDER_PROGRAM_ID 2
 
-#if __TARGET_ARCH_arm64
 // Number of frames to walk per tail call iteration.
 #define MAX_STACK_DEPTH_PER_PROGRAM 8
 // Number of BPF tail calls that will be attempted.
 #define MAX_TAIL_CALLS 16
-#endif
-
-#if __TARGET_ARCH_x86
-// Number of frames to walk per tail call iteration.
-#define MAX_STACK_DEPTH_PER_PROGRAM 9
-// Number of BPF tail calls that will be attempted.
-#define MAX_TAIL_CALLS 15
-#endif
 
 // Maximum number of frames.
 #define MAX_STACK_DEPTH 127

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
 	"github.com/puzpuzpuz/xsync/v2"
+	"github.com/zcalusic/sysinfo"
 	"golang.org/x/sys/unix"
 
 	"github.com/parca-dev/parca-agent/pkg/buildid"
@@ -591,7 +592,9 @@ func (p *CPU) Run(ctx context.Context) error {
 	level.Debug(p.logger).Log("msg", "loading BPF modules")
 	native, bpfMaps, err := loadBPFModules(p.logger, p.reg, p.config.MemlockRlimit, *p.config)
 	if err != nil {
-		return fmt.Errorf("load bpf program: %w", err)
+		var si sysinfo.SysInfo
+		si.GetSysInfo()
+		return fmt.Errorf("load bpf program: %w with kernel %s", err, si.Kernel.Release)
 	}
 	defer native.Close()
 	level.Debug(p.logger).Log("msg", "BPF modules loaded")


### PR DESCRIPTION
Our e2e tests in CI are failing with `argument list too long`. They seem to be running on `6.2.0-1011-azure`. So this failure is not expected but let's see if we can address this.

Reducing the size has a small performance penalty so it would be preferred to use a well-known kernel that works.
