### PR TITLE
Remove redundant unwind rows

### DIFF
--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -434,6 +434,23 @@ func requireNoDuplicatedPC(t *testing.T, ut CompactUnwindTable) {
 	}
 }
 
+func requireNoRedundantRows(t *testing.T, ut CompactUnwindTable) {
+	t.Helper()
+
+	var lastRow CompactUnwindTableRow
+	for _, row := range ut {
+		row := row
+
+		// Not using IsRedundant because if it were buggy this test
+		// would be useless.
+		lastRow.pc = 0
+		row.pc = 0
+
+		require.NotEqual(t, lastRow, row)
+		lastRow = row
+	}
+}
+
 func TestIsSorted(t *testing.T) {
 	matches, err := filepath.Glob("../../../testdata/vendored/x86/*")
 	require.Nil(t, err)
@@ -454,6 +471,17 @@ func TestNoRepeatedPCs(t *testing.T) {
 		ut, _, err := GenerateCompactUnwindTable(match)
 		require.Nil(t, err)
 		requireNoDuplicatedPC(t, ut)
+	}
+}
+
+func TestNoRedundantRows(t *testing.T) {
+	matches, err := filepath.Glob("../../../testdata/vendored/x86/*")
+	require.Nil(t, err)
+
+	for _, match := range matches {
+		ut, _, err := GenerateCompactUnwindTable(match)
+		require.Nil(t, err)
+		requireNoRedundantRows(t, ut)
 	}
 }
 


### PR DESCRIPTION
As we binary search over the unwind information, any neighbouring rows with the same unwind info can be summarised in just one.

This optimisation was obvious from early on and I added it back in September last year (parca-dev/parca-agent#794) but it was removed later on and never re-added.

Test Plan
=========

Snapshot tests + added unit tests
