### PR TITLE
ci(container): disable gloud auth on PRs

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -218,7 +218,8 @@ jobs:
         uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 # v3.2.0
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69' # v1
+        if: github.event_name != 'pull_request'
+        uses: 'google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69' # v1.3.0
         id: 'auth'
         with:
           token_format: "access_token" # this is important as it will generate the token to be used as an oauth2 token for the next step


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->

```
Error: google-github-actions/auth failed with: retry function failed after 4 attempts: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
```

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->

### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan
<!-- How did you test it? How can we test it? -->
