### PR TITLE
Use OS num CPUs instead of runtime schedulable ones

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/pyroscope-io/jfr-parser v0.7.1
 	github.com/rzajac/flexbuf v0.14.0
 	github.com/stretchr/testify v1.8.4
+	github.com/tklauser/numcpus v0.7.0
 	github.com/xyproto/ainur v1.3.3
 	github.com/zcalusic/sysinfo v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -580,6 +580,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.45 h1:5/ZGOv846tP6+2X7w//8QjLgH2KcUK+Hc
 github.com/tencentyun/cos-go-sdk-v5 v0.7.45/go.mod h1:DH9US8nB+AJXqwu/AMOrCFN1COv3dpytXuJWHgdg7kE=
 github.com/thanos-io/objstore v0.0.0-20231112185854-37752ee64d98 h1:gx2MTto1UQRumGoJzY3aFPQ31Ov3nOV7NaD7j6q288k=
 github.com/thanos-io/objstore v0.0.0-20231112185854-37752ee64d98/go.mod h1:JauBAcJ61tRSv9widgISVmA6akQXDeUMXBrVmWW4xog=
+github.com/tklauser/numcpus v0.7.0 h1:yjuerZP127QG9m5Zh/mSO4wqurYil27tHrqwRoRjpr4=
+github.com/tklauser/numcpus v0.7.0/go.mod h1:bb6dMVcj8A42tSE7i32fsIUCbQNllK5iDguyOZRUzAY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xyproto/ainur v1.3.3 h1:DjbkZg7iNblH1abwfIQG2siI0z3LOyVuWEmCq2S9GKc=

--- a/pkg/cpuinfo/cpu.go
+++ b/pkg/cpuinfo/cpu.go
@@ -13,8 +13,8 @@
 
 package cpuinfo
 
-import "runtime"
+import "github.com/tklauser/numcpus"
 
-func NumCPU() int {
-	return runtime.NumCPU()
+func NumCPU() (int, error) {
+	return numcpus.GetPresent()
 }

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -764,7 +764,10 @@ func (p *CPU) Run(ctx context.Context) error {
 	// By default we sample at 19Hz (19 times per second),
 	// which is every ~0.05s or 52,631,578 nanoseconds (1 Hz = 1e9 ns).
 	samplingPeriod := int64(1e9 / p.config.ProfilingSamplingFrequency)
-	cpus := cpuinfo.NumCPU()
+	cpus, err := cpuinfo.NumCPU()
+	if err != nil {
+		return fmt.Errorf("get number of CPUs: %w", err)
+	}
 
 	level.Debug(p.logger).Log("msg", "attaching perf event to all CPUs")
 	for i := 0; i < cpus; i++ {


### PR DESCRIPTION
### Why?

`runtime.NumCPU()` does not report the present/available CPUs it reports the schedulable ones.

### What?

Read available CPUs from sysfs.

### How?

Using the [`numcpus`](https://github.com/tklauser/numcpus) package.

### Test Plan

Tested locally and it works, and added a metric to report the detected number as well.
