### PR TITLE
unwinder/native: Increase size of mappings

### DIFF
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -81,7 +81,7 @@ const (
 	// we have tested is 262k per map, which we rounded it down to 250k.
 	MaxUnwindShards       = 30         // How many unwind table shards we have.
 	maxUnwindTableSize    = 250 * 1000 // Always needs to be sync with MAX_UNWIND_TABLE_SIZE in the BPF program.
-	maxMappingsPerProcess = 250        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
+	maxMappingsPerProcess = 400        // Always need to be in sync with MAX_MAPPINGS_PER_PROCESS.
 	maxUnwindTableChunks  = 30         // Always need to be in sync with MAX_UNWIND_TABLE_CHUNKS.
 	maxProcesses          = 5000       // Always need to be in sync with MAX_PROCESSES.
 

--- a/pkg/stack/unwind/maps.go
+++ b/pkg/stack/unwind/maps.go
@@ -18,6 +18,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"hash/maphash"
+	"sort"
 	"strings"
 
 	"github.com/prometheus/procfs"
@@ -159,6 +160,12 @@ func ListExecutableMappings(rawMappings []*procfs.ProcMap) ExecutableMappings {
 			firstSeen = true
 		}
 	}
+
+	// Should be sorted but let's ensure this is the case as we want to binary search over
+	// this in the unwinder.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].LoadAddr < result[j].LoadAddr
+	})
 
 	return result
 }


### PR DESCRIPTION
This commit increases the maximum mappings a process without FP can have. This limitation affected a small number of users, but it was still a blocker for some.

Additionally, rather than a linear search, we switch to using binary search on the mappings as otherwise it's too many instructions for the BPF verifier to check.

Test Plan
=========

```
=== RUN   TestCPUProfilerWorks/mixed_mode_unwinding
=== RUN   TestCPUProfilerWorks/unwinder_metrics_work
--- PASS: TestCPUProfilerWorks (20.79s)
    --- PASS: TestCPUProfilerWorks/dwarf_unwinding (0.08s)
    --- PASS: TestCPUProfilerWorks/fp_unwinding (0.67s)
    --- PASS: TestCPUProfilerWorks/mixed_mode_unwinding (0.04s)
    --- PASS: TestCPUProfilerWorks/unwinder_metrics_work (0.00s)
PASS
ok      github.com/parca-dev/parca-agent/test/integration       20.810s
```

and kernel tests pass
