### PR TITLE
*: Optimize procinfo mapping updates

### DIFF
--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -289,7 +289,6 @@ func (im *InfoManager) fetch(ctx context.Context, pid int) (info Info, err error
 		Mappings:    mappings,
 		Interpreter: interp,
 	}
-
 	im.cache.Add(pid, info)
 
 	now = time.Now()

--- a/pkg/process/maps.go
+++ b/pkg/process/maps.go
@@ -16,8 +16,10 @@ package process
 
 import (
 	"debug/elf"
+	"encoding/gob"
 	"errors"
 	"fmt"
+	"hash/maphash"
 	"io/fs"
 	"os"
 	"path"
@@ -94,7 +96,7 @@ func (ms Mappings) ConvertToPprof() []*profile.Mapping {
 	return res
 }
 
-func (ms Mappings) ExecutableSections() []*Mapping {
+func (ms Mappings) Executables() []*Mapping {
 	res := make([]*Mapping, 0, len(ms))
 
 	for _, m := range ms {
@@ -104,6 +106,25 @@ func (ms Mappings) ExecutableSections() []*Mapping {
 	}
 
 	return res
+}
+
+var seed = maphash.MakeSeed()
+
+// Hash produces a summary of the raw mappings.
+// It only hashes the raw mappings, not the bookkeeping information.
+func (ms Mappings) Hash() (uint64, error) {
+	rawMappings := make([]*procfs.ProcMap, 0, len(ms))
+	for _, m := range ms {
+		rawMappings = append(rawMappings, m.ProcMap)
+	}
+	var h maphash.Hash
+	h.SetSeed(seed)
+	encoder := gob.NewEncoder(&h)
+	err := encoder.Encode(rawMappings)
+	if err != nil {
+		return 0, fmt.Errorf("encode error: %w", err)
+	}
+	return h.Sum64(), nil
 }
 
 var (

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1288,7 +1288,7 @@ func (m *Maps) AddUnwindTableForProcess(pid int, executableMappings unwind.Execu
 	mappingInfoMemory.PutUint64(isJitCompiler)
 	// .interpreter_type
 	var interpreterType uint64
-	// Inportant: the below *must* be called after AddInterpreter.
+	// Important: the below *must* be called after AddInterpreter.
 	interp, ok := m.syncedInterpreters[pid]
 	if ok {
 		interpreterType = uint64(interp.Type)

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -38,6 +38,7 @@ type StackID struct {
 // TODO: Unify PID types.
 type ProcessInfoManager interface {
 	Fetch(ctx context.Context, pid int) (process.Info, error)
+	FetchWithFreshMappings(ctx context.Context, pid int) (process.Info, error)
 	Info(ctx context.Context, pid int) (process.Info, error)
 }
 

--- a/pkg/stack/unwind/executable.go
+++ b/pkg/stack/unwind/executable.go
@@ -96,7 +96,6 @@ func NewHasFramePointersCache(logger log.Logger, reg prometheus.Registerer) Fram
 }
 
 func HasFramePointers(executable string) (bool, error) {
-	// TODO(kakkoyun): Migrate objectfile and pool.
 	f, err := elf.Open(executable)
 	if err != nil {
 		return false, fmt.Errorf("failed to open ELF file for path %s: %w", executable, err)

--- a/pkg/stack/unwind/maps.go
+++ b/pkg/stack/unwind/maps.go
@@ -23,10 +23,6 @@ import (
 	"github.com/prometheus/procfs"
 )
 
-var seed = maphash.MakeSeed()
-
-// TODO(kakkoyun): Merge with process/mappings.
-
 // ExecutableMapping represents an executable memory mapping.
 type ExecutableMapping struct {
 	LoadAddr   uint64
@@ -89,6 +85,8 @@ func (pm ExecutableMappings) HasJitted() bool {
 	}
 	return false
 }
+
+var seed = maphash.MakeSeed()
 
 // Hash produces a summary of the executable mappings.
 func (pm ExecutableMappings) Hash() (uint64, error) {


### PR DESCRIPTION
- Make sure process information updated only it is necessary
- Refresh process info mappings when needed

### Why?
We need to make sure process information is always up-to-date for correctness.
While aiming for correctness, we should make sure we prevent unnecessary work.
This PR makes sure that process information and interpreter information is up-to-date when mappings are changed.
Also, refactors the event handling a little bit to make it easier to reason about.

### What?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b920269</samp>

This pull request improves the performance and accuracy of the process profiling by adding caching and hashing mechanisms for the process mappings and interpreter information. It also refactors some code in the `cpu`, `bpfmaps`, and `unwind` packages to simplify and clarify the logic.

### Test Plan

* Test locally against interpreters
