### PR TITLE
New Build Pipeline: Use Zig as compiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "github.com/parca-dev/testdata"]
 	path = test/testdata
 	url = https://github.com/parca-dev/testdata
+[submodule "3rdparty/libelf"]
+	path = 3rdparty/libelf
+	url = https://github.com/arachsys/libelf.git

--- a/devbox.json
+++ b/devbox.json
@@ -12,17 +12,15 @@
     "gettext@0.21.1",
     "automake@1.16.5",
     "libtool@2.4.7",
-    "elfutils@0.189",
-    "glibc.dev",
-    "glibc.static",
     "llvmPackages_14.stdenv@latest",
     "llvmPackages_14.bintools@latest",
-    "llvmPackages_14.lld@latest"
+    "llvmPackages_14.lld@latest",
+    "github:mitchellh/zig-overlay#master"
   ],
   "env": {
-    "CC": "clang",
-    "CXX": "clang++",
-    "LD": "lld",
+    "CC": "zig cc -target `uname -m`-linux-musl",
+    "CXX": "zig c++ -target `uname -m`-linux-musl",
+    "LD": "ld.lld",
     "GOROOT": "${PWD}/.devbox/nix/profile/default/share/go",
     "GOPATH": "${PWD}/.devbox/go",
     "GOBIN": "${PWD}/.devbox/go/bin"

--- a/devbox.lock
+++ b/devbox.lock
@@ -81,20 +81,6 @@
         }
       }
     },
-    "elfutils@0.189": {
-      "last_modified": "2023-11-15T19:29:39Z",
-      "resolved": "github:NixOS/nixpkgs/61202fc8677a6e9e0a82eb6610eeef28852fc790#elfutils",
-      "source": "devbox-search",
-      "version": "0.189",
-      "systems": {
-        "aarch64-linux": {
-          "store_path": "/nix/store/0sl1y6xfi59ibf0q3v14327hshmmbw0i-elfutils-0.189-bin"
-        },
-        "x86_64-linux": {
-          "store_path": "/nix/store/j6c8jnz1fq1a2szc2md5g4mfkrgnwbqk-elfutils-0.189-bin"
-        }
-      }
-    },
     "gettext@0.21.1": {
       "last_modified": "2023-12-31T07:44:09Z",
       "resolved": "github:NixOS/nixpkgs/d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7#gettext",
@@ -114,14 +100,6 @@
           "store_path": "/nix/store/f0m95a8gfkwgijbiscbkn7f3ra6ha70x-gettext-0.21.1"
         }
       }
-    },
-    "glibc.dev": {
-      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#glibc.dev",
-      "source": "nixpkg"
-    },
-    "glibc.static": {
-      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#glibc.static",
-      "source": "nixpkg"
     },
     "go@1.21.4": {
       "last_modified": "2023-11-17T14:14:56Z",


### PR DESCRIPTION
This PR compiles dependencies, using [Zig Build System](https://ziglang.org/learn/build-system).

As of now, it doesn't address cross-compilation concerns.

- It uses `musl` and statically links everything. 
- It reduces build time dependecies.