### PR TITLE
e2e: Reduce waits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,14 +365,16 @@ observable-dev/down:
 
 E2E_KUBECONTEXT := parca-e2e
 
+.PHONY: actions-e2e-local
+actions-e2e-local:
+	minikube --profile=$(E2E_KUBECONTEXT) start --driver=kvm2
+	./e2e/ci-e2e.sh $(VERSION) $(E2E_KUBECONTEXT)
+	$(GO) test -timeout=20m -v ./e2e --context "$(E2E_KUBECONTEXT)" || minikube --profile=$(E2E_KUBECONTEXT) delete
+
 .PHONY: actions-e2e
 actions-e2e:
-	# If running locally, first run:
-	#    minikube --profile=$(E2E_KUBECONTEXT) start --driver=virtualbox
 	./e2e/ci-e2e.sh $(VERSION) $(E2E_KUBECONTEXT)
-	$(GO) test -v ./e2e --context "$(E2E_KUBECONTEXT)"
-	# If running locally, you can now delete the cluster:
-	#    minikube --profile=$(E2E_KUBECONTEXT) delete
+	$(GO) test -timeout=20m -v ./e2e --context "$(E2E_KUBECONTEXT)"
 
 .PHONY: $(DOCKER_BUILDER)
 $(DOCKER_BUILDER): Dockerfile.cross-builder | $(OUT_DIR) check_$(CMD_DOCKER)

--- a/e2e/ci-e2e.sh
+++ b/e2e/ci-e2e.sh
@@ -55,8 +55,7 @@ function deploy() {
     "${KUBECTL[@]}" --namespace=parca rollout status deployment/parca --timeout=2m
     "${KUBECTL[@]}" --namespace=parca rollout status daemonset/parca-agent --timeout=2m
 
-    echo '>>> Profiling system for 5 minutes...'
-    sleep 300
+    echo '>>> Finished deployment'
 }
 
 function main() {


### PR DESCRIPTION
Rather than wait 5 minutes no matter how long it actually takes, wait directly in the tests.

Also, reduce some waiting times and timeouts that were too large, add a build rule to run tests locally and remove printed kernel version as this doesn't run in k8s and it might be not very clear.

15 minutes have been chosen because running in CI typically takes 10 minutes.
