### PR TITLE
metadata: Add arch label

### DIFF
--- a/pkg/kernel/common.go
+++ b/pkg/kernel/common.go
@@ -45,6 +45,16 @@ func Release() (string, error) {
 	return int8SliceToString(uname.Release[:]), nil
 }
 
+// Machine fetches the machine string of the current running kernel.
+func Machine() (string, error) {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return "", err
+	}
+
+	return int8SliceToString(uname.Machine[:]), nil
+}
+
 const vdsoPattern = "/usr/lib/modules/*/vdso/*.so"
 
 func FindVDSO() (string, error) {

--- a/pkg/metadata/java.go
+++ b/pkg/metadata/java.go
@@ -38,6 +38,7 @@ func Java(logger log.Logger, nsCache *namespace.Cache) Provider {
 			return nil, ctx.Err()
 		}
 
+		// TODO(kakkoyun): Move caching to this layer.
 		java, err := cache.IsJavaProcess(pid)
 		if err != nil {
 			return nil, fmt.Errorf("failed to determine if PID %d belongs to a java process: %w", pid, err)
@@ -51,6 +52,7 @@ func Java(logger log.Logger, nsCache *namespace.Cache) Provider {
 			"java": model.LabelValue(fmt.Sprintf("%t", java)),
 		}
 		if javaVersion, err := getJavaVersion(ctx, pid); err != nil {
+			// TODO(kakkoyun): Cache the whole label set.
 			res["jdk"] = model.LabelValue(javaVersion)
 		}
 		return res, nil

--- a/pkg/metadata/system.go
+++ b/pkg/metadata/system.go
@@ -50,15 +50,25 @@ func System() Provider {
 	}}}
 }
 
+const unknown = "unknown"
+
 // Call the system metadata getters just once as they will not
 // change while the Agent is running.
 func setMetadata() {
-	release := "unknown"
-	revision := "unknown"
+	var (
+		release      = unknown
+		revision     = unknown
+		architecture = unknown
+	)
 
 	r, err := kernel.Release()
 	if err == nil {
 		release = r
+	}
+
+	m, err := kernel.Machine()
+	if err == nil {
+		architecture = m
 	}
 
 	b, err := buildinfo.FetchBuildInfo()
@@ -68,5 +78,6 @@ func setMetadata() {
 	labels = model.LabelSet{
 		"kernel_release": model.LabelValue(release),
 		"agent_revision": model.LabelValue(revision),
+		"arch":           model.LabelValue(architecture),
 	}
 }


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Why?
<!-- author to complete -->
<!-- Please explain us why we need this change? -->

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 560d61a</samp>

Add "arch" label to parca-agent metadata and refactor metadata collection. This change uses a new `kernel.Machine` function to get the architecture information and adds TODO comments to `Java` function in `pkg/metadata/java.go` for future improvements.

### How?
<!-- Please explain us how should it work? Or let the copilot handle it. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 560d61a</samp>

*  Add architecture information to the metadata labels of the parca-agent ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-6c2e7538e4aa866cb928ff61f643a552b24fdc4dbea4e940f3ad53e256f8c103R48-R57), [link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-caa579f31e766ca2205d028a60a20c9ac822d7c0aac72bdab51eb85fda36f454R58), [link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-caa579f31e766ca2205d028a60a20c9ac822d7c0aac72bdab51eb85fda36f454R65-R69), [link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-caa579f31e766ca2205d028a60a20c9ac822d7c0aac72bdab51eb85fda36f454R77))
  - Define a new function `Machine` in the `kernel` package that returns the machine string of the current kernel using `syscall.Uname` ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-6c2e7538e4aa866cb928ff61f643a552b24fdc4dbea4e940f3ad53e256f8c103R48-R57))
  - Declare a variable `architecture` in the `setMetadata` function in the `system` package and initialize it to "unknown" ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-caa579f31e766ca2205d028a60a20c9ac822d7c0aac72bdab51eb85fda36f454R58))
  - Call the `Machine` function and assign its result to `architecture` if no error occurs ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-caa579f31e766ca2205d028a60a20c9ac822d7c0aac72bdab51eb85fda36f454R65-R69))
  - Add the `architecture` variable as a value for the "arch" key in the label set returned by `setMetadata` ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-caa579f31e766ca2205d028a60a20c9ac822d7c0aac72bdab51eb85fda36f454R77))
* Add TODO comments to the `Java` function in the `metadata` package to indicate future improvements for the caching logic ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-35835b1e76e2185d9ae1138faf6c0b347ce295ca3f965b004c8e8b64ce34a8f3R41), [link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-35835b1e76e2185d9ae1138faf6c0b347ce295ca3f965b004c8e8b64ce34a8f3R55))
  - Suggest moving the caching logic to the `metadata` layer instead of the `profile` layer ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-35835b1e76e2185d9ae1138faf6c0b347ce295ca3f965b004c8e8b64ce34a8f3R41))
  - Suggest caching the whole label set instead of individual values ([link](https://github.com/parca-dev/parca-agent/pull/2218/files?diff=unified&w=0#diff-35835b1e76e2185d9ae1138faf6c0b347ce295ca3f965b004c8e8b64ce34a8f3R55))

### Test Plan
<!-- How did you test it? How can we test it? -->

<!--

copilot:poem

-->
