### PR TITLE
Decrease upper number of unwind shards

### DIFF
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -79,7 +79,7 @@ const (
 
 	// With the current compact rows, the max items we can store in the kernels
 	// we have tested is 262k per map, which we rounded it down to 250k.
-	MaxUnwindShards       = 50         // How many unwind table shards we have.
+	MaxUnwindShards       = 30         // How many unwind table shards we have.
 	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in the BPF program.
 	maxMappingsPerProcess = 250        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
 	maxUnwindTableChunks  = 30         // Always need to be in sync with MAX_UNWIND_TABLE_CHUNKS.


### PR DESCRIPTION
Decrease upper number of unwind shards from 50 to 30, saving 70 MB from the locked kernel memory in BPF maps.

We don't need as many shards as we now remove redundant unwind information. After running many tests we've realised that the number was too high, most of the time we don't need a number this high.

See https://github.com/parca-dev/parca-agent/pull/2081.

If needed, in the future, we could make value customisable

Test Plan
=========

**Before**

```
parca_agent_bpf_map_max_entries{bpf_map_name="unwind_tables"} 50
parca_agent_bpf_map_memlock{bpf_map_name="unwind_tables"} 2.17005808e+08 <= 217 MB
parca_agent_bpf_map_value_size{bpf_map_name="unwind_tables"} 3.5e+06
```

**After**

```
parca_agent_bpf_map_max_entries{bpf_map_name="unwind_tables"} 30
parca_agent_bpf_map_memlock{bpf_map_name="unwind_tables"} 1.47004176e+08 <= 147 MB
parca_agent_bpf_map_value_size{bpf_map_name="unwind_tables"} 3.5e+06
```