### PR TITLE
pkg/analytics: Add support for report arbitrary metrics

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -725,6 +725,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 			numCPU,
 			version,
 			si,
+			reg,
 			!isRootPIDNamespace,
 		)
 		ctx, cancel := context.WithCancel(ctx)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -142,7 +142,7 @@ func (s *AnalyticsSender) Run(ctx context.Context) {
 						"parca_agent_bpf_program_miss_kthreads_total",
 						"parca_agent_bpf_program_miss_zero_pid_total",
 						"parca_agent_bpf_program_runs_total":
-						addCounterVec(wreq, metric.GetName(), s.machineID, now, metric.Metric)
+						addCounterVec(wreq, metric.GetName(), s.machineID, now, metric.GetMetric())
 					}
 				}
 			}
@@ -164,7 +164,7 @@ func addCounterVec(wreq *prometheuspb.WriteRequest, name, machineID string, now 
 				Value: pair.GetValue(),
 			})
 		}
-		wreq.Timeseries = append(wreq.Timeseries, &prometheuspb.TimeSeries{
+		wreq.Timeseries = append(wreq.GetTimeseries(), &prometheuspb.TimeSeries{
 			Labels: labels,
 			Samples: []*prometheuspb.Sample{{
 				Value:     m.GetCounter().GetValue(),


### PR DESCRIPTION
This should be super helpful when looking at the overall performance of the parca-agent across various environments and sizes.

The first set of metrics is still up for discussion.
