### PR TITLE
pkg/stack/unwind: Remove unused argument

### DIFF
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1616,7 +1616,7 @@ func (m *Maps) setUnwindTableForMapping(buf *profiler.EfficientBuffer, pid int, 
 		// Generate the unwind table.
 		// PERF(javierhonduco): Not reusing a buffer here yet, let's profile and decide whether this
 		// change would be worth it.
-		ut, arch, err := unwind.GenerateCompactUnwindTable(fullExecutablePath, mapping.Executable)
+		ut, arch, err := unwind.GenerateCompactUnwindTable(fullExecutablePath)
 		level.Debug(m.logger).Log("msg", "found unwind entries", "executable", mapping.Executable, "len", len(ut))
 
 		if err != nil {

--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -236,7 +236,7 @@ func CompactUnwindTableRepresentation(unwindTable UnwindTable, arch elf.Machine)
 
 // GenerateCompactUnwindTable produces the compact unwind table for a given
 // executable.
-func GenerateCompactUnwindTable(fullExecutablePath, executable string) (CompactUnwindTable, elf.Machine, error) {
+func GenerateCompactUnwindTable(fullExecutablePath string) (CompactUnwindTable, elf.Machine, error) {
 	var ut CompactUnwindTable
 
 	// Fetch FDEs.

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -413,12 +413,16 @@ func TestCompactUnwindTableArm64(t *testing.T) {
 var cutResult CompactUnwindTable
 
 func BenchmarkGenerateCompactUnwindTable(b *testing.B) {
+	objectFilePath := "../../../testdata/vendored/x86/libpython3.10.so.1.0"
+
 	b.ReportAllocs()
 
 	var cut CompactUnwindTable
+	var err error
 	for n := 0; n < b.N; n++ {
-		cut, _, _ = GenerateCompactUnwindTable("../../../testdata/vendored/x86/libpython3.10.so.1.0", "test")
+		cut, _, err = GenerateCompactUnwindTable(objectFilePath)
 	}
 
+	require.Nil(b, err)
 	cutResult = cut
 }


### PR DESCRIPTION
Remove unused argument from GenerateCompactUnwindTable and ensure its benchmark is not failing.

Test Plan
=======

CI