### PR TITLE
metadata: Separate label sets per runtime

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -844,15 +844,11 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		discoveryMetadata,
 		metadata.Target(flags.Node, flags.Metadata.ExternalLabels),
 		metadata.Compiler(logger, reg, ofp),
-		metadata.Runtime(pfs, reg),
-		metadata.Process(pfs),
+		metadata.Runtime(reg, pfs),
 		metadata.Java(logger, nsCache),
+		metadata.Process(pfs),
 		metadata.System(),
 		metadata.PodHosts(),
-	}
-	interpreterUnwindingEnabled := flags.Hidden.EnablePythonUnwinding || flags.Hidden.EnableRubyUnwinding
-	if interpreterUnwindingEnabled {
-		providers = append(providers, metadata.Interpreter(pfs, reg))
 	}
 
 	labelsManager := labels.NewManager(
@@ -911,7 +907,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		labelsManager,
 		flags.Profiling.Duration,
 		flags.Debuginfo.UploadCacheDuration,
-		interpreterUnwindingEnabled,
+		flags.Hidden.EnablePythonUnwinding || flags.Hidden.EnableRubyUnwinding,
 	)
 	{
 		logger := log.With(logger, "group", "process_info_manager")

--- a/pkg/metadata/java.go
+++ b/pkg/metadata/java.go
@@ -33,7 +33,7 @@ import (
 func Java(logger log.Logger, nsCache *namespace.Cache) Provider {
 	cache := java.NewHSPerfDataCache(logger, nsCache)
 
-	return &StatelessProvider{"java process", func(ctx context.Context, pid int) (model.LabelSet, error) {
+	return &StatelessProvider{"java", func(ctx context.Context, pid int) (model.LabelSet, error) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}

--- a/pkg/metadata/labels/manager.go
+++ b/pkg/metadata/labels/manager.go
@@ -138,15 +138,18 @@ func (m *Manager) labelSet(ctx context.Context, pid int) (model.LabelSet, error)
 			level.Debug(m.logger).Log("msg", "failed to get metadata", "provider", provider.Name(), "err", err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
+		}
+		if lbl == nil {
 			span.End()
 			continue
 		}
-		labelSet = labelSet.Merge(lbl)
 
+		labelSet = labelSet.Merge(lbl)
 		if shouldCache {
 			// Stateless providers are cached for a longer period of time.
 			m.providerCache.Add(providerCacheKey(provider.Name(), pid), labelSet)
 		}
+		span.End()
 	}
 
 	return labelSet, nil

--- a/pkg/metadata/nodejs.go
+++ b/pkg/metadata/nodejs.go
@@ -1,0 +1,77 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//nolint:dupl
+package metadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/procfs"
+
+	"github.com/parca-dev/parca-agent/pkg/cache"
+	"github.com/parca-dev/parca-agent/pkg/runtime/nodejs"
+)
+
+func NodeJS(reg prometheus.Registerer, procfs procfs.FS) Provider {
+	cache := cache.NewLRUCache[int, model.LabelSet](
+		prometheus.WrapRegistererWith(prometheus.Labels{"cache": "metadata_nodejs"}, reg),
+		128,
+	)
+	return &StatelessProvider{"nodejs", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if lset, ok := cache.Get(pid); ok {
+			return lset, nil
+		}
+
+		p, err := procfs.Proc(pid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate procfs for PID %d: %w", pid, err)
+		}
+
+		ok, err := nodejs.IsRuntime(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if PID %d is a NodeJS runtime: %w", pid, err)
+		}
+
+		if !ok {
+			cache.Add(pid, nil)
+			return nil, nil
+		}
+		lset := model.LabelSet{
+			"nodejs": model.LabelValue(fmt.Sprint(true)),
+		}
+
+		rt, err := nodejs.RuntimeInfo(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch interpreter info for PID %d: %w", pid, err)
+		}
+		if rt == nil {
+			cache.Add(pid, lset)
+			return nil, nil
+		}
+
+		lset = lset.Merge(model.LabelSet{
+			"nodejs_version": model.LabelValue(rt.Version.String()),
+		})
+		cache.Add(pid, lset)
+		return lset, nil
+	}}
+}

--- a/pkg/metadata/nodejs.go
+++ b/pkg/metadata/nodejs.go
@@ -18,6 +18,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -56,7 +57,7 @@ func NodeJS(reg prometheus.Registerer, procfs procfs.FS) Provider {
 			return nil, nil
 		}
 		lset := model.LabelSet{
-			"nodejs": model.LabelValue(fmt.Sprint(true)),
+			"nodejs": model.LabelValue(strconv.FormatBool(true)),
 		}
 
 		rt, err := nodejs.RuntimeInfo(p)

--- a/pkg/metadata/python.go
+++ b/pkg/metadata/python.go
@@ -18,6 +18,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -55,7 +56,7 @@ func Python(reg prometheus.Registerer, procfs procfs.FS) Provider {
 			return nil, nil
 		}
 		lset := model.LabelSet{
-			"python": model.LabelValue(fmt.Sprint(true)),
+			"python": model.LabelValue(strconv.FormatBool(true)),
 		}
 
 		rt, err := python.RuntimeInfo(p)

--- a/pkg/metadata/python.go
+++ b/pkg/metadata/python.go
@@ -65,7 +65,7 @@ func Python(reg prometheus.Registerer, procfs procfs.FS) Provider {
 		}
 		if rt == nil {
 			cache.Add(pid, lset)
-			return nil, nil
+			return lset, nil
 		}
 
 		lset = lset.Merge(model.LabelSet{

--- a/pkg/metadata/ruby.go
+++ b/pkg/metadata/ruby.go
@@ -1,0 +1,76 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//nolint:dupl
+package metadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/procfs"
+
+	"github.com/parca-dev/parca-agent/pkg/cache"
+	"github.com/parca-dev/parca-agent/pkg/runtime/ruby"
+)
+
+func Ruby(reg prometheus.Registerer, procfs procfs.FS) Provider {
+	cache := cache.NewLRUCache[int, model.LabelSet](
+		prometheus.WrapRegistererWith(prometheus.Labels{"cache": "metadata_ruby"}, reg),
+		128,
+	)
+	return &StatelessProvider{"ruby", func(ctx context.Context, pid int) (model.LabelSet, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if lset, ok := cache.Get(pid); ok {
+			return lset, nil
+		}
+
+		p, err := procfs.Proc(pid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate procfs for PID %d: %w", pid, err)
+		}
+
+		ok, err := ruby.IsRuntime(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if PID %d is a Ruby runtime: %w", pid, err)
+		}
+		if !ok {
+			cache.Add(pid, nil)
+			return nil, nil
+		}
+		lset := model.LabelSet{
+			"ruby": model.LabelValue(fmt.Sprint(true)),
+		}
+
+		rt, err := ruby.RuntimeInfo(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch interpreter info for PID %d: %w", pid, err)
+		}
+		if rt == nil {
+			cache.Add(pid, lset)
+			return nil, nil
+		}
+
+		lset = lset.Merge(model.LabelSet{
+			"ruby_version": model.LabelValue(rt.Version.String()),
+		})
+		cache.Add(pid, lset)
+		return lset, nil
+	}}
+}

--- a/pkg/metadata/ruby.go
+++ b/pkg/metadata/ruby.go
@@ -18,6 +18,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -55,7 +56,7 @@ func Ruby(reg prometheus.Registerer, procfs procfs.FS) Provider {
 			return nil, nil
 		}
 		lset := model.LabelSet{
-			"ruby": model.LabelValue(fmt.Sprint(true)),
+			"ruby": model.LabelValue(strconv.FormatBool(true)),
 		}
 
 		rt, err := ruby.RuntimeInfo(p)

--- a/pkg/metadata/ruby.go
+++ b/pkg/metadata/ruby.go
@@ -65,7 +65,7 @@ func Ruby(reg prometheus.Registerer, procfs procfs.FS) Provider {
 		}
 		if rt == nil {
 			cache.Add(pid, lset)
-			return nil, nil
+			return lset, nil
 		}
 
 		lset = lset.Merge(model.LabelSet{

--- a/pkg/runtime/interpreter/interpreter.go
+++ b/pkg/runtime/interpreter/interpreter.go
@@ -56,7 +56,7 @@ func Fetch(p procfs.Proc) (*runtime.Interpreter, error) {
 
 func determineInterpreterType(proc procfs.Proc) (runtime.InterpreterType, error) {
 	errs := errors.New("failed to determine intepreter")
-	ok, err := ruby.IsInterpreter(proc)
+	ok, err := ruby.IsRuntime(proc)
 	if ok {
 		return runtime.InterpreterRuby, nil
 	}
@@ -64,7 +64,7 @@ func determineInterpreterType(proc procfs.Proc) (runtime.InterpreterType, error)
 		errs = errors.Join(errs, err)
 	}
 
-	ok, err = python.IsInterpreter(proc)
+	ok, err = python.IsRuntime(proc)
 	if ok {
 		return runtime.InterpreterPython, nil
 	}

--- a/pkg/runtime/nodejs/nodejs.go
+++ b/pkg/runtime/nodejs/nodejs.go
@@ -110,7 +110,7 @@ func RuntimeInfo(proc procfs.Proc) (*runtime.Runtime, error) {
 	}
 
 	rt := &runtime.Runtime{
-		Type: "nodejs",
+		Name: "nodejs",
 	}
 
 	exe, err := proc.Executable()
@@ -128,7 +128,7 @@ func RuntimeInfo(proc procfs.Proc) (*runtime.Runtime, error) {
 	if err == nil {
 		version, err := semver.NewVersion(versionString)
 		if err != nil {
-			return rt, fmt.Errorf("new version, %s: %w", versionString, err)
+			return rt, fmt.Errorf("new version: %q: %w", versionString, err)
 		}
 		rt.Version = version
 		return rt, nil
@@ -171,7 +171,7 @@ func RuntimeInfo(proc procfs.Proc) (*runtime.Runtime, error) {
 
 	version, err := semver.NewVersion(versionString)
 	if err != nil {
-		return rt, fmt.Errorf("new version, %s: %w", versionString, err)
+		return rt, fmt.Errorf("new version: %q: %w", versionString, err)
 	}
 	rt.Version = version
 	return rt, nil

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -69,7 +69,7 @@ func absolutePath(proc procfs.Proc, p string) string {
 	return path.Join("/proc/", strconv.Itoa(proc.PID), "/root/", p)
 }
 
-func IsInterpreter(proc procfs.Proc) (bool, error) {
+func IsRuntime(proc procfs.Proc) (bool, error) {
 	// First, let's check the executable's pathname since it's the cheapest and fastest.
 	exe, err := proc.Executable()
 	if err != nil {
@@ -129,7 +129,7 @@ func versionFromBSS(f *interpreterExecutableFile) (string, error) {
 	return "", errors.New("version not found")
 }
 
-func versionFromPath(f *interpreterExecutableFile) (string, error) {
+func versionFromPath(f *os.File) (string, error) {
 	versionString, err := scanVersionPath([]byte(f.Name()))
 	if err != nil {
 		return "", fmt.Errorf("scan version string: %w", err)
@@ -443,7 +443,42 @@ func (i interpreter) interpHeadOffset() (uint64, error) {
 	}
 }
 
-func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
+func (i interpreter) Close() error {
+	if i.exe != nil {
+		if err := i.exe.Close(); err != nil {
+			return fmt.Errorf("close exe: %w", err)
+		}
+	}
+	if i.lib != nil {
+		if err := i.lib.Close(); err != nil {
+			return fmt.Errorf("close lib: %w", err)
+		}
+	}
+	return nil
+}
+
+func RuntimeInfo(proc procfs.Proc) (*runtime.Runtime, error) {
+	isPython, err := IsRuntime(proc)
+	if err != nil {
+		return nil, fmt.Errorf("is runtime: %w", err)
+	}
+	if !isPython {
+		return nil, nil //nolint:nilnil
+	}
+
+	rt := &runtime.Runtime{
+		Name: "python",
+	}
+
+	interpreter, err := newInterpreter(proc)
+	if err != nil {
+		return nil, fmt.Errorf("new interpreter: %w", err)
+	}
+	rt.Version = interpreter.version
+	return rt, nil
+}
+
+func newInterpreter(proc procfs.Proc) (*interpreter, error) {
 	maps, err := proc.ProcMaps()
 	if err != nil {
 		return nil, fmt.Errorf("error reading process maps: %w", err)
@@ -497,7 +532,7 @@ func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("open executable: %w", err)
 		}
-		defer f.Close()
+
 		exe, err = newInterpreterExecutableFile(proc.PID, f, pythonExecutableStartAddress)
 		if err != nil {
 			return nil, fmt.Errorf("new elf file: %w", err)
@@ -508,7 +543,6 @@ func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("open library: %w", err)
 		}
-		defer f.Close()
 
 		lib, err = newInterpreterExecutableFile(proc.PID, f, libpythonStartAddress)
 		if err != nil {
@@ -531,7 +565,7 @@ func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
 	if versionString == "" {
 		for _, source := range versionSources {
 			// As a last resort, try to parse the version from the path.
-			versionString, err = versionFromPath(source)
+			versionString, err = versionFromPath(source.File)
 			if versionString != "" && err == nil {
 				break
 			}
@@ -540,14 +574,22 @@ func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
 
 	version, err := semver.NewVersion(versionString)
 	if err != nil {
-		return nil, fmt.Errorf("new version: %w", err)
+		return nil, fmt.Errorf("new version: %q: %w", version, err)
 	}
 
-	interpreter := &interpreter{
+	return &interpreter{
 		exe:     exe,
 		lib:     lib,
 		version: version,
+	}, nil
+}
+
+func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
+	interpreter, err := newInterpreter(proc)
+	if err != nil {
+		return nil, fmt.Errorf("new interpreter: %w", err)
 	}
+	defer interpreter.Close()
 
 	threadStateAddress, err := interpreter.threadStateAddress()
 	if err != nil {
@@ -566,8 +608,11 @@ func InterpreterInfo(proc procfs.Proc) (*runtime.Interpreter, error) {
 	}
 
 	return &runtime.Interpreter{
+		Runtime: runtime.Runtime{
+			Name:    "Python",
+			Version: interpreter.version,
+		},
 		Type:               runtime.InterpreterPython,
-		Version:            interpreter.version,
 		MainThreadAddress:  threadStateAddress,
 		InterpreterAddress: interpreterAddress,
 	}, nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -38,18 +38,18 @@ func (it InterpreterType) String() string {
 	}
 }
 
-type Interpreter struct {
-	Type    InterpreterType
+type RuntimeName string
+
+type Runtime struct {
+	Name    RuntimeName
 	Version *semver.Version
+}
+
+type Interpreter struct {
+	Runtime
+	Type InterpreterType
 
 	// The address of the main thread state for Python.
 	MainThreadAddress  uint64
 	InterpreterAddress uint64
-}
-
-type Type string
-
-type Runtime struct {
-	Type    Type
-	Version *semver.Version
 }


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Why?
According to our users' feedback individual sets of labels per runtime easier to reason about. This PR converts "runtime"=XXX and "runtime_version" to "XXX"=true and "XXX_version" labels.

### What?
<!-- Please explain us what does it do? Or let the copilot handle it. -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0096c23</samp>

Refactored the runtime and metadata packages to support multiple languages and simplify the code. Added metadata providers for Python and Ruby. Renamed and embedded structs and functions for clarity and consistency. Improved error handling and tracing.

![CleanShot 2023-11-16 at 17 13 02](https://github.com/parca-dev/parca-agent/assets/536449/ddf86303-0cdd-45de-820d-e513303f4435)
![CleanShot 2023-11-16 at 16 51 06](https://github.com/parca-dev/parca-agent/assets/536449/69367e0f-66d3-476b-a90f-7e04163bfa4b)
![CleanShot 2023-11-16 at 16 50 09](https://github.com/parca-dev/parca-agent/assets/536449/80ce8006-f48c-4ebc-9f63-2325588a4b63)
