### PR TITLE
Add support for printing the final BPF tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ $(OUT_BIN_EH_FRAME): go/deps
 write-dwarf-unwind-tables: build
 	make -C testdata validate EH_FRAME_BIN=../dist/eh-frame
 	make -C testdata validate-compact EH_FRAME_BIN=../dist/eh-frame
+	make -C testdata validate-final EH_FRAME_BIN=../dist/eh-frame
 
 test-dwarf-unwind-tables: write-dwarf-unwind-tables
 	$(CMD_GIT) diff --exit-code testdata/

--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -15,6 +15,7 @@
 package unwind
 
 import (
+	"bytes"
 	"debug/elf"
 	"fmt"
 	"sort"
@@ -83,6 +84,21 @@ func (cutr *CompactUnwindTableRow) RbpOffset() int16 {
 
 func (cutr *CompactUnwindTableRow) IsEndOfFDEMarker() bool {
 	return cutr.cfaType == uint8(cfaTypeEndFdeMarker)
+}
+
+func (cutr *CompactUnwindTableRow) ToString(showLr bool) string {
+	r := bytes.NewBufferString("")
+
+	fmt.Fprintf(r, "pc: %x ", cutr.Pc())
+	fmt.Fprintf(r, "cfa_type: %-2d ", cutr.CfaType())
+	fmt.Fprintf(r, "rbp_type: %-2d ", cutr.RbpType())
+	fmt.Fprintf(r, "cfa_offset: %-4d ", cutr.CfaOffset())
+	fmt.Fprintf(r, "rbp_offset: %-4d", cutr.RbpOffset())
+	if showLr {
+		fmt.Fprintf(r, "lr_offset: %-4d", cutr.LrOffset())
+	}
+
+	return r.String()
 }
 
 type CompactUnwindTable []CompactUnwindTableRow

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -116,17 +116,8 @@ func (ptb *UnwindTableBuilder) PrintTable(writer io.Writer, path string, compact
 					return err
 				}
 
-				fmt.Fprintf(writer, "\t")
-				fmt.Fprintf(writer, "pc: %x ", compactRow.Pc())
-				fmt.Fprintf(writer, "cfa_type: %-2d ", compactRow.CfaType())
-				fmt.Fprintf(writer, "rbp_type: %-2d ", compactRow.RbpType())
-				fmt.Fprintf(writer, "cfa_offset: %-4d ", compactRow.CfaOffset())
-				fmt.Fprintf(writer, "rbp_offset: %-4d", compactRow.RbpOffset())
-				if arch == elf.EM_AARCH64 {
-					fmt.Fprintf(writer, "lr_offset: %-4d", compactRow.LrOffset())
-				}
-
-				fmt.Fprintf(writer, "\n")
+				showLr := arch == elf.EM_AARCH64
+				fmt.Fprintf(writer, "\t%s\n", compactRow.ToString(showLr))
 			} else {
 				//nolint:exhaustive
 				switch unwindRow.CFA.Rule {


### PR DESCRIPTION
Final BPF tables contain all the post-processing done to them before
being loaded in the BPF maps. This PR also refactors the printing to
be reused in the compact table generation, too.

