### PR TITLE
Add event metrics

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -130,6 +130,10 @@ struct unwinder_stats_t {
   u64 success_dwarf_to_jit;
   u64 success_dwarf_reach_bottom;
   u64 success_jit_reach_bottom;
+
+  u64 event_request_unwind_information;
+  u64 event_request_process_mappings;
+  u64 event_request_refresh_process_info;
 };
 
 const volatile struct unwinder_config_t unwinder_config = {};
@@ -273,6 +277,10 @@ DEFINE_COUNTER(success_dwarf_to_jit);
 DEFINE_COUNTER(success_dwarf_reach_bottom);
 DEFINE_COUNTER(success_jit_reach_bottom);
 
+DEFINE_COUNTER(event_request_unwind_information);
+DEFINE_COUNTER(event_request_process_mappings);
+DEFINE_COUNTER(event_request_refresh_process_info);
+
 static void unwind_print_stats() {
   // Do not use the LOG macro, always print the stats.
   u32 zero = 0;
@@ -339,6 +347,8 @@ static __always_inline void request_unwind_information(struct bpf_perf_event_dat
   if(event_rate_limited(payload, unwinder_config.rate_limit_unwind_info)) {
     return;
   }
+
+  bump_unwind_event_request_unwind_information();
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &payload, sizeof(u64));
 }
 
@@ -347,6 +357,7 @@ static __always_inline void request_process_mappings(struct bpf_perf_event_data 
   if(event_rate_limited(payload, unwinder_config.rate_limit_process_mappings)) {
     return;
   }
+  bump_unwind_event_request_process_mappings();
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &payload, sizeof(u64));
 }
 
@@ -355,6 +366,7 @@ static __always_inline void request_refresh_process_info(struct bpf_perf_event_d
   if(event_rate_limited(payload, unwinder_config.rate_limit_process_mappings)) {
     return;
   }
+  bump_unwind_event_request_refresh_process_info();
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &payload, sizeof(u64));
 }
 

--- a/pkg/profiler/cpu/bpf/metrics/collector.go
+++ b/pkg/profiler/cpu/bpf/metrics/collector.go
@@ -46,6 +46,10 @@ type unwinderStats struct {
 	SuccessDWARFToJIT           uint64
 	SuccessDWARFReachBottom     uint64
 	SuccessJITReachBottom       uint64
+
+	EventRequestUnwindInformation  uint64
+	EventRequestProcessMappings    uint64
+	EventRequestRefreshProcessInfo uint64
 }
 
 type bpfMetrics struct {
@@ -174,6 +178,10 @@ func (c *Collector) collectUnwinderStatistics(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.SuccessDWARFToJIT), "dwarf_to_jit")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.SuccessDWARFReachBottom), "dwarf_reach_bottom")
 	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.SuccessJITReachBottom), "jit_reach_bottom")
+
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.EventRequestUnwindInformation), "event_request_unwind_info")
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.EventRequestProcessMappings), "event_request_process_mappings")
+	ch <- prometheus.MustNewConstMetric(descNativeUnwinderSuccess, prometheus.CounterValue, float64(stats.EventRequestRefreshProcessInfo), "event_request_refresh_process_info")
 }
 
 func (c *Collector) getBPFMetrics() []*bpfMetrics {
@@ -274,6 +282,10 @@ func (c *Collector) readCounters() (unwinderStats, error) {
 		total.SuccessDWARFToJIT += partial.SuccessDWARFToJIT
 		total.SuccessDWARFReachBottom += partial.SuccessDWARFReachBottom
 		total.SuccessJITReachBottom += partial.SuccessJITReachBottom
+
+		total.EventRequestUnwindInformation += partial.EventRequestUnwindInformation
+		total.EventRequestProcessMappings += partial.EventRequestProcessMappings
+		total.EventRequestRefreshProcessInfo += partial.EventRequestRefreshProcessInfo
 	}
 
 	return total, nil


### PR DESCRIPTION
Test Plan
=========

```
[javierhonduco@fedora parca-agent]$ curl --silent http://localhost:7071/metrics | grep event_request
parca_agent_native_unwinder_success_total{unwinder="event_request_process_mappings"} 143
parca_agent_native_unwinder_success_total{unwinder="event_request_refresh_process_info"} 0
parca_agent_native_unwinder_success_total{unwinder="event_request_unwind_info"} 4
```
