### PR TITLE
metadata: Add runtime labels for NodeJS

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -835,6 +835,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		discoveryMetadata,
 		metadata.Target(flags.Node, flags.Metadata.ExternalLabels),
 		metadata.Compiler(logger, reg, ofp),
+		metadata.Runtime(pfs, reg),
 		metadata.Process(pfs),
 		metadata.Java(logger, nsCache),
 		metadata.System(),

--- a/pkg/metadata/labels/manager.go
+++ b/pkg/metadata/labels/manager.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -134,7 +135,7 @@ func (m *Manager) labelSet(ctx context.Context, pid int) (model.LabelSet, error)
 		lbl, err := provider.Labels(ctx, pid)
 		if err != nil {
 			// NOTICE: Can be too noisy. Keeping this for debugging purposes.
-			// level.Debug(p.logger).Log("msg", "failed to get metadata", "provider", provider.Name(), "err", err)
+			level.Debug(m.logger).Log("msg", "failed to get metadata", "provider", provider.Name(), "err", err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			span.End()

--- a/pkg/metadata/runtime.go
+++ b/pkg/metadata/runtime.go
@@ -1,0 +1,71 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//nolint:dupl
+package metadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/procfs"
+
+	"github.com/parca-dev/parca-agent/pkg/cache"
+	"github.com/parca-dev/parca-agent/pkg/runtime"
+	"github.com/parca-dev/parca-agent/pkg/runtime/vm"
+)
+
+func Runtime(procfs procfs.FS, reg prometheus.Registerer) Provider {
+	cache := cache.NewLRUCache[int, *runtime.Runtime](
+		prometheus.WrapRegistererWith(prometheus.Labels{"cache": "metadata_runtime"}, reg),
+		512,
+	)
+	return &StatelessProvider{"runtime", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		p, err := procfs.Proc(pid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate procfs for PID %d: %w", pid, err)
+		}
+
+		if rt, ok := cache.Get(pid); ok {
+			if rt == nil {
+				return nil, nil
+			}
+			return model.LabelSet{
+				"runtime":         model.LabelValue(rt.Type),
+				"runtime_version": model.LabelValue(rt.Version.String()),
+			}, nil
+		}
+
+		rt, err := vm.Fetch(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch interpreter info for PID %d: %w", pid, err)
+		}
+		if rt == nil {
+			cache.Add(pid, nil)
+			return nil, nil
+		}
+		cache.Add(pid, rt)
+
+		return model.LabelSet{
+			"runtime":         model.LabelValue(rt.Type),
+			"runtime_version": model.LabelValue(rt.Version.String()),
+		}, nil
+	}}
+}

--- a/pkg/runtime/nodejs/nodejs.go
+++ b/pkg/runtime/nodejs/nodejs.go
@@ -1,0 +1,240 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"debug/elf"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/prometheus/procfs"
+
+	"github.com/parca-dev/parca-agent/pkg/runtime"
+)
+
+var nodejsIdentifyingSymbols = [][]byte{
+	[]byte("InterpreterEntryTrampoline"),
+}
+
+func IsV8(ef *elf.File) (bool, error) {
+	return runtime.HasSymbols(ef, nodejsIdentifyingSymbols)
+}
+
+func IsRuntime(proc procfs.Proc) (bool, error) {
+	exe, err := proc.Executable()
+	if err != nil {
+		return false, err
+	}
+
+	var isNodeJS bool
+	if isNodeJSBin(exe) {
+		var err error
+		ef, err := elf.Open(absolutePath(proc, exe))
+		if err != nil {
+			return false, fmt.Errorf("open elf file: %w", err)
+		}
+
+		isNodeJS, err = runtime.HasSymbols(ef, nodejsIdentifyingSymbols)
+		if err != nil {
+			return false, fmt.Errorf("failed to check for symbols: %w", err)
+		}
+	}
+
+	if isNodeJS {
+		return true, nil
+	}
+
+	maps, err := proc.ProcMaps()
+	if err != nil {
+		return false, fmt.Errorf("error reading process maps: %w", err)
+	}
+
+	var (
+		found bool
+		lib   string
+	)
+	for _, m := range maps {
+		if pathname := m.Pathname; pathname != "" {
+			if m.Perms.Execute {
+				if isNodeJSLib(pathname) {
+					found = true
+					lib = pathname
+					break
+				}
+			}
+		}
+	}
+	if !found {
+		// If we didn't find a library, we can't be sure that this is a nodejs process.
+		return false, nil
+	}
+
+	ef, err := elf.Open(absolutePath(proc, lib))
+	if err != nil {
+		return false, fmt.Errorf("open elf file: %w", err)
+	}
+
+	isNodeJS, err = runtime.HasSymbols(ef, nodejsIdentifyingSymbols)
+	if err != nil {
+		return false, fmt.Errorf("failed to check for symbols: %w", err)
+	}
+
+	return isNodeJS, nil
+}
+
+func RuntimeInfo(proc procfs.Proc) (*runtime.Runtime, error) {
+	isNodeJS, err := IsRuntime(proc)
+	if err != nil {
+		return nil, fmt.Errorf("is runtime: %w", err)
+	}
+	if !isNodeJS {
+		return nil, nil //nolint:nilnil
+	}
+
+	rt := &runtime.Runtime{
+		Type: "nodejs",
+	}
+
+	exe, err := proc.Executable()
+	if err != nil {
+		return rt, err
+	}
+
+	f, err := os.Open(absolutePath(proc, exe))
+	if err != nil {
+		return rt, fmt.Errorf("open executable: %w", err)
+	}
+	defer f.Close()
+
+	versionString, err := versionFromData(f)
+	if err == nil {
+		version, err := semver.NewVersion(versionString)
+		if err != nil {
+			return rt, fmt.Errorf("new version, %s: %w", versionString, err)
+		}
+		rt.Version = version
+		return rt, nil
+	}
+
+	maps, err := proc.ProcMaps()
+	if err != nil {
+		return nil, fmt.Errorf("error reading process maps: %w", err)
+	}
+
+	var (
+		found bool
+		lib   string
+	)
+	for _, m := range maps {
+		if pathname := m.Pathname; pathname != "" {
+			if m.Perms.Execute {
+				if isNodeJSLib(pathname) {
+					found = true
+					lib = pathname
+					break
+				}
+			}
+		}
+	}
+	if !found {
+		return rt, fmt.Errorf("library %q not found in process maps", exe)
+	}
+
+	lf, err := os.Open(absolutePath(proc, lib))
+	if err != nil {
+		return rt, fmt.Errorf("open library: %w", err)
+	}
+	defer lf.Close()
+
+	versionString, err = versionFromData(lf)
+	if err != nil {
+		return rt, fmt.Errorf("version from data: %w", err)
+	}
+
+	version, err := semver.NewVersion(versionString)
+	if err != nil {
+		return rt, fmt.Errorf("new version, %s: %w", versionString, err)
+	}
+	rt.Version = version
+	return rt, nil
+}
+
+func isNodeJSBin(exe string) bool {
+	return path.Base(exe) == "node" || path.Base(exe) == "nodemon" || path.Base(exe) == "nodejs"
+}
+
+var libRegex = regexp.MustCompile(`/libnode.so\.[0-9]+`)
+
+func isNodeJSLib(lib string) bool {
+	return libRegex.MatchString(lib)
+}
+
+func absolutePath(proc procfs.Proc, p string) string {
+	return path.Join("/proc/", strconv.Itoa(proc.PID), "/root/", p)
+}
+
+func versionFromData(f *os.File) (string, error) {
+	ef, err := elf.NewFile(f)
+	if err != nil {
+		return "", fmt.Errorf("new file: %w", err)
+	}
+	defer ef.Close()
+
+	var lastError error
+	for _, sec := range ef.Sections {
+		if sec.Name == ".data" || sec.Name == ".rodata" {
+			data, err := sec.Data()
+			if err != nil {
+				lastError = fmt.Errorf("read data: %w", err)
+				continue
+			}
+			versionString, err := scanVersionBytes(data)
+			if err != nil {
+				lastError = fmt.Errorf("scan version bytes: %w", err)
+				continue
+			}
+			return versionString, nil
+		}
+	}
+	// If it is found, execution should never reach here.
+	if lastError != nil {
+		return "", lastError
+	}
+	return "", errors.New("version not found")
+}
+
+const semVerRegex string = `v([0-9]+)(\.[0-9]+)(\.[0-9]+)` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+func scanVersionBytes(data []byte) (string, error) {
+	nodejsVersionRegex := regexp.MustCompile(semVerRegex)
+
+	match := nodejsVersionRegex.FindSubmatch(data)
+	if match == nil {
+		return "", errors.New("failed to find version string")
+	}
+
+	ver, err := semver.NewVersion(string(match[0]))
+	if err != nil {
+		return "", err
+	}
+
+	return ver.Original(), nil
+}

--- a/pkg/runtime/nodejs/nodejs_test.go
+++ b/pkg/runtime/nodejs/nodejs_test.go
@@ -1,0 +1,125 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_scanVersionBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []byte
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:        "empty",
+			input:       []byte{},
+			expectedErr: true,
+		},
+		{
+			name:        "unmatched",
+			input:       []byte("asdasd"),
+			expectedErr: true,
+		},
+		{
+			name:     "v1.2.3",
+			input:    []byte("asdasd v1.2.3 asdasd"),
+			expected: "v1.2.3",
+		},
+		{
+			name:        "only major",
+			input:       []byte("asdasd v1 asdasd"),
+			expectedErr: true,
+		},
+		{
+			name:        "only major and minor",
+			input:       []byte("asdasd v1.2 asdasd"),
+			expectedErr: true,
+		},
+		{
+			name:     "Pre-release",
+			input:    []byte("asdasd v1.2.3-pre (asdasd)"),
+			expected: "v1.2.3-pre",
+		},
+		{
+			name:     "Release candidate",
+			input:    []byte("asdasd v1.2.3-rc.1 (asdasd)"),
+			expected: "v1.2.3-rc.1",
+		},
+		{
+			name:     "Build metadata",
+			input:    []byte("asdasd v1.2.3+build.1 (asdasd)"),
+			expected: "v1.2.3+build.1",
+		},
+		{
+			name:     "Pre-release and build metadata",
+			input:    []byte("asdasd v1.2.3-pre+build.1 (asdasd)"),
+			expected: "v1.2.3-pre+build.1",
+		},
+		{
+			name:     "With nodejs/ prefix",
+			input:    []byte(`asdasd nodejs/v1.2.3-pre+build.1 (asdasd)`),
+			expected: "v1.2.3-pre+build.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := scanVersionBytes(tt.input)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expected, version)
+		})
+	}
+}
+
+func Test_isNodeJSLib(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "libnode",
+			input: " /usr/bin/../lib/libnode.so.120",
+			want:  true,
+		},
+		{
+			name:  "libnode with version",
+			input: " /usr/bin/../lib/libnode.so.120",
+			want:  true,
+		},
+		{
+			name:  "Dynamic lib with suffix",
+			input: "/usr/lib/x86_64-linux-gnu/libnode.so.64.0.0d",
+			want:  true,
+		},
+		{
+			name:  "Static lib",
+			input: "/usr/lib/x86_64-linux-gnu/libnode.a",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isNodeJSLib(tt.input))
+		})
+	}
+}

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -596,11 +596,11 @@ func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
 	}, nil
 }
 
-var re = regexp.MustCompile(`/libpython\d.\d\d?(m|d|u)?.so`)
+var libRegex = regexp.MustCompile(`/libpython\d.\d\d?(m|d|u)?.so`)
 
 func isPythonLib(pathname string) bool {
 	// Alternatively, we could check the ELF file for the interpreter symbol.
-	return re.MatchString(pathname)
+	return libRegex.MatchString(pathname)
 }
 
 func isPythonBin(pathname string) bool {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -13,7 +13,9 @@
 
 package runtime
 
-import "github.com/Masterminds/semver/v3"
+import (
+	"github.com/Masterminds/semver/v3"
+)
 
 type InterpreterType uint64
 
@@ -39,7 +41,15 @@ func (it InterpreterType) String() string {
 type Interpreter struct {
 	Type    InterpreterType
 	Version *semver.Version
+
 	// The address of the main thread state for Python.
 	MainThreadAddress  uint64
 	InterpreterAddress uint64
+}
+
+type Type string
+
+type Runtime struct {
+	Type    Type
+	Version *semver.Version
 }

--- a/pkg/runtime/vm/vm.go
+++ b/pkg/runtime/vm/vm.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Parca Authors
+// Copyright 2022-2023 The Parca Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -10,29 +10,28 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
-package runtime
+package vm
 
 import (
-	"debug/elf"
-	"errors"
 	"fmt"
+
+	"github.com/prometheus/procfs"
+
+	"github.com/parca-dev/parca-agent/pkg/runtime"
+	"github.com/parca-dev/parca-agent/pkg/runtime/nodejs"
 )
 
-var v8IdentifyingSymbols = [][]byte{
-	[]byte("InterpreterEntryTrampoline"),
-}
-
-// HACK: This is a somewhat a brittle check.
-func IsV8(f *elf.File) (bool, error) {
-	var (
-		isV8 bool
-		err  error
-	)
-
-	if isV8, err = IsSymbolNameInSymbols(f, v8IdentifyingSymbols); err != nil && !errors.Is(err, elf.ErrNoSymbols) {
-		return isV8, fmt.Errorf("search symbols: %w", err)
+func Fetch(p procfs.Proc) (*runtime.Runtime, error) {
+	rt, err := nodejs.RuntimeInfo(p)
+	if rt == nil {
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch nodejs runtime info: %w", err)
+		}
+		// Expected case, the process is not a nodejs process.
+		return nil, nil //nolint: nilnil
 	}
 
-	return isV8, nil
+	return rt, nil
 }

--- a/pkg/stack/unwind/executable.go
+++ b/pkg/stack/unwind/executable.go
@@ -28,7 +28,7 @@ import (
 	"github.com/xyproto/ainur"
 
 	"github.com/parca-dev/parca-agent/pkg/cache"
-	"github.com/parca-dev/parca-agent/pkg/runtime"
+	"github.com/parca-dev/parca-agent/pkg/runtime/nodejs"
 )
 
 type FramePointerCache struct {
@@ -96,13 +96,13 @@ func NewHasFramePointersCache(logger log.Logger, reg prometheus.Registerer) Fram
 }
 
 func HasFramePointers(executable string) (bool, error) {
-	f, err := elf.Open(executable)
+	ef, err := elf.Open(executable)
 	if err != nil {
 		return false, fmt.Errorf("failed to open ELF file for path %s: %w", executable, err)
 	}
-	defer f.Close()
+	defer ef.Close()
 
-	compiler := ainur.Compiler(f)
+	compiler := ainur.Compiler(ef)
 	// Go 1.7 [0] enabled FP for x86_64. arm64 got them enabled in 1.12 [1].
 	//
 	// Note: we don't take into account applications that use cgo yet.
@@ -129,7 +129,7 @@ func HasFramePointers(executable string) (bool, error) {
 	// v8 uses a custom code generator for some of it's ahead-of-time functions. They do contain
 	// frame pointers, but no DWARF unwind information, so we force frame pointer unwinding as
 	// mixed mode unwinding (fp -> DWARF) won't work here.
-	isV8, err := runtime.IsV8(f)
+	isV8, err := nodejs.IsV8(ef)
 	if err != nil {
 		return false, fmt.Errorf("check if executable is v8: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

The version information set in here https://github.com/nodejs/node/blob/36ecf8ca656063060421e5b5440ac056f3a51e20/src/node_version.h so they end up in `.data` or `.rodata` sections.

Tested against multiple versions https://pprof.me/75e08cdd91547a303b82065b9281bf1e


![CleanShot 2023-11-15 at 13 09 51](https://github.com/parca-dev/parca-agent/assets/536449/990c5cbc-f933-4be0-8b26-a34f3a81040c)
![CleanShot 2023-11-15 at 13 09 41](https://github.com/parca-dev/parca-agent/assets/536449/18071702-bc48-4605-824e-b4ccd78afeec)
![CleanShot 2023-11-15 at 13 09 36](https://github.com/parca-dev/parca-agent/assets/536449/3a9a552d-3e3b-4f35-a85c-82037123961f)
