### PR TITLE
pkg/objectfile: Use mount namespace id in cache key instead of build id

### DIFF
--- a/pkg/objectfile/object_file.go
+++ b/pkg/objectfile/object_file.go
@@ -39,6 +39,8 @@ type ObjectFile struct {
 	Modtime  time.Time
 	openedAt time.Time
 
+	mountNamespaceID string
+
 	// ELF file is read using ReaderAt,
 	// which means concurrent reads are allowed.
 	elf *elf.File


### PR DESCRIPTION
In the worst case, determining the build id can be very expensive, as we need to hash the .text section. Determining the mount namespace id is significantly cheaper and with mount namespace id, modtime and path we still have a key that is highly stable for the properties that we need it for.

### Why?

We have been seeing a lot of text section hashing in CPU profiling data of the agent in customer environments.

### What?

Use a cheaper to determine cache key.

### How?

Instead of requiring to determine the build id of an object file for its cache key, we use the combination of the processes' mount namespace id, path and mod time.

### Test Plan

Old and new unit tests passing and ran for a bit while performing some high process churn loops in bash.