### PR TITLE
fix: bpf struct sizes fixes

### DIFF
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -102,7 +102,7 @@ const (
 			mapping_t mappings[MAX_MAPPINGS_PER_PROCESS];
 		} process_info_t;
 	*/
-	mappingInfoSizeBytes = 8 + 8 + (maxMappingsPerProcess * 8 * 5)
+	mappingInfoSizeBytes = 8*4 + (maxMappingsPerProcess * 8 * 5)
 	/*
 		TODO: once we generate the bindings automatically, remove this.
 
@@ -440,7 +440,7 @@ func (m *Maps) setRbperfProcessData(pid int, procData rbperf.ProcessData) error 
 	}
 
 	buf := new(bytes.Buffer)
-	buf.Grow(int(unsafe.Sizeof(&procData)))
+	buf.Grow(int(unsafe.Sizeof(procData)))
 
 	err = binary.Write(buf, binary.LittleEndian, &procData)
 	if err != nil {
@@ -472,7 +472,7 @@ func (m *Maps) setRbperfVersionOffsets(versionOffsets []ruby.VersionOffsets) err
 	buf := new(bytes.Buffer)
 	i := uint32(0)
 	for _, versionOffset := range versionOffsets {
-		buf.Grow(int(unsafe.Sizeof(&versionOffset)))
+		buf.Grow(int(unsafe.Sizeof(versionOffset)))
 
 		err = binary.Write(buf, binary.LittleEndian, &versionOffset)
 		if err != nil {
@@ -503,7 +503,7 @@ func (m *Maps) setPyperfIntepreterInfo(pid int, interpInfo pyperf.InterpreterInf
 	}
 
 	buf := new(bytes.Buffer)
-	buf.Grow(int(unsafe.Sizeof(&interpInfo)))
+	buf.Grow(int(unsafe.Sizeof(interpInfo)))
 
 	err = binary.Write(buf, binary.LittleEndian, &interpInfo)
 	if err != nil {
@@ -534,7 +534,7 @@ func (m *Maps) setPyperfVersionOffsets(versionOffsets []python.VersionOffsets) e
 	buf := new(bytes.Buffer)
 	i := uint32(0)
 	for _, v := range versionOffsets {
-		buf.Grow(int(unsafe.Sizeof(&v)))
+		buf.Grow(int(unsafe.Sizeof(v)))
 		err = binary.Write(buf, binary.LittleEndian, &v)
 		if err != nil {
 			level.Debug(m.logger).Log("msg", "write versionOffsets to buffer", "err", err)

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -97,7 +97,9 @@ const (
 		} mapping_t;
 
 		typedef struct {
+			u64 should_use_fp_by_default;
 			u64 is_jit_compiler;
+			u64 interpreter_type;
 			u64 len;
 			mapping_t mappings[MAX_MAPPINGS_PER_PROCESS];
 		} process_info_t;

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -802,7 +802,6 @@ func (p *CPU) Run(ctx context.Context) error {
 		// it[2].
 		// [1]: https://github.com/aquasecurity/libbpfgo/blob/64458ba5a32013dda2d4f88838dde8456922333d/libbpfgo.go#L240
 		// [2]: https://github.com/aquasecurity/libbpfgo/blob/64458ba5a32013dda2d4f88838dde8456922333d/libbpfgo.go#L420
-
 		if err != nil {
 			return fmt.Errorf("attach perf event: %w", err)
 		}


### PR DESCRIPTION
### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->
1. I noticed `mappingInfoSizeBytes` is off by `0x10` which may lead to reading little bit of garbage out of bounds of the allocation.
2. Buffer growing in various places seems incorrect - it should not take pointers
https://go.dev/play/p/wSGZw-SAocA

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->

### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan
<!-- How did you test it? How can we test it? -->
