### PR TITLE
Add check for known kernel issues

### DIFF
--- a/pkg/kernel/version.go
+++ b/pkg/kernel/version.go
@@ -1,0 +1,50 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package kernel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/zcalusic/sysinfo"
+)
+
+func GetRelease() (*semver.Version, error) {
+	var si sysinfo.SysInfo
+	si.GetSysInfo()
+
+	shortKernelVersion := si.Kernel.Release
+	splitted := strings.Split(si.Kernel.Release, "-")
+	if len(splitted) > 0 {
+		shortKernelVersion = splitted[0]
+	}
+
+	val, err := semver.NewVersion(shortKernelVersion)
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+func HasKnownBugs(version *semver.Version) bool {
+	knownBadRevisions, err := semver.NewConstraint(">=5.19, <6.1")
+	if err != nil {
+		// This will never happen. The line above is covered in tests.
+		panic(fmt.Sprintf("bad constrain, this should never happen %v", err))
+	}
+
+	return knownBadRevisions.Check(version)
+}

--- a/pkg/kernel/version_test.go
+++ b/pkg/kernel/version_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package kernel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnsupportedKernelVersions(t *testing.T) {
+	name := func(version string, knownBugs bool) string {
+		verb := "does not have"
+		if knownBugs {
+			verb = "has"
+		}
+		return fmt.Sprintf("%s %s known bugs", version, verb)
+	}
+
+	testcases := []struct {
+		version   string
+		knownBugs bool
+	}{
+		{
+			version:   "5.18",
+			knownBugs: false,
+		},
+		{
+			version:   "5.19",
+			knownBugs: true,
+		},
+		{
+			version:   "5.19.3",
+			knownBugs: true,
+		},
+		{
+			version:   "6.0.1",
+			knownBugs: true,
+		},
+		{
+			version:   "6.1",
+			knownBugs: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(name(tt.version, tt.knownBugs), func(t *testing.T) {
+			v := semver.MustParse(tt.version)
+			require.Equal(t, HasKnownBugs(v), tt.knownBugs)
+		})
+	}
+}


### PR DESCRIPTION
Releases >=5.19 && <6.1 have a pretty bad kernel bug that can result in whole sytem lock ups that can only be fixed with a reboot (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1033398).

The fix got backported to -stable
(https://www.spinics.net/lists/stable/msg662452.html, and https://www.spinics.net/lists/stable/msg662218.html for 6.1 and 6.3 respectively).

Let's not run the Agent in these kernels, but provide a flag to bypass this check. Note that running a buggy kernel can result in your machine going down.

Related issue: https://github.com/parca-dev/parca-agent/issues/1675

Test Plan
=========

Tested locally + added unit tests
