### PR TITLE
profiler: Fix error handling

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -549,7 +549,7 @@ func (p *CPU) addUnwindTableForProcess(ctx context.Context, pid int) {
 	}
 
 	level.Debug(p.logger).Log("msg", "adding unwind tables", "pid", pid)
-	if err := p.bpfMaps.AddUnwindTableForProcess(pid, nil, true); err == nil {
+	if err = p.bpfMaps.AddUnwindTableForProcess(pid, nil, true); err == nil {
 		// Happy path.
 		return
 	}


### PR DESCRIPTION
The err variable was clobbered so we were reading the wrong value

Test Plan
========

```
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1140,6 +1140,7 @@ func (m *Maps) AddUnwindTableForProcess(pid int, executableMappings unwind.Execu
        // is challenging if the process name contains spaces, etc).
        //  - PIDs can be recycled.

+       return fmt.Errorf("le error")
        m.mutex.Lock()
        defer m.mutex.Unlock()
```

Before:
```
msg="failed to add unwind table" pid=18846 err=null
```

After:
```
msg="failed to add unwind table" pid=18846 err="le err"
```