### PR TITLE
Disable sending analytics report by default

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -691,7 +691,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags) error {
 		})
 	}
 
-	if !flags.AnalyticsOptOut {
+	if flags.AnalyticsOptOut {
 		logger := log.With(logger, "group", "analytics")
 		c := analytics.NewClient(
 			tp,


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->
As in https://github.com/parca-dev/parca-agent/issues/2382 , We need people's consent to collect their analytic info like machines.

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->
change check logic
### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan
<!-- How did you test it? How can we test it? -->
