### PR TITLE
pkg/compiler: Fix path building

### DIFF
--- a/pkg/metadata/compiler.go
+++ b/pkg/metadata/compiler.go
@@ -54,6 +54,8 @@ func Compiler(logger log.Logger, reg prometheus.Registerer, procfs procfs.FS, ci
 			if err != nil {
 				return nil, fmt.Errorf("failed to get executable path for PID %d: %w", pid, err)
 			}
+
+			path = fmt.Sprintf("/proc/%d/root%s", pid, path)
 			if cachedLabels, ok := cache.Get(path); ok {
 				return cachedLabels, nil
 			}


### PR DESCRIPTION
Previously often saw log lines like:

```
level=debug name=parca-agent ts=2023-11-29T12:43:06.00844425Z caller=manager.go:138 component=labels_manager msg="failed to get metadata" provider=compiler err="failed to get compiler info for /usr/local/bin/node: failed to open ELF file /usr/local/bin/node: error opening /usr/local/bin/node: open /usr/local/bin/node: no such file or directory"
```