### PR TITLE
docs: update kernel minimum requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Parca-agent follows [CNCF Code of Conduct](https://github.com/cncf/foundation/bl
 <!-- TODO: Add code of conduct info-->
 # Prerequisites
 
-- Linux Kernel version 4.18+
+- Linux Kernel version 5.4+
 - A source of targets to discover from: Kubernetes or systemd.
 
 Install the following dependencies (Instructions are linked for each dependency).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Parca-agent follows [CNCF Code of Conduct](https://github.com/cncf/foundation/bl
 <!-- TODO: Add code of conduct info-->
 # Prerequisites
 
-- Linux Kernel version 5.4+
+- Linux Kernel version 5.3+ with BTF
 - A source of targets to discover from: Kubernetes or systemd.
 
 Install the following dependencies (Instructions are linked for each dependency).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The collected data can be viewed locally via HTTP endpoints and then be configur
 
 ## Requirements
 
-* Linux Kernel version 5.4+
+* Linux Kernel version 5.3+ with BTF
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The collected data can be viewed locally via HTTP endpoints and then be configur
 
 ## Requirements
 
-* Linux Kernel version 4.18+
+* Linux Kernel version 5.4+
 
 ## Quickstart
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,7 +4,7 @@ Parca Agent implements a sampling profiler, to sample stack traces [19 times per
 
 Parca Agent is a whole-system profiler. It collects stack traces from all the processes that run on the host system. This provides more insights about all the aspects of the system to the user. Please see our [blog post](https://www.polarsignals.com/blog/posts/2022/08/24/system-wide-profiling/) about internals of this mechanism.
 
-Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)-capable Kernel (Linux Kernel 5.4+).
+Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)-capable Kernel (Linux Kernel 5.3+ with BTF).
 
 From a high level it performs the following steps:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,7 +4,7 @@ Parca Agent implements a sampling profiler, to sample stack traces [19 times per
 
 Parca Agent is a whole-system profiler. It collects stack traces from all the processes that run on the host system. This provides more insights about all the aspects of the system to the user. Please see our [blog post](https://www.polarsignals.com/blog/posts/2022/08/24/system-wide-profiling/) about internals of this mechanism.
 
-Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)-capable Kernel (Linux Kernel 4.18+).
+Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)-capable Kernel (Linux Kernel 5.4+).
 
 From a high level it performs the following steps:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,7 +13,7 @@ Parca Agent binaries and container image build processes have been specifically 
 
 ### No Clang/LLVM
 
-Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), and pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html) capable Kernel (Linux Kernel 5.4+).
+Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), and pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html) capable Kernel (Linux Kernel 5.3+ with BTF).
 
 ### No external dependencies
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,7 +13,7 @@ Parca Agent binaries and container image build processes have been specifically 
 
 ### No Clang/LLVM
 
-Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), and pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html) capable Kernel (Linux Kernel 4.18+).
+Parca Agent uses BPF CO-RE (Compile Once – Run Everywhere) using [libbpf](https://github.com/libbpf/libbpf), and pre-compiles all BPF programs, and statically embeds them in the target binary, from where it is loaded via libbpf when used. This means that Parca Agent does not need to compile the BPF program at startup or runtime like when using [bcc-tools](https://github.com/iovisor/bcc/tree/master/tools), meaning no Clang & LLVM, nor kernel headers need to be installed on the host. The only requirement is a [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html) capable Kernel (Linux Kernel 5.4+).
 
 ### No external dependencies
 


### PR DESCRIPTION
Related: #1769

According to [this](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md), 5.4 only introduces `BPF_MAP_TYPE_DEVMAP_HASH` for eBPF. Any explanation for why requiring 5.4 instead of the original 4.18+(e.g. Almalinux 8.7 would be excluded)?