### PR TITLE
Add metrics to track number and type of bpf program early exits

### DIFF
--- a/pkg/profiler/cpu/bpf/metrics/collector.go
+++ b/pkg/profiler/cpu/bpf/metrics/collector.go
@@ -342,7 +342,6 @@ func (c *Collector) readCounters() (unwinderStats, error) {
 		total.TotalZeroPids += partial.TotalZeroPids
 		total.TotalKthreads += partial.TotalKthreads
 		total.TotalFilterMisses += partial.TotalFilterMisses
-
 	}
 
 	return total, nil


### PR DESCRIPTION
Trying to understand why a busy computer isn't generating many samples
