### PR TITLE
Reduce number of the reads from the interpreter symbol table

### DIFF
--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -51,7 +51,7 @@ struct {
 } stack_traces SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, 1); // Set in the user-space.
     __type(key, symbol_t);
     __type(value, u32);
@@ -61,8 +61,40 @@ struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __uint(max_entries, 1);
     __type(key, u32);
-    __type(value, u64);
+    __type(value, u32);
 } symbol_index_storage SEC(".maps");
+
+const volatile int num_cpus = 200; // Hard-limit of 200 CPUs.
+
+static inline __attribute__((__always_inline__)) u32 get_symbol_id(symbol_t *sym) {
+	int *found_id = bpf_map_lookup_elem(&symbol_table, sym);
+	if (found_id) {
+		return *found_id;
+	}
+
+	u32 zero = 0;
+	u32 *sym_idx = bpf_map_lookup_elem(&symbol_index_storage, &zero);
+	if (sym_idx == NULL) {
+		// Appease the verifier, this will never fail.
+		return 0;
+	}
+
+	// u32 idx = __sync_fetch_and_add(sym_idx, 1);
+	// The previous __sync_fetch_and_add does not seem to work in 5.4 and 5.10
+	//  > libbpf: prog 'walk_ruby_stack': -- BEGIN PROG LOAD LOG --\nBPF_STX uses reserved fields
+	//
+	// Checking for the version does not work as these branches are not pruned
+	// in older kernels, so we shard the id generation per CPU.
+	u32 idx = *sym_idx * num_cpus + bpf_get_smp_processor_id();
+	*sym_idx += 1;
+
+	int err;
+	err = bpf_map_update_elem(&symbol_table, sym, &idx, BPF_ANY);
+	if (err) {
+		return 0;
+	}
+	return idx;
+}
 
 static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *key, const void *init) {
     void *val;

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -49,6 +49,8 @@ func (f Function) FullName() string {
 	return f.ModuleName + "::" + f.Name
 }
 
+type InterpreterSymbolTable map[uint32]*Function
+
 type Writer interface {
 	Write(w io.Writer) error
 	WriteUncompressed(w io.Writer) error

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -107,12 +107,14 @@ type CPU struct {
 	profileConverter   *pprof.Manager
 	profileStore       profiler.ProfileStore
 
-	framePointerCache unwind.FramePointerCache
-
 	// Notify that the BPF program was loaded.
 	bpfProgramLoaded chan bool
 	bpfMaps          *bpfmaps.Maps
-	byteOrder        binary.ByteOrder
+
+	framePointerCache unwind.FramePointerCache
+	interpSymTab      profile.InterpreterSymbolTable
+
+	byteOrder binary.ByteOrder
 
 	mtx                            *sync.RWMutex
 	lastError                      error
@@ -828,7 +830,7 @@ func (p *CPU) Run(ctx context.Context) error {
 		}
 
 		obtainStart := time.Now()
-		rawData, interpreterSymbolTable, err := p.obtainRawData(ctx)
+		rawData, err := p.obtainRawData(ctx)
 		if err != nil {
 			p.metrics.obtainAttempts.WithLabelValues(labelError).Inc()
 			level.Warn(p.logger).Log("msg", "failed to obtain profiles from eBPF maps", "err", err)
@@ -867,6 +869,10 @@ func (p *CPU) Run(ctx context.Context) error {
 				continue
 			}
 
+			interpreterSymbolTable, err := p.interpreterSymbolTable(perProcessRawData.RawSamples)
+			if err != nil {
+				level.Debug(p.logger).Log("msg", "failed to get interpreter symbol table", "pid", pid, "err", err)
+			}
 			pprof, executableInfos, err := p.profileConverter.NewConverter(
 				pfs,
 				pid,
@@ -939,18 +945,57 @@ type profileKey struct {
 	tid int32
 }
 
+// interpreterSymbolTable returns an up-to-date symbol table for the interpreter.
+func (p *CPU) interpreterSymbolTable(samples []profile.RawSample) (profile.InterpreterSymbolTable, error) {
+	if !p.config.RubyUnwindingEnabled && !p.config.PythonUnwindingEnabled {
+		return nil, nil
+	}
+
+	if p.interpSymTab == nil {
+		if err := p.updateInterpreterSymbolTable(); err != nil {
+			// Return the old version of the symbol table if we failed to update it.
+			return p.interpSymTab, err
+		}
+		return p.interpSymTab, nil
+	}
+
+	for _, sample := range samples {
+		if sample.InterpreterStack == nil {
+			continue
+		}
+
+		for _, id := range sample.InterpreterStack {
+			if _, ok := p.interpSymTab[uint32(id)]; !ok {
+				if err := p.updateInterpreterSymbolTable(); err != nil {
+					// Return the old version of the symbol table if we failed to update it.
+					return p.interpSymTab, err
+				}
+				// We only need to update the symbol table once.
+				return p.interpSymTab, nil
+			}
+		}
+	}
+	// The symbol table is up-to-date.
+	return p.interpSymTab, nil
+}
+
+func (p *CPU) updateInterpreterSymbolTable() error {
+	interpSymTab, err := p.bpfMaps.InterpreterSymbolTable()
+	if err != nil {
+		return fmt.Errorf("get interpreter symbol table: %w", err)
+	}
+	p.interpSymTab = interpSymTab
+	return nil
+}
+
 // obtainProfiles collects profiles from the BPF maps.
-func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*profile.Function, error) {
+func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
 	rawData := map[profileKey]map[bpfprograms.CombinedStack]uint64{}
-	var (
-		interpreterSymbolTable map[uint32]*profile.Function
-		interpErr              error
-	)
 
 	it := p.bpfMaps.StackCounts.Iterator()
 	for it.Next() {
 		if ctx.Err() != nil {
-			return nil, interpreterSymbolTable, ctx.Err()
+			return nil, ctx.Err()
 		}
 
 		// This byte slice is only valid for this iteration, so it must be
@@ -962,7 +1007,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 		// See the comment in stackCountKey for more details.
 		if err := binary.Read(bytes.NewBuffer(keyBytes), p.byteOrder, &key); err != nil {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonKey).Inc()
-			return nil, interpreterSymbolTable, fmt.Errorf("read stack count key: %w", err)
+			return nil, fmt.Errorf("read stack count key: %w", err)
 		}
 
 		// Profile aggregation key.
@@ -982,7 +1027,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonUser).Inc()
 			if errors.Is(userErr, bpfmaps.ErrUnrecoverable) {
 				p.metrics.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelError).Inc()
-				return nil, interpreterSymbolTable, userErr
+				return nil, userErr
 			}
 			if errors.Is(userErr, bpfmaps.ErrUnwindFailed) {
 				p.metrics.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelFailed).Inc()
@@ -995,11 +1040,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 		}
 
 		if key.InterpreterStackID != 0 {
-			// TODO: Improve error handling.
-			interpreterSymbolTable, interpErr = p.bpfMaps.InterpreterSymbolTable()
-			interpErr = errors.Join(interpErr, p.bpfMaps.ReadStack(key.InterpreterStackID, interpreterStack))
-
-			if interpErr != nil {
+			if interpErr := p.bpfMaps.ReadStack(key.InterpreterStackID, interpreterStack); interpErr != nil {
 				p.metrics.readMapAttempts.WithLabelValues(labelInterpreter, labelInterpreterUnwind, labelError).Inc()
 				level.Debug(p.logger).Log("msg", "failed to read interpreter stacks", "err", interpErr)
 			} else {
@@ -1013,7 +1054,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonKernel).Inc()
 			if errors.Is(kernelErr, bpfmaps.ErrUnrecoverable) {
 				p.metrics.readMapAttempts.WithLabelValues(labelKernel, labelKernelUnwind, labelError).Inc()
-				return nil, interpreterSymbolTable, kernelErr
+				return nil, kernelErr
 			}
 			if errors.Is(kernelErr, bpfmaps.ErrUnwindFailed) {
 				p.metrics.readMapAttempts.WithLabelValues(labelKernel, labelKernelUnwind, labelFailed).Inc()
@@ -1034,7 +1075,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 		value, err := p.bpfMaps.ReadStackCount(keyBytes)
 		if err != nil {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonCount).Inc()
-			return nil, interpreterSymbolTable, fmt.Errorf("read value: %w", err)
+			return nil, fmt.Errorf("read value: %w", err)
 		}
 		if value == 0 {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonZeroCount).Inc()
@@ -1054,14 +1095,14 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[uint32]*p
 	}
 	if it.Err() != nil {
 		p.metrics.stackDrop.WithLabelValues(labelStackDropReasonIterator).Inc()
-		return nil, interpreterSymbolTable, fmt.Errorf("failed iterator: %w", it.Err())
+		return nil, fmt.Errorf("failed iterator: %w", it.Err())
 	}
 
 	if err := p.bpfMaps.FinalizeProfileLoop(); err != nil {
 		level.Warn(p.logger).Log("msg", "failed to clean BPF maps that store stacktraces", "err", err)
 	}
 
-	return preprocessRawData(rawData), interpreterSymbolTable, nil
+	return preprocessRawData(rawData), nil
 }
 
 // preprocessRawData takes the raw data from the BPF maps and converts it into


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

- Uses `BPF_MAP_TYPE_LRU_HASH` for the symbol table. To eliminate cleaning up the map.
> Both BPF_MAP_TYPE_LRU_HASH and BPF_MAP_TYPE_LRU_PERCPU_HASH were introduced in version 4.10

- Caches the symbol table in the user space.
- Only updates the table if it encounters a new symbol ID.

It should work even better in combination with #2286 

### Benchmark
**Before:** 

1500-2500 CGo calls pm

Metrics:
![CleanShot 2023-11-23 at 21 25 50](https://github.com/parca-dev/parca-agent/assets/536449/7ded5244-6432-4f3b-990e-a9fe899abdb8)

 
Profile:
- https://pprof.me/aebf36cac18a2f6c1725aec810ea87bc

**After:**

200-300 CGo calls pm

Metrics: 
![CleanShot 2023-11-23 at 21 47 13](https://github.com/parca-dev/parca-agent/assets/536449/1a460bfd-8b8f-4340-b402-2db44d2ca55d)

Profile:
- [TBA](https://pprof.me/d44684fefc312522443fa1c1747a1ac1)

**Comparison**
![CleanShot 2023-11-23 at 21 44 22](https://github.com/parca-dev/parca-agent/assets/536449/776fbdf7-c77d-4342-aa91-4c95de16f0fa)
