### PR TITLE
unwinder/native: Unify native stacks

### DIFF
--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -12,9 +12,8 @@
 typedef struct {
     int pid;
     int tgid;
-    int user_stack_id;
-    int kernel_stack_id;
-    u64 user_stack_id_dwarf_id;
+    u64 user_stack_id;
+    u64 kernel_stack_id;
     u64 interpreter_stack_id;
 } stack_count_key_t;
 

--- a/pkg/profiler/cpu/bpf/maps/metrics.go
+++ b/pkg/profiler/cpu/bpf/maps/metrics.go
@@ -49,7 +49,6 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m.refreshProcessInfoErrors.WithLabelValues(labelUnwindTableAdd)
 
 	m.mapCleanErrors.WithLabelValues(StackTracesMapName)
-	m.mapCleanErrors.WithLabelValues(DWARFStackTracesMapName)
 	m.mapCleanErrors.WithLabelValues(StackCountsMapName)
 	m.mapCleanErrors.WithLabelValues(ProcessInfoMapName)
 	m.mapCleanErrors.WithLabelValues(UnwindInfoChunksMapName)

--- a/pkg/profiler/cpu/bpf/programs/programs.go
+++ b/pkg/profiler/cpu/bpf/programs/programs.go
@@ -30,7 +30,7 @@ var (
 	objects embed.FS
 
 	// native programs.
-	CPUProgramFD              = uint64(0)
+	NativeProgramFD           = uint64(0)
 	RubyEntrypointProgramFD   = uint64(1)
 	PythonEntrypointProgramFD = uint64(2)
 	// rbperf programs.
@@ -38,8 +38,8 @@ var (
 	// python programs.
 	PythonUnwinderProgramFD = uint64(0)
 
-	ProgramName              = "profile_cpu"
-	DWARFUnwinderProgramName = "walk_user_stacktrace_impl"
+	ProgramName              = "entrypoint"
+	DWARFUnwinderProgramName = "unwind_with_dwarf_info"
 )
 
 type CombinedStack [tripleStackDepth]uint64

--- a/pkg/profiler/cpu/metrics.go
+++ b/pkg/profiler/cpu/metrics.go
@@ -26,20 +26,19 @@ const (
 
 	labelKernelUnwind      = "kernel_unwind"
 	labelInterpreterUnwind = "interpreter_unwind"
-	labelDwarfUnwind       = "dwarf_unwind"
+	labelNativeUnwind      = "native_unwind"
 
 	labelError   = "error"
 	labelMissing = "missing"
 	labelFailed  = "failed"
 	labelSuccess = "success"
 
-	labelStackDropReasonKey              = "read_stack_key"
-	labelStackDropReasonUserDWARF        = "read_user_stack_with_dwarf"
-	labelStackDropReasonUserFramePointer = "read_user_stack_with_frame_pointer"
-	labelStackDropReasonKernel           = "read_kernel_stack"
-	labelStackDropReasonCount            = "read_stack_count"
-	labelStackDropReasonZeroCount        = "read_stack_count_zero"
-	labelStackDropReasonIterator         = "iterator"
+	labelStackDropReasonKey       = "read_stack_key"
+	labelStackDropReasonUser      = "read_user_stack"
+	labelStackDropReasonKernel    = "read_kernel_stack"
+	labelStackDropReasonCount     = "read_stack_count"
+	labelStackDropReasonZeroCount = "read_stack_count_zero"
+	labelStackDropReasonIterator  = "iterator"
 
 	labelEventEmpty           = "empty"
 	labelEventUnwindInfo      = "unwind_info"
@@ -147,17 +146,16 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m.obtainAttempts.WithLabelValues(labelError)
 
 	m.stackDrop.WithLabelValues(labelStackDropReasonKey)
-	m.stackDrop.WithLabelValues(labelStackDropReasonUserDWARF)
-	m.stackDrop.WithLabelValues(labelStackDropReasonUserFramePointer)
+	m.stackDrop.WithLabelValues(labelStackDropReasonUser)
 	m.stackDrop.WithLabelValues(labelStackDropReasonKernel)
 	m.stackDrop.WithLabelValues(labelStackDropReasonCount)
 	m.stackDrop.WithLabelValues(labelStackDropReasonZeroCount)
 	m.stackDrop.WithLabelValues(labelStackDropReasonIterator)
 
-	m.readMapAttempts.WithLabelValues(labelUser, labelDwarfUnwind, labelSuccess)
-	m.readMapAttempts.WithLabelValues(labelUser, labelDwarfUnwind, labelError)
-	m.readMapAttempts.WithLabelValues(labelUser, labelDwarfUnwind, labelMissing)
-	m.readMapAttempts.WithLabelValues(labelUser, labelDwarfUnwind, labelFailed)
+	m.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelSuccess)
+	m.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelError)
+	m.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelMissing)
+	m.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelFailed)
 
 	m.readMapAttempts.WithLabelValues(labelUser, labelKernelUnwind, labelSuccess)
 	m.readMapAttempts.WithLabelValues(labelUser, labelKernelUnwind, labelError)


### PR DESCRIPTION
TL;DR: Unifying native stacks (fp, dwarf, kernel) decreases our BPF memory usage by ~70MB while reducing the amount of code. The effectiveness of stack storage and aggregation is improved and userspace might need to do less work thanks to it.

Context
=======

DWARF-derived unwinding stores its stack in a BPF hashmap where the stack hash (64 bits) is the key and the value is the stack formed by its addresses and length.

The kernel provided unwinder for user stacks with frame pointers and for kernel stacks was invoked via `bpf_get_stackid()` which only works with maps of type `BPF_MAP_TYPE_STACK_TRACE`.

This divergence led to our code needing two different maps for native stack storage, one for user code unwound without frame pointers `dwarf_stack_traces`, and another one for user code unwound with frame pointers, as well as kernel stacks `stack_traces`.

Having two maps is wasteful as this kernel memory is locked and can never be paged out. Tracing programs can't have lazily allocated maps either so ideally we would reduce memory usage.

Right now, each map roughly needs 66MB (excluding the overhead from internal bookeeping of the maps), 64000 entries * (8B key len + 8B len lenth + 8B size of frame * 127 frames).

Proposed solution
=================

This commit unifies all the native stack storage, the main changes are:

- Migrate user FP unwinder and kernel unwinder to `bpf_get_stack`, which received a byte buffer and returns the number of bytes of the unwound stack;
- Unify both stack storage maps into a single map, `stack_traces`;
- Remove custom stack readers for DWARF / FP / Kernel into a single helper as the stack layout is the same now;

As we now store all stacks in a single map with the same storage as before, now we ensure that the scratch stack is zeroed to ensure we have a better utilisation of the stack aggregation map. Before there could be garbage values after the length of the stack. This didn't affect correctness as we never read past it, but it resulted in worse aggregation as the stack hashes of two equal stacks with different garbage values would differ. This should also help make userspace faster in these cases as less data will have to be read / deleted from the stack agg maps.

Future work
===========

- We could also unify the interpreter stack here. This might be done in a different PR. A possibility would be to encode (frame_id << 32 | lineno) as a 64 bit value;
- The total stack storage is decreased by half. The effectiveness of it might be higher as we remove garbage values, but a way to tune the size of the maps would be ideal. This will be added in a forthcoming PR;

Test Plan
=========

- [x]: Integration tests must pass
- [x]: Kernel tests must pass
- [ ]: Run in Demo environment

