### PR TITLE
unwinder/native: Per code region unwinder selection 

### DIFF
--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -23,7 +23,8 @@ typedef struct {
     u64 bp;
     u32 tail_calls;
     stack_trace_t stack;
-    bool unwinding_jit; // set to true during JITed unwinding; false unless mixed-mode unwinding is enabled
+    bool unwinding_jit;
+    bool use_fp;
 
     u64 interpreter_type;
     stack_count_key_t stack_key;

--- a/pkg/profiler/cpu/bpf/programs/programs.go
+++ b/pkg/profiler/cpu/bpf/programs/programs.go
@@ -38,8 +38,8 @@ var (
 	// python programs.
 	PythonUnwinderProgramFD = uint64(0)
 
-	ProgramName              = "entrypoint"
-	DWARFUnwinderProgramName = "unwind_with_dwarf_info"
+	ProgramName               = "entrypoint"
+	NativeUnwinderProgramName = "native_unwind"
 )
 
 type CombinedStack [tripleStackDepth]uint64

--- a/pkg/stack/unwind/compact_unwind_table.go
+++ b/pkg/stack/unwind/compact_unwind_table.go
@@ -23,7 +23,7 @@ import (
 	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
 )
 
-type BpfCfaType uint16
+type BpfCfaType uint8
 
 // Constants are just to denote the rule type of calculation we do
 // i.e whether we should compute based on rbp or rsp.
@@ -291,6 +291,6 @@ func GenerateCompactUnwindTable(fullExecutablePath string) (CompactUnwindTable, 
 	// any improvements. See benchmark in the test file.
 	sort.Sort(ut)
 
-	// Remove redundant rows in place.
+	// Remove redundant rows.
 	return ut.RemoveRedundant(), arch, nil
 }


### PR DESCRIPTION
Before this commit we either used frame pointers or DWARF-derived unwind
information to unwind a process. We first attempt to unwind using frame
pointers and if it looks like it worked (we can't be sure about this,
see comments for more details) we aggregate the sample, otherwise we ask
userspace to write unwind information, if present. We have to exceptions
for this case, we never generated unwind info for v8-based apps [0] nor
for Go-based apps [1].

This commit enables per code region switching of unwinders, what this
means in practice is that it will allow us to unwind Go or V8
applications, that should have frame pointers in the majority of their
code using the FP unwinder, but switch to the DWARF-derived unwinder for
part of the code that do not have them, such as for native libraries
written in C or C++ that were compiled without them. Our agent is a good
example of this as we rely on CGO with a bunch of libraries that can be
compiled without FPs.

Additionally, this work also adds support for unwinding interpreters
whose native code sections contain FPs.

- [0]: https://www.polarsignals.com/blog/posts/2023/07/12/correctly-profiling-node-js-with-zero-instrumentation
- [1]: Go has FP enabled by default

Test Plan
=========

Tested on the Agent, CI is clean,

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>