### PR TITLE
feat(snap): ensure snapd restarts service if the agent crashes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,4 +50,4 @@ apps:
     command: parca-agent-wrapper
     daemon: simple
     install-mode: disable
-    restart-condition: never
+    restart-condition: always


### PR DESCRIPTION
### Why?
If a user starts Parca Agent with `snap start parca-agent` and the agent crashes, currently it stays dormant.

### What?
A simple change to the systemd configuration for the snap daemon

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dc2bd8e</samp>

* Change the restart condition of the `parca-agent` service to always ([link](https://github.com/parca-dev/parca-agent/pull/2215/files?diff=unified&w=0#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5L53-R53)). This improves the reliability and availability of the agent, which collects and sends profiling data to the Parca server. The change was discussed and agreed upon in issue #62.

### Test Plan
<!-- How did you test it? How can we test it? -->

<!--

copilot:poem

-->
