### PR TITLE
Add counter metric for total bytes sent to remote store

### DIFF
--- a/pkg/agent/batch_remote_write_client.go
+++ b/pkg/agent/batch_remote_write_client.go
@@ -31,6 +31,7 @@ import (
 type metrics struct {
 	writeRawRetries            prometheus.Counter
 	writeRawWithRetriesLatency prometheus.Histogram
+	writeRawBytes              prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -47,6 +48,10 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Help:                        "Histogram of overall latency when sending WriteRaw gRPC request with retries",
 			NativeHistogramBucketFactor: 1.1,
 		})
+	m.writeRawBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "parca_agent_batch_writer_bytes_total",
+		Help: "The amount of bytes sent by the batch writer",
+	})
 
 	return &m
 }
@@ -138,6 +143,14 @@ func (b *BatchWriteClient) batch(ctx context.Context) error {
 
 	if len(batch) > 0 {
 		level.Debug(b.logger).Log("msg", "batch write client sent profiles", "count", len(batch))
+
+		batchBytes := 0
+		for _, series := range batch {
+			for _, sample := range series.GetSamples() {
+				batchBytes += len(sample.RawProfile)
+			}
+		}
+		b.metrics.writeRawBytes.Add(float64(batchBytes))
 	}
 	return nil
 }

--- a/pkg/agent/batch_remote_write_client.go
+++ b/pkg/agent/batch_remote_write_client.go
@@ -147,7 +147,7 @@ func (b *BatchWriteClient) batch(ctx context.Context) error {
 		batchBytes := 0
 		for _, series := range batch {
 			for _, sample := range series.GetSamples() {
-				batchBytes += len(sample.RawProfile)
+				batchBytes += len(sample.GetRawProfile())
 			}
 		}
 		b.metrics.writeRawBytes.Add(float64(batchBytes))


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->

This metric helps to figure out how much each agent is sending in raw profile bytes to the remote store across an entire fleet of agents. 

### What?

Adding a Prometheus counter.

### How?

For each successfully sent batch we sum up all the bytes of raw profiles and add it to the `parca_agent_batch_writer_bytes_total` counter. 
It allows for queries to figure out how many bytes each agent sends with a query like:
```
sum by(pod) (rate(parca_agent_batch_writer_bytes_total{job="parca-agent"}[5m]))
```

We do the same in our cloud backend.

### Test Plan
<!-- How did you test it? How can we test it? -->

Run the agent and check out the metric via Prometheus. 