### PR TITLE
Improve BPF events handling

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -315,7 +315,7 @@ static __always_inline bool event_rate_limited(u64 event_id) {
     return false;
   }
 
-  int max_events_per_event_id = 2;
+  int max_events_per_event_id = 50; // By default the profile loop is 10 seconds. Allow 5 events per second.
 
   u32 zero = 0;
   u32* val = bpf_map_lookup_or_try_init(&events_count, &event_id, &zero);

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -803,8 +803,8 @@ func (p *CPU) Run(ctx context.Context) error {
 
 	// Process BPF events.
 	var (
-		eventsChan  = make(chan []byte)
-		lostChannel = make(chan uint64)
+		eventsChan  = make(chan []byte, 30)
+		lostChannel = make(chan uint64, 10)
 	)
 	perfBuf, err := native.InitPerfBuf("events", eventsChan, lostChannel, 64)
 	if err != nil {
@@ -812,7 +812,7 @@ func (p *CPU) Run(ctx context.Context) error {
 	}
 	perfBuf.Poll(int(p.config.PerfEventBufferPollInterval.Milliseconds()))
 
-	requestUnwindInfoChannel := make(chan int)
+	requestUnwindInfoChannel := make(chan int, 30)
 	go p.listenEvents(ctx, eventsChan, lostChannel, requestUnwindInfoChannel)
 	go p.onDemandUnwindInfoBatcher(ctx, requestUnwindInfoChannel)
 


### PR DESCRIPTION
- Buffer the channels we use in Go
- The rate limit was too strict, especially for applications that JIT compile lots of different code sections over time

We might have per event rate limits in the future if needed