### PR TITLE
Move debuginfo extraction to elfwriter package

### DIFF
--- a/pkg/debuginfo/manager.go
+++ b/pkg/debuginfo/manager.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/parca-dev/parca-agent/pkg/cache"
+	"github.com/parca-dev/parca-agent/pkg/elfwriter"
 	parcahttp "github.com/parca-dev/parca-agent/pkg/http"
 	"github.com/parca-dev/parca-agent/pkg/objectfile"
 	"github.com/parca-dev/parca-agent/pkg/process"
@@ -80,7 +81,7 @@ type Manager struct {
 
 	httpClient *http.Client
 
-	*Extractor
+	*elfwriter.Extractor
 	*Finder
 }
 
@@ -119,7 +120,7 @@ func New(
 		tempDir:         tempDir,
 
 		httpClient: parcahttp.NewClient(reg),
-		Extractor:  NewExtractor(logger, tracer),
+		Extractor:  elfwriter.NewExtractor(logger, tracer),
 		Finder:     NewFinder(logger, tracer, reg, debugDirs),
 
 		hashCache: hashCache,

--- a/pkg/elfwriter/elfwriter_test.go
+++ b/pkg/elfwriter/elfwriter_test.go
@@ -26,26 +26,6 @@ import (
 
 const textSectionName = ".text"
 
-var isDwarf = func(s *elf.Section) bool {
-	return strings.HasPrefix(s.Name, ".debug_") ||
-		strings.HasPrefix(s.Name, ".zdebug_") ||
-		strings.HasPrefix(s.Name, "__debug_") // macos
-}
-
-var isSymbolTable = func(s *elf.Section) bool {
-	return s.Name == ".symtab" ||
-		s.Name == ".dynsym" ||
-		s.Name == ".strtab" ||
-		s.Name == ".dynstr" ||
-		s.Type == elf.SHT_SYMTAB ||
-		s.Type == elf.SHT_DYNSYM ||
-		s.Type == elf.SHT_STRTAB
-}
-
-var isGoSymbolTable = func(s *elf.Section) bool {
-	return s.Name == ".gosymtab" || s.Name == ".gopclntab" || s.Name == ".go.buildinfo"
-}
-
 var isNote = func(s *elf.Section) bool {
 	return strings.HasPrefix(s.Name, ".note")
 }

--- a/pkg/elfwriter/extract.go
+++ b/pkg/elfwriter/extract.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 //
 
-package debuginfo
+package elfwriter
 
 import (
 	"context"
@@ -26,14 +26,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"go.opentelemetry.io/otel/trace"
-
-	"github.com/parca-dev/parca-agent/pkg/elfwriter"
 )
-
-type SeekReaderAt interface {
-	io.ReaderAt
-	io.Seeker
-}
 
 // Extractor extracts debug information from a binary.
 type Extractor struct {
@@ -86,7 +79,7 @@ func (e *Extractor) Extract(ctx context.Context, dst io.WriteSeeker, src SeekRea
 }
 
 func extract(dst io.WriteSeeker, src SeekReaderAt) error {
-	w, err := elfwriter.NewFromSource(dst, src)
+	w, err := NewFromSource(dst, src)
 	if err != nil {
 		return fmt.Errorf("failed to initialize writer: %w", err)
 	}

--- a/pkg/elfwriter/extract_test.go
+++ b/pkg/elfwriter/extract_test.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 //
 
-package debuginfo
+package elfwriter
 
 import (
 	"debug/elf"
@@ -36,7 +36,7 @@ func TestExtractor_Extract(t *testing.T) {
 		{
 			name: "valid extracted debuginfo",
 			args: args{
-				src: "testdata/readelf-sections",
+				src: "../debuginfo/testdata/readelf-sections",
 			},
 			expectedProgramHeaders: []elf.ProgHeader{
 				{


### PR DESCRIPTION
The debuginfo package has dependencies to Linux only things which makes it hard to test extraction on osx. This is primarily to make development easier.
