### PR TITLE
metadata: Cache and control compiler metadata fetches

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"runtime"
+	goruntime "runtime"
 	runtimepprof "runtime/pprof"
 	"strconv"
 	"strings"
@@ -85,6 +85,7 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/profiler"
 	"github.com/parca-dev/parca-agent/pkg/profiler/cpu"
 	"github.com/parca-dev/parca-agent/pkg/rlimit"
+	"github.com/parca-dev/parca-agent/pkg/runtime"
 	"github.com/parca-dev/parca-agent/pkg/template"
 	"github.com/parca-dev/parca-agent/pkg/tracer"
 	"github.com/parca-dev/parca-agent/pkg/vdso"
@@ -310,7 +311,7 @@ func getTelemetryMetadata() map[string]string {
 
 	r["git_commit"] = commit
 	r["agent_version"] = version
-	r["go_arch"] = runtime.GOARCH
+	r["go_arch"] = goruntime.GOARCH
 	r["kernel_release"] = si.Kernel.Release
 	r["cpu_cores"] = strconv.Itoa(cpuinfo.NumCPU())
 
@@ -360,7 +361,7 @@ func main() {
 
 		// Run garbage collector to minimize the amount of memory that the parent
 		// telemetry process uses.
-		runtime.GC()
+		goruntime.GC()
 		err := cmd.Run()
 		if err != nil {
 			level.Error(logger).Log("msg", "======================= unexpected error =======================")
@@ -468,7 +469,7 @@ func main() {
 	intro.Print()
 
 	// TODO(sylfrena): Entirely remove once full support for DWARF Unwinding Arm64 is added and production tested for a few days
-	if runtime.GOARCH == "arm64" {
+	if goruntime.GOARCH == "arm64" {
 		flags.DWARFUnwinding.Disable = false
 		level.Info(logger).Log("msg", "ARM64 support is currently in beta. DWARF-based unwinding is not fully supported yet, see https://github.com/parca-dev/parca-agent/discussions/1376 for more details")
 	}
@@ -512,8 +513,8 @@ func main() {
 	}
 
 	// Set profiling rates.
-	runtime.SetBlockProfileRate(flags.BlockProfileRate)
-	runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
+	goruntime.SetBlockProfileRate(flags.BlockProfileRate)
+	goruntime.SetMutexProfileFraction(flags.MutexProfileFraction)
 
 	if err := run(logger, reg, flags); err != nil {
 		level.Error(logger).Log("err", err)
@@ -693,7 +694,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		a := analytics.NewSender(
 			logger,
 			c,
-			runtime.GOARCH,
+			goruntime.GOARCH,
 			cpuinfo.NumCPU(),
 			version,
 			si,
@@ -838,12 +839,13 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 	defer ofp.Close() // Will make sure all the files are closed.
 
 	nsCache := namespace.NewCache(logger, reg, flags.Profiling.Duration)
+	compilerInfoManager := runtime.NewCompilerInfoManager(reg, ofp)
 
 	// All the metadata providers work best-effort.
 	providers := []metadata.Provider{
 		discoveryMetadata,
 		metadata.Target(flags.Node, flags.Metadata.ExternalLabels),
-		metadata.Compiler(logger, reg, ofp),
+		metadata.Compiler(logger, reg, pfs, compilerInfoManager),
 		metadata.Runtime(reg, pfs),
 		metadata.Java(logger, nsCache),
 		metadata.Process(pfs),
@@ -928,6 +930,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 			log.With(logger, "component", "cpu_profiler"),
 			reg,
 			processInfoManager,
+			compilerInfoManager,
 			converter.NewManager(
 				log.With(logger, "component", "converter_manager"),
 				reg,

--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -58,7 +58,7 @@ func Compiler(logger log.Logger, reg prometheus.Registerer, procfs procfs.FS, ci
 				return cachedLabels, nil
 			}
 
-			compiler, err := cic.Fetch(path)
+			compiler, err := cic.Fetch(path) // nolint:contextcheck
 			if err != nil {
 				return nil, fmt.Errorf("failed to get compiler info for %s: %w", path, err)
 			}

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -511,7 +511,7 @@ func (p *CPU) onDemandUnwindInfoBatcher(ctx context.Context, requestUnwindInfoCh
 
 func (p *CPU) addUnwindTableForProcess(ctx context.Context, pid int) {
 	executable := fmt.Sprintf("/proc/%d/exe", pid)
-	hasFramePointers, err := p.framePointerCache.HasFramePointers(executable)
+	hasFramePointers, err := p.framePointerCache.HasFramePointers(executable) // nolint:contextcheck
 	if err != nil {
 		// It might not exist as reading procfs is racy. If the executable has no symbols
 		// that we use as a heuristic to detect whether it has frame pointers or not,

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
+	goruntime "runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -52,6 +52,7 @@ import (
 	bpfmetrics "github.com/parca-dev/parca-agent/pkg/profiler/cpu/bpf/metrics"
 	bpfprograms "github.com/parca-dev/parca-agent/pkg/profiler/cpu/bpf/programs"
 	"github.com/parca-dev/parca-agent/pkg/rlimit"
+	"github.com/parca-dev/parca-agent/pkg/runtime"
 	"github.com/parca-dev/parca-agent/pkg/stack/unwind"
 )
 
@@ -126,6 +127,7 @@ func NewCPUProfiler(
 	logger log.Logger,
 	reg prometheus.Registerer,
 	processInfoManager profiler.ProcessInfoManager,
+	compilerInfoManager *runtime.CompilerInfoManager,
 	profileConverter *pprof.Manager,
 	profileWriter profiler.ProfileStore,
 	config *Config,
@@ -143,7 +145,7 @@ func NewCPUProfiler(
 		profileStore:       profileWriter,
 
 		// CPU profiler specific caches.
-		framePointerCache: unwind.NewHasFramePointersCache(logger, reg),
+		framePointerCache: unwind.NewHasFramePointersCache(logger, reg, compilerInfoManager),
 
 		byteOrder: byteorder.GetHostByteOrder(),
 
@@ -1128,7 +1130,7 @@ func preprocessRawData(rawData map[profileKey]map[bpfprograms.CombinedStack]uint
 }
 
 func getArch() elf.Machine {
-	switch runtime.GOARCH {
+	switch goruntime.GOARCH {
 	case "arm64":
 		return elf.EM_AARCH64
 	case "amd64":

--- a/pkg/runtime/compiler.go
+++ b/pkg/runtime/compiler.go
@@ -1,0 +1,107 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/xyproto/ainur"
+
+	"github.com/parca-dev/parca-agent/pkg/cache"
+	"github.com/parca-dev/parca-agent/pkg/objectfile"
+)
+
+type Compiler struct {
+	Runtime
+
+	Type     string
+	BuildID  string
+	Stripped bool
+	Static   bool
+}
+
+// TODO(kakkoyun): Consider moving this to the ProcessInfoManager.
+// Requires FramePointerCache to be moved as well.
+
+// CompilerInfoManager is a cache for compiler information.
+// Fetching this information is expensive, so we cache it.
+// The cache is safe for concurrent use.
+// It also controls throughput of fetches.
+type CompilerInfoManager struct {
+	p *objectfile.Pool
+	c *cache.Cache[string, *Compiler]
+}
+
+func NewCompilerInfoManager(reg prometheus.Registerer, objFilePool *objectfile.Pool) *CompilerInfoManager {
+	return &CompilerInfoManager{
+		p: objFilePool,
+		c: cache.NewLFUCache[string, *Compiler](
+			prometheus.WrapRegistererWith(prometheus.Labels{"cache": "runtime_compiler_info"}, reg),
+			2048,
+		),
+	}
+}
+
+func (c *CompilerInfoManager) Fetch(path string) (*Compiler, error) {
+	if compiler, ok := c.c.Get(path); ok {
+		return compiler, nil
+	}
+
+	obj, err := c.p.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open ELF file %s: %w", path, err)
+	}
+
+	ef, err := obj.ELF()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ELF file %s: %w", path, err)
+	}
+
+	cType := ainur.Compiler(ef)
+	compiler := &Compiler{
+		Runtime: Runtime{
+			Name:    RuntimeName(name(cType)),
+			Version: version(cType),
+		},
+		Type:     cType,
+		Static:   ainur.Static(ef),
+		Stripped: ainur.Stripped(ef),
+		BuildID:  obj.BuildID,
+	}
+	c.c.Add(path, compiler)
+	return compiler, nil
+}
+
+func name(cType string) string {
+	parts := strings.Split(cType, " ")
+	if len(parts) > 0 && parts[0] != "" {
+		return parts[0]
+	}
+	return "unknown"
+}
+
+func version(cType string) *semver.Version {
+	parts := strings.Split(cType, " ")
+	if len(parts) < 2 {
+		return nil
+	}
+	ver, err := semver.NewVersion(parts[1])
+	if err != nil {
+		return nil
+	}
+	return ver
+}

--- a/pkg/runtime/compiler_test.go
+++ b/pkg/runtime/compiler_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022-2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func Test_version(t *testing.T) {
+	tests := []struct {
+		input string
+		want  *semver.Version
+	}{
+		{
+			input: "GCC 7.2.0",
+			want:  semver.MustParse("7.2.0"),
+		},
+		{
+			input: "Clang 8.2.1",
+			want:  semver.MustParse("8.2.1"),
+		},
+		{
+			input: "Go 1.16.5",
+			want:  semver.MustParse("1.16.5"),
+		},
+		{
+			input: "Rust (GCC 9.3.0)",
+			want:  nil,
+		},
+		{
+			input: "Rust 1.27.0-nightly",
+			want:  semver.MustParse("1.27.0-nightly"),
+		},
+		{
+			input: "DMD",
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := version(tt.input); got != nil && got.Compare(tt.want) != 0 {
+				t.Errorf("version() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/runtime/nodejs/nodejs.go
+++ b/pkg/runtime/nodejs/nodejs.go
@@ -34,7 +34,13 @@ var nodejsIdentifyingSymbols = [][]byte{
 	[]byte("InterpreterEntryTrampoline"),
 }
 
-func IsV8(ef *elf.File) (bool, error) {
+func IsV8(path string) (bool, error) {
+	ef, err := elf.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open elf file: %w", err)
+	}
+	defer ef.Close()
+
 	return runtime.HasSymbols(ef, nodejsIdentifyingSymbols)
 }
 

--- a/test/integration/profiler_test.go
+++ b/test/integration/profiler_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/profile"
 	"github.com/parca-dev/parca-agent/pkg/profiler"
 	"github.com/parca-dev/parca-agent/pkg/profiler/cpu"
+	"github.com/parca-dev/parca-agent/pkg/runtime"
 	"github.com/parca-dev/parca-agent/pkg/vdso"
 )
 
@@ -271,12 +272,13 @@ func prepareProfiler(t *testing.T, profileStore profiler.ProfileStore, logger lo
 	}
 
 	dbginfo := debuginfo.NoopDebuginfoManager{}
+	cim := runtime.NewCompilerInfoManager(reg, ofp)
 	labelsManager := labels.NewManager(
 		logger,
 		noop.NewTracerProvider().Tracer("test"),
 		reg,
 		[]metadata.Provider{
-			metadata.Compiler(logger, reg, ofp),
+			metadata.Compiler(logger, reg, pfs, cim),
 			metadata.Process(pfs),
 			metadata.System(),
 			metadata.PodHosts(),
@@ -302,6 +304,7 @@ func prepareProfiler(t *testing.T, profileStore profiler.ProfileStore, logger lo
 			loopDuration,
 			false, // interpreter unwinding enabled
 		),
+		cim,
 		parcapprof.NewManager(
 			logger,
 			reg,


### PR DESCRIPTION
- Wrap ainur.Compiler with a cache
- Control fetching throughput

Should fix the spikes we see in certain environments: https://pprof.me/0ba26790b69399ef65ea84dc3facb424/?profileType=profile%3Asamples%3Acount%3Acpu%3Ananoseconds

![image](https://github.com/parca-dev/parca-agent/assets/536449/de407d74-ad9e-421a-841f-6d4900a9e6ca)

