### PR TITLE
unwinder/interpreters: Unify interpreter stacks

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -210,8 +210,6 @@ typedef struct {
 BPF_HASH(debug_threads_ids, int, u8, 1); // Table size will be updated in userspace.
 BPF_HASH(process_info, int, process_info_t, MAX_PROCESSES);
 
-BPF_HASH(stack_traces, u64, stack_trace_t, MAX_STACK_TRACES_ENTRIES);
-
 BPF_HASH(unwind_info_chunks, u64, unwind_info_chunks_t,
          5 * 1000); // Mapping of executable ID to unwind info chunks.
 BPF_HASH(unwind_tables, u64, stack_unwind_table_t,

--- a/bpf/unwinders/pyperf.bpf.c
+++ b/bpf/unwinders/pyperf.bpf.c
@@ -397,7 +397,7 @@ submit:
   LOG("[debug] stack hash: %d", stack_hash);
 
   // Insert stack.
-  int err = bpf_map_update_elem(&interpreter_stack_traces, &stack_hash, &state->sample.stack, BPF_ANY);
+  int err = bpf_map_update_elem(&stack_traces, &stack_hash, &state->sample.stack, BPF_ANY);
   if (err != 0) {
     LOG("[error] bpf_map_update_elem with ret: %d", err);
   }

--- a/bpf/unwinders/rbperf.bpf.c
+++ b/bpf/unwinders/rbperf.bpf.c
@@ -276,7 +276,7 @@ int walk_ruby_stack(struct bpf_perf_event_data *ctx) {
     }
 
     // Insert stack.
-    int err = bpf_map_update_elem(&interpreter_stack_traces, &ruby_stack_hash, &state->stack.frames, BPF_ANY);
+    int err = bpf_map_update_elem(&stack_traces, &ruby_stack_hash, &state->stack.frames, BPF_ANY);
     if (err != 0) {
         LOG("[error] bpf_map_update_elem with ret: %d", err);
     }

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -48,7 +48,7 @@ struct {
     __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
     __type(key, u64);
     __type(value, stack_trace_t);
-} interpreter_stack_traces SEC(".maps"); // TODO think about this.
+} stack_traces SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -996,7 +996,9 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 
 		if key.InterpreterStackID != 0 {
 			// TODO: Improve error handling.
-			interpreterSymbolTable, interpErr = p.bpfMaps.ReadInterpreterStack(key.InterpreterStackID, interpreterStack)
+			interpreterSymbolTable, interpErr = p.bpfMaps.InterpreterSymbolTable()
+			interpErr = errors.Join(interpErr, p.bpfMaps.ReadStack(key.InterpreterStackID, interpreterStack))
+
 			if interpErr != nil {
 				p.metrics.readMapAttempts.WithLabelValues(labelInterpreter, labelInterpreterUnwind, labelError).Inc()
 				level.Debug(p.logger).Log("msg", "failed to read interpreter stacks", "err", interpErr)


### PR DESCRIPTION
A follow-up to [0] where native stacks were unified. This commit changes the interpreter stack storage to use the same storage as the native stacks, saving ~70 MB of BPF maps when the interpreters are enabled

Test Plan
=========

```
$ make && ./run-agent.sh
level=info name=parca-agent ts=2023-11-08T11:55:27.206248307Z caller=cpu.go:212 component=cpu_profiler msg="loaded rbperf BPF module"
level=info name=parca-agent ts=2023-11-08T11:55:27.208622214Z caller=cpu.go:229 component=cpu_profiler msg="loaded pyperf BPF module"
```

<img width="594" alt="image" src="https://github.com/parca-dev/parca-agent/assets/959128/9826a97c-0ceb-4b31-b55e-04ac6b0d7366">
