### PR TITLE
bpf: Fix task identifier usage

### DIFF
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -52,7 +52,7 @@ import (
 )
 
 const (
-	DebugPIDsMapName              = "debug_pids"
+	DebugThreadsIDsMapName        = "debug_threads_ids"
 	StackCountsMapName            = "stack_counts"
 	eventsCountMapName            = "events_count"
 	StackTracesMapName            = "stack_traces"
@@ -707,21 +707,21 @@ func (m *Maps) AdjustMapSizes(debugEnabled bool, unwindTableShards, eventsBuffer
 		return fmt.Errorf("resize event map from default to %d elements: %w", maxProcesses, err)
 	}
 
-	// Adjust debug_pids size.
+	// Adjust debug_threads_ids size.
 	if debugEnabled {
-		debugPIDs, err := m.nativeModule.GetMap(DebugPIDsMapName)
+		debugThreadsIDs, err := m.nativeModule.GetMap(DebugThreadsIDsMapName)
 		if err != nil {
 			return fmt.Errorf("get debug pids map: %w", err)
 		}
-		if err := debugPIDs.SetMaxEntries(maxProcesses); err != nil {
-			return fmt.Errorf("resize debug pids map from default to %d elements: %w", maxProcesses, err)
+		if err := debugThreadsIDs.SetMaxEntries(maxProcesses); err != nil {
+			return fmt.Errorf("resize debug threads ids map from default to %d elements: %w", maxProcesses, err)
 		}
 	}
 	return nil
 }
 
 func (m *Maps) Create() error {
-	debugPIDs, err := m.nativeModule.GetMap(DebugPIDsMapName)
+	debugPIDs, err := m.nativeModule.GetMap(DebugThreadsIDsMapName)
 	if err != nil {
 		return fmt.Errorf("get debug pids map: %w", err)
 	}


### PR DESCRIPTION
The name of PID (process ID) and TID (thread ID) in the kernel vs. in userspace is different, which is a bit confusing [0].

We tried to be careful here, but in some cases we used the "per thread ID" (using this name for clarity's sake) when we should have used the "per process ID". While I don't believe this caused any correctness issues, it will add overhead for multi threaded applications. For example, in `process_info` we keep a mapping of "per process ID" to the process information, which among other things, it contains the executable mappings of the process, so we can find the current object we are executing. Having this "per thread ID" is redundant, as every sibling thread has the same memory mappings as they share the same address space.

With these changes we will reduce CPU usage as we have to do less work and we can keep more info in the BPF maps, as we will use them more efficiently.

Running https://github.com/parca-dev/testdata/pull/21: **Before**

```
$ ppstree -p `pidof basic-cpp-multithreaded-no-fp`
basic-cpp-multi(146858)─┬─{basic-cpp-multi}(146859)
                        └─{basic-cpp-multi}(146860)
```

```
$ sudo bpftool map dump name process_info | grep "key"
        "key": 146858,
        "key": 146859,
        "key": 146860,
```

**After**

```
$ sudo bpftool map dump name process_info | grep "key"
        "key": 146858,
```

Test Plan
=========

Before: https://pprof.me/2de82f2
After: https://pprof.me/4b7b713

+ integration tests + visual inspection of various profiles.

[0]: https://man7.org/linux/man-pages/man2/getpid.2.html (notes section)