### PR TITLE
runtime: Optimize FindSymbol

### DIFF
--- a/pkg/runtime/elf_symbols.go
+++ b/pkg/runtime/elf_symbols.go
@@ -14,8 +14,10 @@
 package runtime
 
 import (
+	"bufio"
 	"bytes"
 	"debug/elf"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -57,19 +59,18 @@ func IsSymbolNameInDynamicSymbols(f *elf.File, matches [][]byte) (bool, error) {
 	return isSymbolNameInSection(f, elf.SHT_DYNSYM, matches)
 }
 
-func isSymbolNameInSection(f *elf.File, t elf.SectionType, matches [][]byte) (bool, error) {
-	symtabSection := f.SectionByType(t)
+func isSymbolNameInSection(ef *elf.File, t elf.SectionType, matches [][]byte) (bool, error) {
+	symtabSection := ef.SectionByType(t)
 	if symtabSection == nil {
 		return false, elf.ErrNoSymbols
 	}
 
-	if symtabSection.Link <= 0 || symtabSection.Link >= uint32(len(f.Sections)) {
-		return false, errors.New("section has invalid string table link")
+	strtabReader, err := stringTableReader(ef, symtabSection.Link)
+	if err != nil {
+		return false, fmt.Errorf("cannot load string table section: %w", err)
 	}
 
-	s := f.Sections[symtabSection.Link].Open()
-
-	sr, err := ainur.NewStreamReader(s, 8192)
+	sr, err := ainur.NewStreamReader(strtabReader, 8192)
 	if err != nil {
 		return false, fmt.Errorf("create stream reader: %w", err)
 	}
@@ -94,31 +95,240 @@ func isSymbolNameInSection(f *elf.File, t elf.SectionType, matches [][]byte) (bo
 	return false, nil
 }
 
+func scanNullTerminated(data []byte, atEOF bool) (int, []byte, error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil // io.EOF
+	}
+
+	if i := bytes.IndexByte(data, 0); i >= 0 {
+		// We have a full null-terminated line.
+		return i + 1, data[0:i], nil
+	}
+
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+
+	// Request more data.
+	return 0, nil, nil
+}
+
+func firstIndexOfMatchingSymbol(r io.Reader, matches [][]byte) (int, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(scanNullTerminated)
+
+	bytesRead := 0
+	for scanner.Scan() {
+		for _, match := range matches {
+			b := scanner.Bytes()
+			if len(b) == len(match) && bytes.Equal(b, match) {
+				return bytesRead, nil
+			}
+		}
+		bytesRead += len(scanner.Bytes()) + 1 // +1 for null terminator
+	}
+	if err := scanner.Err(); err != nil {
+		return -1, fmt.Errorf("scanner: %w", err)
+	}
+	return -1, nil
+}
+
 // FindSymbol finds symbol by name in the given elf file.
 func FindSymbol(ef *elf.File, symbol string) (*elf.Symbol, error) {
-	symbols, err := ef.Symbols()
+	sym, err := getSymbol(ef, elf.SHT_SYMTAB, symbol)
 	// If there are no symbols, try dynamic symbols.
 	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
-		return nil, fmt.Errorf("error reading ELF symbols: %w", err)
+		return nil, fmt.Errorf("error getting ELF symbols: %w", err)
+	}
+	if sym != nil {
+		return sym, nil
 	}
 
-	for _, s := range symbols {
-		if s.Name == symbol {
-			return &s, nil
-		}
-	}
-
-	dynamicSymbols, err := ef.DynamicSymbols()
+	sym, err = getSymbol(ef, elf.SHT_DYNSYM, symbol)
 	if err != nil {
 		return nil, fmt.Errorf("error reading ELF dynamic symbols: %w", err)
 	}
-	for _, s := range dynamicSymbols {
-		if s.Name == symbol {
-			return &s, nil
-		}
+	if sym != nil {
+		return sym, nil
 	}
 
 	return nil, fmt.Errorf("symbol %q not found", symbol)
+}
+
+func getSymbol(ef *elf.File, typ elf.SectionType, symbol string) (*elf.Symbol, error) {
+	switch ef.Class {
+	case elf.ELFCLASS64:
+		return getSymbol64(ef, typ, symbol)
+
+	case elf.ELFCLASS32:
+		return getSymbol32(ef, typ, symbol)
+
+	case elf.ELFCLASSNONE:
+		fallthrough
+
+	default:
+		return nil, fmt.Errorf("unknown ELF class: %v", ef.Class)
+	}
+}
+
+func getSymbol32(ef *elf.File, typ elf.SectionType, symbol string) (*elf.Symbol, error) {
+	symtabSection := ef.SectionByType(typ)
+	if symtabSection == nil {
+		return nil, elf.ErrNoSymbols
+	}
+
+	strdataReader, err := stringTableReader(ef, symtabSection.Link)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load string table section: %w", err)
+	}
+
+	match, err := firstIndexOfMatchingSymbol(strdataReader, [][]byte{[]byte(symbol)})
+	if err != nil {
+		return nil, fmt.Errorf("cannot find symbol: %w", err)
+	}
+	if match == -1 {
+		return nil, fmt.Errorf("symbol not found, %q", symbol)
+	}
+
+	data, err := symtabSection.Data()
+	if err != nil {
+		return nil, fmt.Errorf("cannot load symbol section: %w", err)
+	}
+
+	symtab := bytes.NewReader(data)
+	if symtab.Len()%elf.Sym64Size != 0 {
+		return nil, errors.New("length of symbol section is not a multiple of Sym64Size")
+	}
+
+	// The first entry is all zeros.
+	var skip [elf.Sym32Size]byte
+	_, err = symtab.Read(skip[:])
+	if err != nil {
+		return nil, fmt.Errorf("cannot read first entry: %w", err)
+	}
+
+	var sym elf.Sym32
+	for symtab.Len() > 0 {
+		if err := binary.Read(symtab, ef.ByteOrder, &sym); err != nil {
+			return nil, fmt.Errorf("cannot read symbol: %w", err)
+		}
+
+		if sym.Name != uint32(match) {
+			continue
+		}
+
+		str, err := readStringFromReaderSeeker(strdataReader, int(sym.Name))
+		if err != nil {
+			return nil, fmt.Errorf("cannot read symbol name: %w", err)
+		}
+
+		return &elf.Symbol{
+			Name:    str,
+			Info:    sym.Info,
+			Other:   sym.Other,
+			Section: elf.SectionIndex(sym.Shndx),
+			Value:   uint64(sym.Value),
+			Size:    uint64(sym.Size),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("symbol not found, %q", symbol)
+}
+
+func getSymbol64(ef *elf.File, typ elf.SectionType, symbol string) (*elf.Symbol, error) {
+	symtabSection := ef.SectionByType(typ)
+	if symtabSection == nil {
+		return nil, elf.ErrNoSymbols
+	}
+
+	strdataReader, err := stringTableReader(ef, symtabSection.Link)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load string table section: %w", err)
+	}
+
+	match, err := firstIndexOfMatchingSymbol(strdataReader, [][]byte{[]byte(symbol)})
+	if err != nil {
+		return nil, fmt.Errorf("cannot find symbol: %w", err)
+	}
+	if match == -1 {
+		return nil, fmt.Errorf("symbol not found, %q", symbol)
+	}
+
+	data, err := symtabSection.Data()
+	if err != nil {
+		return nil, fmt.Errorf("cannot load symbol section: %w", err)
+	}
+
+	symtab := bytes.NewReader(data)
+	if symtab.Len()%elf.Sym64Size != 0 {
+		return nil, errors.New("length of symbol section is not a multiple of Sym64Size")
+	}
+
+	// The first entry is all zeros.
+	var skip [elf.Sym64Size]byte
+	_, err = symtab.Read(skip[:])
+	if err != nil {
+		return nil, fmt.Errorf("cannot read first entry: %w", err)
+	}
+
+	var sym elf.Sym64
+	for symtab.Len() > 0 {
+		if err := binary.Read(symtab, ef.ByteOrder, &sym); err != nil {
+			return nil, fmt.Errorf("cannot read symbol: %w", err)
+		}
+
+		if sym.Name != uint32(match) {
+			continue
+		}
+
+		str, err := readStringFromReaderSeeker(strdataReader, int(sym.Name))
+		if err != nil {
+			return nil, fmt.Errorf("cannot read symbol name: %w", err)
+		}
+
+		return &elf.Symbol{
+			Name:    str,
+			Info:    sym.Info,
+			Other:   sym.Other,
+			Section: elf.SectionIndex(sym.Shndx),
+			Value:   sym.Value,
+			Size:    sym.Size,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("symbol not found, %q", symbol)
+}
+
+// readStringFromReaderSeeker extracts a zero-terminated string from an ELF string table io.Reader.
+func readStringFromReaderSeeker(rs io.ReadSeeker, start int) (string, error) {
+	_, err := rs.Seek(int64(start), io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	for {
+		var b [1]byte
+		if _, err := rs.Read(b[:]); err != nil {
+			return "", err
+		}
+		if b[0] == 0 {
+			break
+		}
+		buf.Write(b[:])
+	}
+
+	return buf.String(), nil
+}
+
+// stringTable reads and returns the string table given by the
+// specified link value.
+func stringTableReader(ef *elf.File, link uint32) (io.ReadSeeker, error) {
+	if link <= 0 || link >= uint32(len(ef.Sections)) {
+		return nil, errors.New("section has invalid string table link")
+	}
+	return ef.Sections[link].Open(), nil
 }
 
 // ReadStringAtAddress reads a null-terminated string from the given address in

--- a/pkg/runtime/elf_symbols_test.go
+++ b/pkg/runtime/elf_symbols_test.go
@@ -1,0 +1,199 @@
+// Copyright 2023 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"debug/elf"
+	"path"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+const testdata = "../../testdata"
+
+// TODO(kakkoyun): Change upstream to use GOARCH.
+func arch() string {
+	ar := runtime.GOARCH
+	switch ar {
+	case "amd64":
+		return "x86"
+	default:
+		return ar
+	}
+}
+
+//nolint:unparam
+func testBinaryPath(p string) string {
+	return path.Join(testdata, "vendored", arch(), p)
+}
+
+func Benchmark_isSymbolNameInSection(b *testing.B) {
+	f, err := elf.Open(testBinaryPath("libpython3.11.so.1.0"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := isSymbolNameInSection(f, elf.SHT_DYNSYM, [][]byte{[]byte("_PyRuntime")})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Test_isSymbolNameInSection(t *testing.T) {
+	libpython := testBinaryPath("libpython3.11.so.1.0")
+
+	type args struct {
+		path    string
+		t       elf.SectionType
+		matches [][]byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "_PyRuntime dynamic",
+			args: args{
+				path:    libpython,
+				t:       elf.SHT_DYNSYM,
+				matches: [][]byte{[]byte("_PyRuntime")},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "_PyRuntime static",
+			args: args{
+				path:    libpython,
+				t:       elf.SHT_SYMTAB,
+				matches: [][]byte{[]byte("_PyRuntime")},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ef, err := elf.Open(tt.args.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				ef.Close()
+			})
+
+			got, err := isSymbolNameInSection(ef, tt.args.t, tt.args.matches)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isSymbolNameInSection() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("isSymbolNameInSection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindSymbol(t *testing.T) {
+	libpython := testBinaryPath("libpython3.11.so.1.0")
+
+	type args struct {
+		path   string
+		symbol string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *elf.Symbol
+		wantErr bool
+	}{
+		{
+			name: "find _PyRuntime",
+			args: args{
+				path:   libpython,
+				symbol: "_PyRuntime",
+			},
+			want: &elf.Symbol{
+				Name:    "_PyRuntime",
+				Info:    17,
+				Other:   0,
+				Section: 25,
+				Value:   0x0000000000557d20,
+				Size:    166688,
+			},
+			wantErr: false,
+		},
+		{
+			name: "find _PyRuntimeState_Fini",
+			args: args{
+				path:   libpython,
+				symbol: "_PyRuntimeState_Fini",
+			},
+			want: &elf.Symbol{
+				Name:    "_PyRuntimeState_Fini",
+				Info:    18,
+				Other:   0,
+				Section: 13,
+				Value:   0x000000000029a7a0,
+				Size:    148,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ef, err := elf.Open(tt.args.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				ef.Close()
+			})
+			got, err := FindSymbol(ef, tt.args.symbol)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindSymbol() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindSymbol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkFindSymbol(b *testing.B) {
+	f, err := elf.Open(testBinaryPath("libpython3.11.so.1.0"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := FindSymbol(f, "_PyRuntime")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
- Add tests and benchmarks for isSymbolNameInSection
- Optimize FindSymbol
- Integrate runtime/ruby with FindSymbol
- Use bufio.Scanner instead of regex
- Use testdata submodule

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

I messed up the history of https://github.com/parca-dev/parca-agent/pull/2280

### Benchmarks

<details><summary>Old</summary>
<p>

```text
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/runtime
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFindSymbol-32               540           2727986 ns/op          687891 B/op      13820 allocs/op
BenchmarkFindSymbol-32               420           2947543 ns/op          687889 B/op      13820 allocs/op
BenchmarkFindSymbol-32               432           2974568 ns/op          687892 B/op      13820 allocs/op
BenchmarkFindSymbol-32               414           2888769 ns/op          687890 B/op      13820 allocs/op
BenchmarkFindSymbol-32               476           2866761 ns/op          687891 B/op      13820 allocs/op
BenchmarkFindSymbol-32               445           2534425 ns/op          687890 B/op      13820 allocs/op
BenchmarkFindSymbol-32               450           2950351 ns/op          687891 B/op      13820 allocs/op
BenchmarkFindSymbol-32               450           2772721 ns/op          687889 B/op      13820 allocs/op
BenchmarkFindSymbol-32               392           2826073 ns/op          687890 B/op      13820 allocs/op
BenchmarkFindSymbol-32               451           2851258 ns/op          687891 B/op      13820 allocs/op
PASS
ok      github.com/parca-dev/parca-agent/pkg/runtime    15.395s
```


</p>
</details> 

<details><summary>New</summary>
<p>

```text
goos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/runtime
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFindSymbol-32               100          10170947 ns/op          692470 B/op      13846 allocs/op
BenchmarkFindSymbol-32               128           8933931 ns/op          691967 B/op      13845 allocs/op
BenchmarkFindSymbol-32               135           9904559 ns/op          692174 B/op      13846 allocs/op
BenchmarkFindSymbol-32               118           9696289 ns/op          692349 B/op      13846 allocs/op
BenchmarkFindSymbol-32               122           9897046 ns/op          692241 B/op      13846 allocs/op
BenchmarkFindSymbol-32               100          10172680 ns/op          692224 B/op      13846 allocs/op
BenchmarkFindSymbol-32               124           9957047 ns/op          692252 B/op      13846 allocs/op
BenchmarkFindSymbol-32               124          10333432 ns/op          692179 B/op      13846 allocs/op
BenchmarkFindSymbol-32               100          10207261 ns/op          692313 B/op      13846 allocs/op
BenchmarkFindSymbol-32               117          10515376 ns/op          692617 B/op      13847 allocs/op
PASS
ok      github.com/parca-dev/parca-agent/pkg/runtime    18.183s
```


</p>
</details> 

**Comparison**

```text
oos: linux
goarch: amd64
pkg: github.com/parca-dev/parca-agent/pkg/runtime
cpu: AMD Ryzen 9 5950X 16-Core Processor            
              │   old.txt    │               new.txt               │
              │    sec/op    │   sec/op     vs base                │
FindSymbol-32   3.732m ± 11%   2.859m ± 5%  -23.40% (p=0.000 n=10)

              │    old.txt    │               new.txt                │
              │     B/op      │     B/op      vs base                │
FindSymbol-32   2656.4Ki ± 0%   671.8Ki ± 0%  -74.71% (p=0.000 n=10)

              │   old.txt   │               new.txt               │
              │  allocs/op  │  allocs/op   vs base                │
FindSymbol-32   29.32k ± 0%   13.82k ± 0%  -52.87% (p=0.000 n=10)
```

### Test Plan

Ruby: https://pprof.me/c6d16202aa0d9a478c4d557709e0fdf5
Python: https://pprof.me/139355b6fe69c0db9e7c5394ec3dcf8e


![CleanShot 2023-11-21 at 20 41 02](https://github.com/parca-dev/parca-agent/assets/536449/29d791f5-193e-43ab-ac4a-de169e2d9359)
![CleanShot 2023-11-21 at 20 40 54](https://github.com/parca-dev/parca-agent/assets/536449/5ae7f876-e23e-420a-9b56-f6752ae62921)

