### PR TITLE
Add filenames for interpreted functions

### DIFF
--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -315,7 +315,7 @@ func (c *Converter) addInterpreterLocation(frameID uint64) *pprofprofile.Locatio
 		ID:      uint64(len(c.result.Location)) + 1,
 		Mapping: c.interpreterMapping,
 		Line: []pprofprofile.Line{{
-			Function: c.addFunction(interpreterSymbol.FullName(), ""),
+			Function: c.addFunction(interpreterSymbol.FullName(), interpreterSymbol.Filename),
 			Line:     int64(interpreterSymbol.StartLine),
 		}},
 	}


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Add missing filenames for interpreters.

### Test Plan

e.g. `/home/kakkoyun/Workspace/Projects/parca-demo/python/fibonacci.py  +20`

![CleanShot 2023-11-21 at 15 12 44](https://github.com/parca-dev/parca-agent/assets/536449/ed773457-f3fd-4886-ba73-9c353ef4d863)

![CleanShot 2023-11-21 at 15 12 35](https://github.com/parca-dev/parca-agent/assets/536449/c1964957-b273-42be-9c92-edaf183ee322)

![CleanShot 2023-11-21 at 15 51 22](https://github.com/parca-dev/parca-agent/assets/536449/a99cdd2a-0b34-4a5b-84c8-e77b793589d8)
