### PR TITLE
runtime: Use ainur.StreamReader instead of io.RuneReader

### DIFF
--- a/pkg/runtime/nodejs/nodejs.go
+++ b/pkg/runtime/nodejs/nodejs.go
@@ -14,7 +14,6 @@
 package nodejs
 
 import (
-	"bufio"
 	"debug/elf"
 	"errors"
 	"fmt"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/prometheus/procfs"
+	"github.com/xyproto/ainur"
 
 	"github.com/parca-dev/parca-agent/pkg/runtime"
 )
@@ -229,25 +229,44 @@ const semVerRegex string = `v([0-9]+)(\.[0-9]+)(\.[0-9]+)` +
 func scanVersionBytes(r io.ReadSeeker) (string, error) {
 	nodejsVersionRegex := regexp.MustCompile(semVerRegex)
 
-	match := nodejsVersionRegex.FindReaderSubmatchIndex(bufio.NewReader(r))
-	if match == nil {
-		return "", errors.New("failed to find version string")
-	}
-
-	if _, err := r.Seek(int64(match[0]), io.SeekStart); err != nil {
-		return "", fmt.Errorf("seek to start: %w", err)
-	}
-
-	matched := make([]byte, match[1]-match[0])
-
-	if _, err := r.Read(matched); err != nil {
-		return "", fmt.Errorf("read matched: %w", err)
-	}
-
-	ver, err := semver.NewVersion(string(matched))
+	bufferSize := 4096
+	sr, err := ainur.NewStreamReader(r, bufferSize)
 	if err != nil {
-		return "", fmt.Errorf("new version, %s: %w", string(matched), err)
+		return "", fmt.Errorf("failed to create stream reader: %w", err)
 	}
 
-	return ver.Original(), nil
+	for {
+		b, err := sr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return "", fmt.Errorf("failed to read next: %w", err)
+		}
+
+		matches := nodejsVersionRegex.FindSubmatchIndex(b)
+		if matches == nil {
+			continue
+		}
+
+		for i := 0; i < len(matches); i++ {
+			if matches[i] == -1 {
+				continue
+			}
+
+			if _, err := r.Seek(int64(matches[i]), io.SeekStart); err != nil {
+				return "", fmt.Errorf("failed to seek to start: %w", err)
+			}
+
+			matched := b[matches[i]:matches[i+1]]
+			ver, err := semver.NewVersion(string(matched))
+			if err != nil {
+				return "", fmt.Errorf("failed to create new version, %s: %w", string(matched), err)
+			}
+
+			return ver.Original(), nil
+		}
+	}
+
+	return "", errors.New("version not found")
 }

--- a/pkg/runtime/nodejs/nodejs_test.go
+++ b/pkg/runtime/nodejs/nodejs_test.go
@@ -17,13 +17,32 @@ import (
 	"bytes"
 	"debug/elf"
 	"io"
+	"path"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+const testdata = "../../../testdata"
+
+func arch() string {
+	ar := runtime.GOARCH
+	switch ar {
+	case "amd64":
+		return "x86"
+	default:
+		return ar
+	}
+}
+
+//nolint:unparam
+func testBinaryPath(p string) string {
+	return path.Join(testdata, "vendored", arch(), p)
+}
+
 func Test_scanVersionBytes(t *testing.T) {
-	ef, err := elf.Open("testdata/node")
+	ef, err := elf.Open(testBinaryPath("node20.8"))
 	require.NoError(t, err)
 	t.Cleanup(func() { ef.Close() })
 
@@ -148,7 +167,7 @@ func Test_isNodeJSLib(t *testing.T) {
 }
 
 func Benchmark_scanVersionBytes(b *testing.B) {
-	ef, err := elf.Open("testdata/node")
+	ef, err := elf.Open(testBinaryPath("node20.8"))
 	require.NoError(b, err)
 
 	sec := ef.Section(".rodata")


### PR DESCRIPTION
- Use ainur.StreamReader instead of io.RuneReader
- Fix tests

### Benchmark


<details><summary>Old</summary>
<p>

```text
oos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/runtime/nodejs
cpu: AMD Ryzen 9 5950X 16-Core Processor            
Benchmark_scanVersionBytes-32                100          11508930 ns/op           32162 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                102          11422398 ns/op           32672 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                100          11774011 ns/op           32991 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                100          11629588 ns/op           32162 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                102          12016436 ns/op           33038 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                103          11492685 ns/op           32602 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                102          11671819 ns/op           33038 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                100          11675831 ns/op           32601 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                100          11757764 ns/op           32601 B/op        178 allocs/op
Benchmark_scanVersionBytes-32                103          11512288 ns/op           32602 B/op        178 allocs/op
PASS
ok      github.com/parca-dev/parca-agent/pkg/runtime/nodejs     15.678s
```

</p>
</details> 

<details><summary>New</summary>
<p>

```text
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/runtime/nodejs
cpu: AMD Ryzen 9 5950X 16-Core Processor            
Benchmark_scanVersionBytes-32               1958            656223 ns/op           32144 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1585            727980 ns/op           32031 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               2030            689447 ns/op           32172 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1796            670143 ns/op           32121 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1525            715696 ns/op           32209 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1504            715440 ns/op           32136 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1597            676401 ns/op           32100 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1540            695197 ns/op           32181 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1615            718022 ns/op           32097 B/op        174 allocs/op
Benchmark_scanVersionBytes-32               1591            688324 ns/op           32242 B/op        174 allocs/op
PASS
ok      github.com/parca-dev/parca-agent/pkg/runtime/nodejs     13.306s
```

</p>
</details> 

**Comparison**
```text
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/runtime/nodejs
cpu: AMD Ryzen 9 5950X 16-Core Processor
                     │    old.txt    │               new.txt               │
                     │    sec/op     │   sec/op     vs base                │
_scanVersionBytes-32   11650.7µ ± 1%   692.3µ ± 4%  -94.06% (p=0.000 n=10)

                     │   old.txt    │               new.txt               │
                     │     B/op     │     B/op      vs base               │
_scanVersionBytes-32   31.84Ki ± 1%   31.39Ki ± 0%  -1.42% (p=0.001 n=10)

                     │  old.txt   │              new.txt              │
                     │ allocs/op  │ allocs/op   vs base               │
_scanVersionBytes-32   178.0 ± 0%   174.0 ± 0%  -2.25% (p=0.000 n=10)
```

### TODO

- [ ] Remove checked in binary

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
