### PR TITLE
Add initial Ruby ARM64 support

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   pre-commit:
+    name: pre-commit checks
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -1,0 +1,97 @@
+name: Integration Tests on AMD64
+
+on:
+  workflow_call:
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  skip-check:
+    name: Skip check
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip-check.outputs.should_skip }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - id: skip-check
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        with:
+          do_not_skip: '["schedule", "workflow_dispatch"]'
+          paths: |-
+            [
+              "**_test.go",
+              ".github/workflows/test.yml",
+              ".go-version",
+              "3rdparty",
+              "Makefile",
+              "bpf/**",
+              "go.mod",
+              "go.sum",
+              "kerneltest/**",
+              "testdata/**",
+              "test/**"
+            ]
+          skip_after_successful_duplicate: false
+
+  integration-tests:
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: .go-version
+
+      - name: Set up Clang
+        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        with:
+          version: "14"
+
+      - name: Install libbpf dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -yq libelf-dev zlib1g-dev
+
+      - name: Initialize and update git submodules
+        run: git submodule init && git submodule update
+
+      - name: Install Go dependencies
+        run: make go/deps
+
+      - name: Build libbpf
+        run: make libbpf
+
+      - name: Build BPF
+        run: make bpf
+
+      - name: Cache Docker images for testcontainers
+        uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('test/integration/*') }}
+
+      - name: Integration Tests (Native)
+        run: make GO=`which go` test/integration/native
+
+      - name: Integration Tests (Python)
+        run: make GO=`which go` test/integration/python
+
+      - name: Integration Tests (Ruby)
+        run: make GO=`which go` test/integration/ruby

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -48,8 +48,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests on AMD64
-    # runs-on: nscloud-ubuntu-22.04-amd64-4x16
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -87,9 +87,11 @@ jobs:
           key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
       - name: Integration Tests (Native)
+        continue-on-error: true
         run: make GO=`which go` test/integration/native
 
       - name: Integration Tests (Python)
+        continue-on-error: true
         run: make GO=`which go` test/integration/python
 
       - name: Integration Tests (Ruby)

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -21,7 +21,7 @@ jobs:
   skip-check:
     name: Skip check
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
     outputs:
       should_skip: ${{ steps.skip-check.outputs.should_skip }}
     permissions:
@@ -34,21 +34,20 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-              "**_test.go",
-              ".github/workflows/test.yml",
+              ".github/workflows/test-integration-arm64.yml",
+              "test/integration/**",
+              "*.go",
               ".go-version",
               "3rdparty",
               "Makefile",
               "bpf/**",
               "go.mod",
-              "go.sum",
-              "kerneltest/**",
-              "testdata/**",
-              "test/**"
+              "go.sum"
             ]
           skip_after_successful_duplicate: false
 
   integration-tests:
+    name: Integration Tests on AMD64
     runs-on: nscloud-ubuntu-22.04-amd64-4x16
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
@@ -68,7 +67,7 @@ jobs:
       - name: Install libbpf dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -yq libelf-dev zlib1g-dev
+          sudo apt-get install -yq libelf-dev zlib1g-dev libzstd-dev
 
       - name: Initialize and update git submodules
         run: git submodule init && git submodule update
@@ -85,7 +84,7 @@ jobs:
       - name: Cache Docker images for testcontainers
         uses: ScribeMD/docker-cache@0.3.7
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('test/integration/*') }}
+          key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
       - name: Integration Tests (Native)
         run: make GO=`which go` test/integration/native

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -59,7 +59,9 @@ jobs:
         run: uname -a
 
       - name: Kernel Config
-        run: zcat /proc/config.gz | grep -i BPF
+        run: |
+          if [ -f /boot/config-$(uname -r) ]; then cat /boot/config-$(uname -r); fi
+          if [ -f /proc/config.gz ]; then zcat /proc/config.gz; fi
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -87,12 +87,12 @@ jobs:
           key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
       - name: Integration Tests (Native)
-        continue-on-error: true
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 
       - name: Integration Tests (Python)
-        continue-on-error: true
+        if: ${{ always() }}
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
 
       - name: Integration Tests (Ruby)
+        if: ${{ always() }}
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -88,9 +88,6 @@ jobs:
       - name: Build BPF
         run: make bpf
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Cache Docker images for testcontainers
         uses: ScribeMD/docker-cache@0.3.7
         with:

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -88,11 +88,11 @@ jobs:
 
       - name: Integration Tests (Native)
         continue-on-error: true
-        run: make GO=`which go` test/integration/native
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 
       - name: Integration Tests (Python)
         continue-on-error: true
-        run: make GO=`which go` test/integration/python
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
 
       - name: Integration Tests (Ruby)
-        run: make GO=`which go` test/integration/ruby
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Kernel Version
         run: uname -a
 
+      - name: Kernel Config
+        run: zcat /proc/config.gz | grep -i BPF
+
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -48,7 +48,8 @@ jobs:
 
   integration-tests:
     name: Integration Tests on AMD64
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    # runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -48,8 +48,8 @@ jobs:
 
   integration-tests:
     name: Integration Tests on AMD64
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
-    # runs-on: ubuntu-latest
+    # runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Kernel Version
+        run: uname -a
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
@@ -84,6 +84,9 @@ jobs:
 
       - name: Build BPF
         run: make bpf
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Cache Docker images for testcontainers
         uses: ScribeMD/docker-cache@0.3.7

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -48,8 +48,8 @@ jobs:
 
   integration-tests:
     name: Integration Tests on AMD64
-    # runs-on: nscloud-ubuntu-22.04-amd64-4x16
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    # runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code

--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Integration Tests on ARM64
 
 on:
   workflow_call:
@@ -49,7 +49,7 @@ jobs:
           skip_after_successful_duplicate: false
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-arm64-4x16
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Kernel Version
+        run: uname -a
+
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -21,7 +21,7 @@ jobs:
   skip-check:
     name: Skip check
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
     outputs:
       should_skip: ${{ steps.skip-check.outputs.should_skip }}
     permissions:
@@ -34,21 +34,20 @@ jobs:
           do_not_skip: '["schedule", "workflow_dispatch"]'
           paths: |-
             [
-              "**_test.go",
-              ".github/workflows/test.yml",
+              ".github/workflows/test-integration-arm64.yml",
+              "test/integration/**",
+              "*.go",
               ".go-version",
               "3rdparty",
               "Makefile",
               "bpf/**",
               "go.mod",
-              "go.sum",
-              "kerneltest/**",
-              "testdata/**",
-              "test/**"
+              "go.sum"
             ]
           skip_after_successful_duplicate: false
 
   integration-tests:
+    name: Integration Tests on ARM64
     runs-on: nscloud-ubuntu-22.04-arm64-4x16
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
@@ -61,14 +60,21 @@ jobs:
           go-version-file: .go-version
 
       - name: Set up Clang
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
-        with:
-          version: "14"
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y llvm-14 clang-14 lld-14
+          sudo ln -s /usr/bin/clang-14 /usr/bin/clang
+          sudo ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld
+          sudo ln -s /usr/bin/llc-14 /usr/bin/llc
+
+      - run: |
+          clang --version
+          ld.lld --version
 
       - name: Install libbpf dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -yq libelf-dev zlib1g-dev
+          sudo apt-get install -yq libelf-dev zlib1g-dev libzstd-dev
 
       - name: Initialize and update git submodules
         run: git submodule init && git submodule update
@@ -85,7 +91,7 @@ jobs:
       - name: Cache Docker images for testcontainers
         uses: ScribeMD/docker-cache@0.3.7
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('test/integration/*') }}
+          key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
       - name: Integration Tests (Native)
         run: make GO=`which go` test/integration/native

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -94,12 +94,12 @@ jobs:
           key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
       - name: Integration Tests (Native)
-        continue-on-error: true
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 
       - name: Integration Tests (Python)
-        continue-on-error: true
+        if: ${{ always() }}
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
 
       - name: Integration Tests (Ruby)
+        if: ${{ always() }}
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -54,58 +54,62 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Kernel Version
-        run: uname -a
+      - name: Skip tests (temporary)
+        run: echo "Skipping tests on ARM64 temporarily"
+        continue-on-error: true
 
-      - name: Kernel Config
-        run: zcat /proc/config.gz | grep -i BPF
+      # - name: Kernel Version
+      #   run: uname -a
 
-      - name: Set up Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: .go-version
+      # - name: Kernel Config
+      #   run: zcat /proc/config.gz | grep -i BPF
 
-      - name: Set up Clang
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y llvm-14 clang-14 lld-14
-          sudo ln -s /usr/bin/clang-14 /usr/bin/clang
-          sudo ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld
-          sudo ln -s /usr/bin/llc-14 /usr/bin/llc
+      # - name: Set up Go
+      #   uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      #   with:
+      #     go-version-file: .go-version
 
-      - run: |
-          clang --version
-          ld.lld --version
+      # - name: Set up Clang
+      #   run: |
+      #     sudo apt-get update -y
+      #     sudo apt-get install -y llvm-14 clang-14 lld-14
+      #     sudo ln -s /usr/bin/clang-14 /usr/bin/clang
+      #     sudo ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld
+      #     sudo ln -s /usr/bin/llc-14 /usr/bin/llc
 
-      - name: Install libbpf dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -yq libelf-dev zlib1g-dev libzstd-dev
+      # - run: |
+      #     clang --version
+      #     ld.lld --version
 
-      - name: Initialize and update git submodules
-        run: git submodule init && git submodule update
+      # - name: Install libbpf dependencies
+      #   run: |
+      #     sudo apt-get update -y
+      #     sudo apt-get install -yq libelf-dev zlib1g-dev libzstd-dev
 
-      - name: Install Go dependencies
-        run: make go/deps
+      # - name: Initialize and update git submodules
+      #   run: git submodule init && git submodule update
 
-      - name: Build libbpf
-        run: make libbpf
+      # - name: Install Go dependencies
+      #   run: make go/deps
 
-      - name: Build BPF
-        run: make bpf
+      # - name: Build libbpf
+      #   run: make libbpf
 
-      - name: Cache Docker images for testcontainers
-        uses: ScribeMD/docker-cache@0.3.7
-        with:
-          key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
+      # - name: Build BPF
+      #   run: make bpf
 
-      - name: Integration Tests (Native)
-        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
+      # - name: Cache Docker images for testcontainers
+      #   uses: ScribeMD/docker-cache@0.3.7
+      #   with:
+      #     key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
-      - name: Integration Tests (Python)
-        if: ${{ always() }}
-        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
+      # - name: Integration Tests (Native)
+      #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 
-      - name: Integration Tests (Ruby)
-        if: ${{ always() }}
-        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby
+      # - name: Integration Tests (Python)
+      #   if: ${{ always() }}
+      #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
+
+      # - name: Integration Tests (Ruby)
+      #   if: ${{ always() }}
+      #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Kernel Version
         run: uname -a
 
+      - name: Kernel Config
+        run: zcat /proc/config.gz | grep -i BPF
+
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -94,9 +94,11 @@ jobs:
           key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
 
       - name: Integration Tests (Native)
+        continue-on-error: true
         run: make GO=`which go` test/integration/native
 
       - name: Integration Tests (Python)
+        continue-on-error: true
         run: make GO=`which go` test/integration/python
 
       - name: Integration Tests (Ruby)

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -54,15 +54,17 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Kernel Version
+        run: uname -a
+
+      - name: Kernel Config
+        run: |
+          if [ -f /boot/config-$(uname -r) ]; then cat /boot/config-$(uname -r); fi
+          if [ -f /proc/config.gz ]; then zcat /proc/config.gz; fi
+
       - name: Skip tests (temporary)
         run: echo "Skipping tests on ARM64 temporarily"
         continue-on-error: true
-
-      # - name: Kernel Version
-      #   run: uname -a
-
-      # - name: Kernel Config
-      #   run: zcat /proc/config.gz | grep -i BPF
 
       # - name: Set up Go
       #   uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -95,11 +95,11 @@ jobs:
 
       - name: Integration Tests (Native)
         continue-on-error: true
-        run: make GO=`which go` test/integration/native
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 
       - name: Integration Tests (Python)
         continue-on-error: true
-        run: make GO=`which go` test/integration/python
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
 
       - name: Integration Tests (Ruby)
-        run: make GO=`which go` test/integration/ruby
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
           skip_after_successful_duplicate: false
 
   test:
+    name: Test
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,10 +83,11 @@ jobs:
       - name: Build BPF
         run: make bpf
 
+      - name: Run DWARF Unwind Table Tests
+        continue-on-error: true
+        run: make test-dwarf-unwind-tables
+
       - name: Run Tests
         # Some of the GH action CI machines have several versions of Go installed.
         # Make sometimes somehow resolves different Go. We need to specify explicitly.
         run: make GO=`which go` test ENABLE_RACE=yes
-
-      - name: Run DWARF Unwind Table Tests
-        run: make test-dwarf-unwind-tables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,10 +84,10 @@ jobs:
         run: make bpf
 
       - name: Run DWARF Unwind Table Tests
-        continue-on-error: true
         run: make test-dwarf-unwind-tables
 
       - name: Run Tests
+        if: ${{ always() }}
         # Some of the GH action CI machines have several versions of Go installed.
         # Make sometimes somehow resolves different Go. We need to specify explicitly.
         run: make GO=`which go` test ENABLE_RACE=yes

--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -672,7 +672,7 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx, u64 pid_t
 
   int err = bpf_map_update_elem(&stack_traces, &user_stack_id, &unwind_state->stack, BPF_ANY);
   if (err != 0) {
-    LOG("[error] bpf_map_update_elem with ret: %d", err);
+    LOG("[error] failed to update user stack with %d", err);
   }
 
   // Hash and add kernel stack.
@@ -682,7 +682,7 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx, u64 pid_t
   stack_key->kernel_stack_id = kernel_stack_id;
   err = bpf_map_update_elem(&stack_traces, &kernel_stack_id, &unwind_state->stack, BPF_ANY);
   if (err != 0) {
-    LOG("[error] bpf_map_update_elem (kernel) with ret: %d", err);
+    LOG("[error] failed to update kernel stack with %d", err);
   }
 
   request_process_mappings(ctx, per_process_id);

--- a/bpf/unwinders/pyperf.h
+++ b/bpf/unwinders/pyperf.h
@@ -116,10 +116,6 @@ typedef struct {
 } PyTupleObject;
 
 typedef struct {
-  u32 major_version;
-  u32 minor_version;
-  u32 patch_version;
-
   PyCFrame py_cframe;
   PyCodeObject py_code_object;
   PyFrameObject py_frame_object;

--- a/bpf/unwinders/rbperf.h
+++ b/bpf/unwinders/rbperf.h
@@ -91,23 +91,21 @@ typedef struct {
 
 typedef struct {
     u64 rb_frame_addr;
-    u32 rb_version;
     u64 start_time;
+    u32 rb_version;
+    _Bool account_for_variable_width;
 } ProcessData;
 
 typedef struct {
-    int major_version;
-    int minor_version;
-    int patch_version;
-    int vm_offset;
-    int vm_size_offset;
-    int control_frame_t_sizeof;
-    int cfp_offset;
-    int label_offset;
-    int path_flavour;
-    int line_info_size_offset;
-    int line_info_table_offset;
-    int lineno_offset;
-    int main_thread_offset;
-    int ec_offset;
+    s64 vm_offset;
+    s64 vm_size_offset;
+    s64 control_frame_t_sizeof;
+    s64 cfp_offset;
+    s64 label_offset;
+    s64 path_flavour;
+    s64 line_info_size_offset;
+    s64 line_info_table_offset;
+    s64 lineno_offset;
+    s64 main_thread_offset;
+    s64 ec_offset;
 } RubyVersionOffsets;

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -73,7 +73,6 @@ import (
 	"github.com/parca-dev/parca-agent/pkg/debuginfo"
 	"github.com/parca-dev/parca-agent/pkg/discovery"
 	parcagrpc "github.com/parca-dev/parca-agent/pkg/grpc"
-	"github.com/parca-dev/parca-agent/pkg/kernel"
 	"github.com/parca-dev/parca-agent/pkg/ksym"
 	"github.com/parca-dev/parca-agent/pkg/logger"
 	"github.com/parca-dev/parca-agent/pkg/metadata"
@@ -271,10 +270,6 @@ type Profiler interface {
 	LastProfileStartedAt() time.Time
 	LastError() error
 	ProcessLastErrors() map[int]error
-}
-
-func isRoot() bool {
-	return os.Geteuid() == 0
 }
 
 func getRPCOptions(flags flags) []grpc.DialOption {
@@ -556,20 +551,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 		configFileExists bool
 	)
 
-	if !isRoot() && !flags.Hidden.AllowRunningAsNonRoot {
-		return errors.New("superuser (root) is required to run Parca Agent to load and manipulate BPF programs")
-	}
-
-	isRootPIDNamespace, err := contained.IsRootPIDNamespace()
-	if err == nil {
-		if !isRootPIDNamespace && !flags.Hidden.AllowRunningInNonRootPIDNamespace {
-			level.Error(logger).Log("msg", "the agent can't run in a container, run with privileges and in the host PID (`hostPID: true` in Kubernetes, `--pid host` in Docker)")
-			os.Exit(1)
-		}
-	} else {
-		level.Error(logger).Log("msg", "could not figure out if we are contained", "err", err)
-	}
-
 	if flags.ConfigPath == "" {
 		level.Info(logger).Log("msg", "no config file provided, using default config")
 	} else {
@@ -600,9 +581,15 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 		return errors.New("the BPF events buffer is too small, should be at least 32 pages")
 	}
 
-	release, err := kernel.GetRelease()
-	if err == nil && kernel.HasKnownBugs(release) && !flags.Hidden.IgnoreUnsafeKernelVersion {
-		return errors.New("this kernel version might cause issues such as freezing your system (https://github.com/parca-dev/parca-agent/discussions/2071). This can be bypassed with --ignore-unsafe-kernel-version but bad things can happen")
+	ok, err := agent.PreflightChecks(
+		flags.Hidden.AllowRunningAsNonRoot,
+		flags.Hidden.AllowRunningInNonRootPIDNamespace,
+		flags.Hidden.IgnoreUnsafeKernelVersion,
+	)
+	if !ok {
+		return fmt.Errorf("preflight checks failed: %w", err)
+	} else if err != nil {
+		level.Warn(logger).Log("msg", "preflight checks failed", "err", err)
 	}
 
 	// Initialize tracing.
@@ -622,14 +609,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to create tracing provider", "err", err)
 		}
-	}
-
-	if err := kernel.CheckBPFEnabled(); err != nil {
-		// TODO: Add a more definitive test for the cases kconfig fails.
-		// - https://github.com/libbpf/libbpf/blob/1714037104da56308ddb539ae0a362a9936121ff/src/libbpf.c#L4396-L4429
-		level.Warn(logger).Log("msg", "failed to determine if eBPF is supported, host kernel might not support eBPF", "err", err)
-	} else {
-		level.Info(logger).Log("msg", "eBPF is supported and enabled by the host kernel")
 	}
 
 	profileStoreClient := agent.NewNoopProfileStoreClient()
@@ -694,7 +673,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 			}
 		})
 	}
-
 	if !flags.AnalyticsOptOut {
 		logger := log.With(logger, "group", "analytics")
 		c := analytics.NewClient(
@@ -709,6 +687,12 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 			"parca-agent",
 			time.Second*5,
 		)
+
+		isRootPIDNamespace, err := contained.IsRootPIDNamespace()
+		if err != nil {
+			return fmt.Errorf("failed to determine if the agent is running in the root PID namespace: %w", err)
+		}
+
 		var si sysinfo.SysInfo
 		si.GetSysInfo()
 		a := analytics.NewSender(

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -688,7 +688,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 			time.Second*5,
 		)
 
-		isRootPIDNamespace, err := contained.IsRootPIDNamespace()
+		isRootPIDNamespace, err := contained.IsRootPIDNamespace(logger)
 		if err != nil {
 			return fmt.Errorf("failed to determine if the agent is running in the root PID namespace: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/parca-dev/parca v0.20.0
-	github.com/parca-dev/runtime-data v0.0.0-20231005134622-f7f398637613
+	github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3
 	github.com/planetscale/vtprotobuf v0.6.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/oracle/oci-go-sdk/v65 v65.53.0 h1:/h+rzaRw7W1eSTeDLhSMTRnyXg1oj5NTPeB
 github.com/oracle/oci-go-sdk/v65 v65.53.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/parca-dev/parca v0.20.0 h1:G/TdZLbZEArZzd86rI2RqMpUtz0verlvO3+NDP/d0m0=
 github.com/parca-dev/parca v0.20.0/go.mod h1:dKRKjo1MK83iEUygyINUYTAriHICGYejD4EWm5MGT+0=
-github.com/parca-dev/runtime-data v0.0.0-20231005134622-f7f398637613 h1:deEEyNLtyRrJrf/A49Iy/PFd0dfcRQEl0h0Jndx67Qg=
-github.com/parca-dev/runtime-data v0.0.0-20231005134622-f7f398637613/go.mod h1:0AFERcIlkTaq5C6IVouvQvhGl0KPOfey+9XwszMAR3E=
+github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3 h1:PW4bmNX8f0ZwgmE+I4YIgJZYHuIXyRsNOFylzSgIAEs=
+github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
 github.com/parquet-go/parquet-go v0.19.0 h1:xtHOBIE0/8CRhmf06V1GJ7q3qARY2/kXiSweFlscwUQ=
 github.com/parquet-go/parquet-go v0.19.0/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/agent/preflight_checks.go
+++ b/pkg/agent/preflight_checks.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-kit/log"
 	"github.com/parca-dev/parca-agent/pkg/contained"
 	"github.com/parca-dev/parca-agent/pkg/kernel"
 )
@@ -29,7 +30,7 @@ func PreflightChecks(
 	ignoreUnsafeKernelVersion bool,
 ) (bool, error) {
 	var errs error
-	isRootPIDNamespace, err := contained.IsRootPIDNamespace()
+	isRootPIDNamespace, err := contained.IsRootPIDNamespace(log.NewNopLogger())
 	if !isRoot() && !allowRunningAsNonRoot {
 		return false, errors.New("superuser (root) is required to run Parca Agent to load and manipulate BPF programs")
 	}

--- a/pkg/agent/preflight_checks.go
+++ b/pkg/agent/preflight_checks.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/go-kit/log"
+
 	"github.com/parca-dev/parca-agent/pkg/contained"
 	"github.com/parca-dev/parca-agent/pkg/kernel"
 )

--- a/pkg/agent/preflight_checks.go
+++ b/pkg/agent/preflight_checks.go
@@ -1,0 +1,64 @@
+// Copyright 2022-2024 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/parca-dev/parca-agent/pkg/contained"
+	"github.com/parca-dev/parca-agent/pkg/kernel"
+)
+
+// PreflightChecks checks if the agent is ready to start.
+func PreflightChecks(
+	allowRunningAsNonRoot bool,
+	allowRunningInNonRootPIDNamespace bool,
+	ignoreUnsafeKernelVersion bool,
+) (bool, error) {
+	var errs error
+	isRootPIDNamespace, err := contained.IsRootPIDNamespace()
+	if !isRoot() && !allowRunningAsNonRoot {
+		return false, errors.New("superuser (root) is required to run Parca Agent to load and manipulate BPF programs")
+	}
+	if err == nil {
+		if !isRootPIDNamespace && !allowRunningInNonRootPIDNamespace {
+			return false, errors.New(
+				"the agent can't run in a container, run with privileges and in the host PID (`hostPID: true` in Kubernetes, `--pid host` in Docker)",
+			)
+		}
+	} else {
+		errs = errors.Join(errs, errors.New("failed to determine if the agent is running in a container"))
+	}
+
+	release, err := kernel.GetRelease()
+	if err != nil {
+		errs = errors.Join(errs, fmt.Errorf("failed to determine the kernel version, error: %w", err))
+	} else if kernel.HasKnownBugs(release) && !ignoreUnsafeKernelVersion {
+		return false, errors.New("this kernel version might cause issues such as freezing your system (https://github.com/parca-dev/parca-agent/discussions/2071). This can be bypassed with --ignore-unsafe-kernel-version but bad things can happen")
+	}
+
+	if err := kernel.CheckBPFEnabled(); err != nil {
+		// TODO: Add a more definitive test for the cases kconfig fails.
+		// - https://github.com/libbpf/libbpf/blob/1714037104da56308ddb539ae0a362a9936121ff/src/libbpf.c#L4396-L4429
+		errs = errors.Join(errs, fmt.Errorf("failed to determine if eBPF is supported, host kernel might not support eBPF, error: %w", err))
+	}
+
+	return true, errs
+}
+
+func isRoot() bool {
+	return os.Geteuid() == 0
+}

--- a/pkg/contained/contained.go
+++ b/pkg/contained/contained.go
@@ -21,10 +21,12 @@ import (
 	"os"
 	"runtime"
 
-	"go.uber.org/atomic"
-
 	libbpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/helpers"
+	"github.com/go-kit/log"
+	"go.uber.org/atomic"
+
+	parcalogger "github.com/parca-dev/parca-agent/pkg/logger"
 )
 
 //go:embed bpf/*
@@ -42,7 +44,9 @@ func testFunction() {
 	fmt.Fprintf(io.Discard, "Side-effect to avoid the compiler to optimize it out.")
 }
 
-func IsRootPIDNamespace() (bool, error) {
+func IsRootPIDNamespace(logger log.Logger) (bool, error) {
+	libbpf.SetLoggerCbs(parcalogger.NewLibbpfLogCallbacks(logger))
+
 	f, err := bpfObjects.Open(fmt.Sprintf("bpf/%s/pid_namespace.bpf.o", runtime.GOARCH))
 	if err != nil {
 		return false, fmt.Errorf("failed to open BPF object: %w", err)

--- a/pkg/kernel/kconfig.go
+++ b/pkg/kernel/kconfig.go
@@ -129,7 +129,7 @@ func checkBPFOptions(configFile string) (bool, error) {
 			// If we reach this point, we were unable to verify the presence of *any* alternatives
 			if !altFound {
 				alts := strings.Join(option.alternatives, ", ")
-				return false, fmt.Errorf("%w; alternatives checked:%s", err, alts)
+				return false, fmt.Errorf("%w; alternatives checked: %s", err, alts)
 			}
 		}
 	}

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1516,12 +1516,7 @@ func (m *Maps) setUnwindTableForMapping(buf *profiler.EfficientBuffer, pid int, 
 
 	f, err := m.objectFilePool.Open(fullExecutablePath)
 	if err != nil {
-		return err
-	}
-
-	ef, err := f.ELF()
-	var elfErr *elf.FormatError
-	if err != nil {
+		var elfErr *elf.FormatError
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
@@ -1529,7 +1524,12 @@ func (m *Maps) setUnwindTableForMapping(buf *profiler.EfficientBuffer, pid int, 
 			level.Debug(m.logger).Log("msg", "bad ELF file format", "err", err)
 			return nil
 		}
-		return fmt.Errorf("elf.Open failed: %w", err)
+		return fmt.Errorf("open object file: %w", err)
+	}
+
+	ef, err := f.ELF()
+	if err != nil {
+		return fmt.Errorf("get ELF from object file: %w", err)
 	}
 	buildID, err := buildid.FromELF(ef)
 	if err != nil {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -598,7 +598,7 @@ func (p *CPU) addUnwindTableForProcess(ctx context.Context, pid int) {
 		p.processErrorTracker.Track(pid, err)
 	default:
 		p.metrics.unwindTableAddErrors.WithLabelValues(labelOther).Inc()
-		level.Error(p.logger).Log("msg", "failed to add unwind table", "pid", pid, "err", err)
+		level.Warn(p.logger).Log("msg", "failed to add unwind table", "pid", pid, "err", err)
 	}
 }
 

--- a/pkg/profiler/rbperf/headers.go
+++ b/pkg/profiler/rbperf/headers.go
@@ -26,10 +26,10 @@ type (
 )
 
 type ProcessData struct {
-	RbFrameAddr u64
-	RbVersion   u32
-	Padding_    [4]byte
-	StartTime   u64
+	RbFrameAddr             u64
+	StartTime               u64
+	RbVersion               u32
+	AccountForVariableWidth bool
 }
 
 type RubyVersionOffsets struct {

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -114,7 +114,7 @@ func IsRunningOnCI() bool {
 // but we shouldn't have to pay this price during local dev.
 func ProfileDuration() time.Duration {
 	if IsRunningOnCI() {
-		return 20 * time.Second
+		return 30 * time.Second
 	}
 	return 5 * time.Second
 }

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -114,7 +114,7 @@ func IsRunningOnCI() bool {
 // but we shouldn't have to pay this price during local dev.
 func ProfileDuration() time.Duration {
 	if IsRunningOnCI() {
-		return 30 * time.Second
+		return 20 * time.Second
 	}
 	return 5 * time.Second
 }

--- a/test/integration/native/native_test.go
+++ b/test/integration/native/native_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/parca-dev/parca-agent/pkg/agent"
 	"github.com/parca-dev/parca-agent/pkg/logger"
 	"github.com/parca-dev/parca-agent/pkg/objectfile"
 	"github.com/parca-dev/parca-agent/pkg/profiler/cpu"
@@ -228,6 +229,12 @@ func TestCPUProfiler(t *testing.T) {
 	level.Info(logger).Log("profileDuration", profileDuration)
 	ctx, cancel := context.WithTimeout(context.Background(), profileDuration)
 	t.Cleanup(cancel)
+
+	ok, err := agent.PreflightChecks(false, false, false)
+	require.Truef(t, ok, "preflight checks failed: %v", err)
+	if err != nil {
+		t.Logf("preflight checks passed but with errors: %v", err)
+	}
 
 	// Now that all the processes are running, start profiling them.
 	err = profiler.Run(ctx)

--- a/test/integration/native/native_test.go
+++ b/test/integration/native/native_test.go
@@ -230,7 +230,7 @@ func TestCPUProfiler(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), profileDuration)
 	t.Cleanup(cancel)
 
-	ok, err := agent.PreflightChecks(false, false, false)
+	ok, _, err := agent.PreflightChecks(false, false, false)
 	require.Truef(t, ok, "preflight checks failed: %v", err)
 	if err != nil {
 		t.Logf("preflight checks passed but with errors: %v", err)

--- a/test/integration/python/python_test.go
+++ b/test/integration/python/python_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 
+	"github.com/parca-dev/parca-agent/pkg/agent"
 	"github.com/parca-dev/parca-agent/pkg/logger"
 	"github.com/parca-dev/parca-agent/pkg/objectfile"
 	"github.com/parca-dev/parca-agent/pkg/profiler/cpu"
@@ -33,6 +34,12 @@ import (
 )
 
 func TestPython(t *testing.T) {
+	ok, err := agent.PreflightChecks(false, false, false)
+	require.Truef(t, ok, "preflight checks failed: %v", err)
+	if err != nil {
+		t.Logf("preflight checks passed but with errors: %v", err)
+	}
+
 	tests := []struct {
 		images  []string
 		program string

--- a/test/integration/python/python_test.go
+++ b/test/integration/python/python_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestPython(t *testing.T) {
-	ok, err := agent.PreflightChecks(false, false, false)
+	ok, _, err := agent.PreflightChecks(false, false, false)
 	require.Truef(t, ok, "preflight checks failed: %v", err)
 	if err != nil {
 		t.Logf("preflight checks passed but with errors: %v", err)

--- a/test/integration/ruby/ruby_test.go
+++ b/test/integration/ruby/ruby_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestRuby(t *testing.T) {
-	ok, err := agent.PreflightChecks(false, false, false)
+	ok, _, err := agent.PreflightChecks(false, false, false)
 	require.Truef(t, ok, "preflight checks failed: %v", err)
 	if err != nil {
 		t.Logf("preflight checks passed but with errors: %v", err)

--- a/test/integration/ruby/ruby_test.go
+++ b/test/integration/ruby/ruby_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 
+	"github.com/parca-dev/parca-agent/pkg/agent"
 	"github.com/parca-dev/parca-agent/pkg/logger"
 	"github.com/parca-dev/parca-agent/pkg/objectfile"
 	"github.com/parca-dev/parca-agent/pkg/profiler/cpu"
@@ -33,6 +34,12 @@ import (
 )
 
 func TestRuby(t *testing.T) {
+	ok, err := agent.PreflightChecks(false, false, false)
+	require.Truef(t, ok, "preflight checks failed: %v", err)
+	if err != nil {
+		t.Logf("preflight checks passed but with errors: %v", err)
+	}
+
 	tests := []struct {
 		images  []string
 		program string


### PR DESCRIPTION
- Update runtime-data
- Adds arm64 integration tests
- Attempts to add namespace runners for integration tests (vanilla runners are containers, and it doesn't support our agent use case). We will find another way with namespace labs people
- Refactors preflight checks and make sure they ran for the integration tests as well
- Fixes `setUnwindTable` error handling
- Shares the `modcache` with sudo test runners

