### PR TITLE
python: Fix detection logic

### DIFF
--- a/pkg/runtime/elf_symbols.go
+++ b/pkg/runtime/elf_symbols.go
@@ -94,40 +94,14 @@ func isSymbolNameInSection(f *elf.File, t elf.SectionType, matches [][]byte) (bo
 	return false, nil
 }
 
-// TODO: Optimize!
-// FindAddressOfSymbol finds the address of the given symbol in the given elf file
-// by searching both the symbol table and the dynamic symbol table.
-// Returns 0 if the symbol is not found.
-func FindAddressOfSymbol(ef *elf.File, symbol string) (uint64, error) {
-	symbols, err := ef.Symbols()
-	if err != nil {
-		return 0, fmt.Errorf("error reading ELF symbols: %w", err)
-	}
-	for _, s := range symbols {
-		if s.Name == symbol {
-			return s.Value, nil
-		}
-	}
-
-	dynamicSymbols, err := ef.DynamicSymbols()
-	if err != nil {
-		return 0, fmt.Errorf("error reading ELF dynamic symbols: %w", err)
-	}
-	for _, s := range dynamicSymbols {
-		if s.Name == symbol {
-			return s.Value, nil
-		}
-	}
-
-	return 0, nil
-}
-
 // FindSymbol finds symbol by name in the given elf file.
 func FindSymbol(ef *elf.File, symbol string) (*elf.Symbol, error) {
 	symbols, err := ef.Symbols()
-	if err != nil {
+	// If there are no symbols, try dynamic symbols.
+	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
 		return nil, fmt.Errorf("error reading ELF symbols: %w", err)
 	}
+
 	for _, s := range symbols {
 		if s.Name == symbol {
 			return &s, nil


### PR DESCRIPTION
First we were checking for symbols and then dynamic symbols, but we should not err if the symbol check fails due to lack of symbols.

This commit also:
- Removes Python detection via `Py_GetVersion.version`, as it's not an existing  ELF symbol (see below)
- Removes `FindAddressOfSymbol()` as it's unused.

```
$ nm --dynamic /proc/68948/root/usr/local/lib/libpython3.10.so.1.0  | grep Py_GetVersion.version
$ nm --dynamic /proc/68948/root/usr/local/lib/libpython3.10.so.1.0  | grep Py_GetVersion
000000000020ac90 T Py_GetVersion
```

"T" means that it's code , not data, so the memory ready won't work (https://linux.die.net/man/1/nm).

Perhaps in the future we could read [this constant](https://github.com/python/cpython/blob/ce1096f974d3158a92e050f9226700775b8db398/Python/getversion.c#L22) instead?

Test Plan
=========

Ran a Python program with the following container images `python:3.10-alpine` and `registry.access.redhat.com/ubi8/python-38`.

https://pprof.me/f62be5f7f0f80c35f093e2c4a07ff010