### PR TITLE
Add support for more Ruby versions

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -380,7 +380,7 @@ func (p *CPU) addUnwindTableForProcess(ctx context.Context, pid int) {
 	if procInfo.Interpreter != nil {
 		err := p.bpfMaps.AddInterpreter(pid, *procInfo.Interpreter)
 		if err != nil {
-			level.Debug(p.logger).Log("msg", "failed to call addInterpreter", "pid", pid, "err", err)
+			level.Debug(p.logger).Log("msg", "failed to call AddInterpreter", "pid", pid, "err", err)
 			return
 		}
 	}
@@ -418,8 +418,7 @@ func (p *CPU) prefetchProcessInfo(ctx context.Context, pid int) {
 	if procInfo.Interpreter != nil {
 		err := p.bpfMaps.AddInterpreter(pid, *procInfo.Interpreter)
 		if err != nil {
-			// Must never fail.
-			panic(err)
+			level.Error(p.logger).Log("msg", "failed to call AddInterpreter", "pid", pid, "err", err)
 		}
 	}
 }


### PR DESCRIPTION
See https://github.com/javierhonduco/rbperf/tree/fc31fb4c0c0cf23b1c44047b666ac502c7c05e90/src/ruby_versions

Test Plan
=========

Tested:

- [x] 2.6.0
- [x] 2.6.3
- [x] 2.7.1
- [x] 2.7.4
- [x] 2.7.6
- [x] 3.0.0
- [x] 3.1.2
- [x] 3.1.3
- [x] 3.2.0
- [x] 3.2.1

<img width="922" alt="image" src="https://github.com/parca-dev/parca-agent/assets/959128/88c037de-50dd-49c2-abcc-23e13b9a1f84">