### PR TITLE
ci(pre-commit): clean up golangci-lint

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,8 +18,6 @@ concurrency:
 env:
   # renovate: datasource=pypi depName=pre-commit versioning=pep440
   PRE_COMMIT_VERSION: ==3.5.0
-  # renovate: datasource=go depName=github.com/golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: v1.55.2
 
 jobs:
   pre-commit:
@@ -49,14 +47,12 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: .go-version
+          cache: false
 
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
         with:
           version: "14"
-
-      - name: Install golangci-lint
-        run: go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 
       - name: Set golangci-lint cache key parts
         run: |


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->

* `golangci-lint` is installed by `pre-commit`
* The Go cache is already set up within `golangci-lint` cache

A follow to #1419 which was itself a follow to #1293

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->

### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan
<!-- How did you test it? How can we test it? -->
