### PR TITLE
*: Use optimized symtabs for jitdump and perfmaps

### DIFF
--- a/pkg/ksym/ksym.go
+++ b/pkg/ksym/ksym.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/parca-dev/parca-agent/pkg/hash"
+	"github.com/parca-dev/parca-agent/pkg/symtab"
 )
 
 type Ksym struct {
@@ -39,7 +40,7 @@ type Ksym struct {
 	lastCacheInvalidation time.Time
 	updateDuration        time.Duration
 	mtx                   *sync.RWMutex
-	optimizedReader       *fileReader
+	optimizedReader       *symtab.FileReader
 }
 
 type realfs struct{}
@@ -124,14 +125,14 @@ func (c *Ksym) reload() error {
 	path := path.Join(c.tempDir, "parca-agent-kernel-symbols")
 
 	// Generate optimized file.
-	writer, err := NewWriter(path, 100)
+	writer, err := symtab.NewWriter(path, 100)
 	if err != nil {
 		return fmt.Errorf("newWriter: %w", err)
 	}
 
 	err = c.loadKsyms(
 		func(addr uint64, symbol string) {
-			_ = writer.addSymbol(symbol, addr)
+			_ = writer.AddSymbol(symbol, addr)
 		},
 	)
 	if err != nil {
@@ -144,7 +145,7 @@ func (c *Ksym) reload() error {
 	}
 
 	// Set up reader.
-	reader, err := NewReader(path)
+	reader, err := symtab.NewReader(path)
 	if err != nil {
 		return fmt.Errorf("newReader: %w", err)
 	}
@@ -213,7 +214,7 @@ func (c *Ksym) resolveKsyms(addrs []uint64) []string {
 	result := make([]string, 0, len(addrs))
 
 	for _, addr := range addrs {
-		symbol, err := c.optimizedReader.symbolize(addr)
+		symbol, err := c.optimizedReader.Symbolize(addr)
 		if err != nil {
 			result = append(result, "")
 		} else {

--- a/pkg/perf/perf_test.go
+++ b/pkg/perf/perf_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestPerfMapParse(t *testing.T) {
-	res, err := ReadPerfMap(log.NewNopLogger(), "testdata/nodejs-perf-map", nil)
+	res, err := ReadPerfMap(log.NewNopLogger(), "testdata/nodejs-perf-map", 0, 0, 0)
 	require.NoError(t, err)
 	require.Len(t, res.addrs, 28)
 
@@ -43,12 +43,12 @@ func TestPerfMapCorruptLine(t *testing.T) {
 }
 
 func TestPerfMapRegression(t *testing.T) {
-	_, err := ReadPerfMap(log.NewNopLogger(), "testdata/nodejs-perf-map-regression", nil)
+	_, err := ReadPerfMap(log.NewNopLogger(), "testdata/nodejs-perf-map-regression", 0, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestPerfMapParseErlangPerfMap(t *testing.T) {
-	_, err := ReadPerfMap(log.NewNopLogger(), "testdata/erlang-perf-map", nil)
+	_, err := ReadPerfMap(log.NewNopLogger(), "testdata/erlang-perf-map", 0, 0, 0)
 	require.NoError(t, err)
 }
 
@@ -56,7 +56,7 @@ func BenchmarkPerfMapParse(b *testing.B) {
 	logger := log.NewNopLogger()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ReadPerfMap(logger, "testdata/nodejs-perf-map", nil)
+		_, err := ReadPerfMap(logger, "testdata/nodejs-perf-map", 0, 0, 0)
 		require.NoError(b, err)
 	}
 }
@@ -65,7 +65,7 @@ func BenchmarkPerfMapParseBig(b *testing.B) {
 	logger := log.NewNopLogger()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ReadPerfMap(logger, "testdata/erlang-perf-map", nil)
+		_, err := ReadPerfMap(logger, "testdata/erlang-perf-map", 0, 0, 0)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/symtab/symtab_test.go
+++ b/pkg/symtab/symtab_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ksym
+package symtab
 
 import (
 	"path"
@@ -26,13 +26,13 @@ func TestOptimizedSymbolizerWorks(t *testing.T) {
 	writer, err := NewWriter(file, 100)
 	require.NoError(t, err)
 
-	err = writer.addSymbol("first", 0x10)
+	err = writer.AddSymbol("first", 0x10)
 	require.NoError(t, err)
 
-	err = writer.addSymbol("mid", 0x50)
+	err = writer.AddSymbol("mid", 0x50)
 	require.NoError(t, err)
 
-	err = writer.addSymbol("last", 0x1200)
+	err = writer.AddSymbol("last", 0x1200)
 	require.NoError(t, err)
 
 	err = writer.Write()
@@ -41,22 +41,22 @@ func TestOptimizedSymbolizerWorks(t *testing.T) {
 	reader, err := NewReader(file)
 	require.NoError(t, err)
 
-	_, err = reader.symbolize(0x0)
+	_, err = reader.Symbolize(0x0)
 	require.Error(t, err)
 
-	symbol, err := reader.symbolize(0x10)
+	symbol, err := reader.Symbolize(0x10)
 	require.NoError(t, err)
 	require.Equal(t, "first", symbol)
 
-	symbol, err = reader.symbolize(0x11)
+	symbol, err = reader.Symbolize(0x11)
 	require.NoError(t, err)
 	require.Equal(t, "first", symbol)
 
-	symbol, err = reader.symbolize(0x50)
+	symbol, err = reader.Symbolize(0x50)
 	require.NoError(t, err)
 	require.Equal(t, "mid", symbol)
 
-	symbol, err = reader.symbolize(0x3000)
+	symbol, err = reader.Symbolize(0x3000)
 	require.NoError(t, err)
 	require.Equal(t, "last", symbol)
 }
@@ -73,7 +73,7 @@ func TestOptimizedSymbolizerWithNoSymbolsWorks(t *testing.T) {
 	reader, err := NewReader(file)
 	require.NoError(t, err)
 
-	_, err = reader.symbolize(0x10)
+	_, err = reader.Symbolize(0x10)
 	require.Error(t, err)
 }
 
@@ -84,9 +84,9 @@ func TestOptimizedSymbolizerOverwrite(t *testing.T) {
 		writer, err := NewWriter(file, 100)
 		require.NoError(t, err)
 
-		writer.addSymbol("first", 0x10)
-		writer.addSymbol("mid", 0x50)
-		writer.addSymbol("last", 0x1200)
+		writer.AddSymbol("first", 0x10)
+		writer.AddSymbol("mid", 0x50)
+		writer.AddSymbol("last", 0x1200)
 		err = writer.Write()
 		require.NoError(t, err)
 	}
@@ -95,9 +95,9 @@ func TestOptimizedSymbolizerOverwrite(t *testing.T) {
 		writer, err := NewWriter(file, 100)
 		require.NoError(t, err)
 
-		writer.addSymbol("first", 0x10)
-		writer.addSymbol("mid", 0x50)
-		writer.addSymbol("last", 0x1200)
+		writer.AddSymbol("first", 0x10)
+		writer.AddSymbol("mid", 0x50)
+		writer.AddSymbol("last", 0x1200)
 		err = writer.Write()
 		require.NoError(t, err)
 	}
@@ -109,7 +109,7 @@ func BenchmarkOptimizedSymbolizerWrite(t *testing.B) {
 
 	for n := 0; n < t.N; n++ {
 		writer, _ := NewWriter(file, 100)
-		writer.addSymbol("first", 0x10)
+		writer.AddSymbol("first", 0x10)
 		writer.Write()
 	}
 }
@@ -121,16 +121,16 @@ func BenchmarkOptimizedSymbolizerRead(t *testing.B) {
 	writer, err := NewWriter(file, 100)
 	require.NoError(t, err)
 
-	writer.addSymbol("first", 0x10)
-	writer.addSymbol("mid", 0x50)
-	writer.addSymbol("last", 0x1200)
+	writer.AddSymbol("first", 0x10)
+	writer.AddSymbol("mid", 0x50)
+	writer.AddSymbol("last", 0x1200)
 	writer.Write()
 
 	reader, err := NewReader(file)
 	require.NoError(t, err)
 
 	for n := 0; n < t.N; n++ {
-		symbol, err := reader.symbolize(0x150)
+		symbol, err := reader.Symbolize(0x150)
 		require.NoError(t, err)
 		require.Equal(t, "mid", symbol)
 	}


### PR DESCRIPTION
This patch utilizes the optimized symbol table previously only used for ksyms to move the results of parsing perfmaps and jitdumps to external memory and memory map it.

Since the overwhelming majority of symbols are never used this allows saving a large amount of memory while still keeping those that are used often in cache, which is handled by the operating system using mmap.

### Why?

Holding the results of parsing jitdump/perfmaps in-memory results in unnecessarily high memory usage.

### What?

Move the result to external memory and memory map it.

### How?

Use the same optimized symbol table as we use for ksyms already.

### Test Plan

Only unit tests so far, I will test it some more with actual workloads once merged.