### PR TITLE
chore: fix nix-shell

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -8,6 +8,9 @@ in
 }) rec {
   name = "parca-agent-devshell";
 
+  # clang-14: error: argument unused during compilation: '--gcc-toolchain=/nix/store/hf2gy3km07d5m0p1lwmja0rg9wlnmyr7-gcc-12.3.0' [-Werror,-Wunused-command-line-argument]
+  env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument";
+
   packages = with pkgs; [
     bpftools
     docker-machine-kvm2

--- a/nix/go-tools.nix
+++ b/nix/go-tools.nix
@@ -12,7 +12,7 @@
       sha256 = "sha256-h7NhJ/V0FaMX7F6OG+FJB4h3nSXUE/4ZYeUwoBZo0C0=";
     };
 
-    vendorSha256 = "sha256-dSYu5Sb6hBTnNE4PXHQK6oGQasCrSu4l7KqhYJxTNDQ=";
+    vendorHash = "sha256-dSYu5Sb6hBTnNE4PXHQK6oGQasCrSu4l7KqhYJxTNDQ=";
 
     CGO_ENABLED = 0;
 
@@ -37,7 +37,7 @@
       sha256 = "sha256-hfMI2d3iRe74nUQ9ydgXUshStk9LFWXkJL1/7ZsEX6g=";
     };
 
-    vendorSha256 = "sha256-uLhXMwnSHFUUiQlpDw/U6fZvNsRuB4cZhxX4qUtdknA=";
+    vendorHash = "sha256-uLhXMwnSHFUUiQlpDw/U6fZvNsRuB4cZhxX4qUtdknA=";
 
     CGO_ENABLED = 0;
 


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->

```
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead
```

```
clang-14: error: argument unused during compilation: '--gcc-toolchain=/nix/store/hf2gy3km07d5m0p1lwmja0rg9wlnmyr7-gcc-12.3.0' [-Werror,-Wunused-command-line-argument]
```

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->

### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan
<!-- How did you test it? How can we test it? -->
