### PR TITLE
python: Use new initial state API from runtime-data

### DIFF
--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -90,11 +90,6 @@ jobs:
       - name: Build BPF
         run: make bpf
 
-      - name: Cache Docker images for testcontainers
-        uses: ScribeMD/docker-cache@0.3.7
-        with:
-          key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
-
       - name: Integration Tests (Native)
         run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -100,11 +100,6 @@ jobs:
       # - name: Build BPF
       #   run: make bpf
 
-      # - name: Cache Docker images for testcontainers
-      #   uses: ScribeMD/docker-cache@0.3.7
-      #   with:
-      #     key: docker-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('test/integration/*') }}
-
       # - name: Integration Tests (Native)
       #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/parca-dev/parca v0.20.0
-	github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3
+	github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db
 	github.com/planetscale/vtprotobuf v0.6.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,8 @@ github.com/parca-dev/parca v0.20.0 h1:G/TdZLbZEArZzd86rI2RqMpUtz0verlvO3+NDP/d0m
 github.com/parca-dev/parca v0.20.0/go.mod h1:dKRKjo1MK83iEUygyINUYTAriHICGYejD4EWm5MGT+0=
 github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3 h1:PW4bmNX8f0ZwgmE+I4YIgJZYHuIXyRsNOFylzSgIAEs=
 github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
+github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db h1:D0304Ys2rhlr0YCQVu5nrnfF8U7951iU65+LVtiTWZE=
+github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
 github.com/parquet-go/parquet-go v0.19.0 h1:xtHOBIE0/8CRhmf06V1GJ7q3qARY2/kXiSweFlscwUQ=
 github.com/parquet-go/parquet-go v0.19.0/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,6 @@ github.com/oracle/oci-go-sdk/v65 v65.53.0 h1:/h+rzaRw7W1eSTeDLhSMTRnyXg1oj5NTPeB
 github.com/oracle/oci-go-sdk/v65 v65.53.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/parca-dev/parca v0.20.0 h1:G/TdZLbZEArZzd86rI2RqMpUtz0verlvO3+NDP/d0m0=
 github.com/parca-dev/parca v0.20.0/go.mod h1:dKRKjo1MK83iEUygyINUYTAriHICGYejD4EWm5MGT+0=
-github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3 h1:PW4bmNX8f0ZwgmE+I4YIgJZYHuIXyRsNOFylzSgIAEs=
-github.com/parca-dev/runtime-data v0.0.0-20240220094357-fc0943ade5d3/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
 github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db h1:D0304Ys2rhlr0YCQVu5nrnfF8U7951iU65+LVtiTWZE=
 github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
 github.com/parquet-go/parquet-go v0.19.0 h1:xtHOBIE0/8CRhmf06V1GJ7q3qARY2/kXiSweFlscwUQ=

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/parca-dev/parca-agent/pkg/elfreader"
 	"github.com/parca-dev/parca-agent/pkg/runtime"
+	runtimedata "github.com/parca-dev/runtime-data/pkg/python"
 )
 
 // Python symbols to look for:
@@ -318,7 +319,7 @@ func (i interpreter) findAddressOf(s string) (uint64, error) {
 }
 
 func (i interpreter) threadStateAddress() (uint64, error) {
-	const37_11, err := semver.NewConstraint(">=3.7.x <=3.11.x")
+	const37_11, err := semver.NewConstraint(">=3.7.x")
 	if err != nil {
 		return 0, fmt.Errorf("new constraint: %w", err)
 	}
@@ -329,11 +330,11 @@ func (i interpreter) threadStateAddress() (uint64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("findAddressOf: %w", err)
 		}
-		offset, err := i.tstateCurrentOffset()
+		_, initialState, err := runtimedata.GetInitialState(i.version)
 		if err != nil {
-			return 0, fmt.Errorf("tstate current offset: %w", err)
+			return 0, fmt.Errorf("get initial state: %w", err)
 		}
-		return addr + offset, nil
+		return addr + uint64(initialState.ThreadStateCurrent), nil
 	// Older versions (<3.7.0) of Python do not have the _PyRuntime struct.
 	default:
 		addr, err := i.findAddressOf(pythonThreadStateSymbol) // _PyThreadState_Current
@@ -344,112 +345,8 @@ func (i interpreter) threadStateAddress() (uint64, error) {
 	}
 }
 
-func (i interpreter) tstateCurrentOffset() (uint64, error) {
-	switch i.arch {
-	case "amd64":
-		return i.tstateCurrentOffsetAmd64()
-	case "arm64":
-		return i.tstateCurrentOffsetArm64()
-	default:
-		return 0, fmt.Errorf("unsupported architecture: %s", goruntime.GOARCH)
-	}
-}
-
-// https://github.com/benfred/py-spy/blob/8a0d06d1b4ca986a061642b87e578112c2f5ab7b/src/python_bindings/mod.rs#L171
-func (i interpreter) tstateCurrentOffsetArm64() (uint64, error) {
-	const3703, err := semver.NewConstraint(">=3.7.0 <=3.7.3")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const37, err := semver.NewConstraint("~3.7.4")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const380, err := semver.NewConstraint("3.8.x")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const39_10, err := semver.NewConstraint("3.9 - 3.10")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const311, err := semver.NewConstraint("3.11.x")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	switch {
-	case const3703.Check(i.version):
-		return 1408, nil
-	case const37.Check(i.version):
-		return 1496, nil
-	case const380.Check(i.version):
-		return 1384, nil
-	case const39_10.Check(i.version):
-		return 584, nil
-	case const311.Check(i.version):
-		return 592, nil
-	default:
-		return 0, fmt.Errorf("unsupported version: %s", i.version.String())
-	}
-}
-
-// https://github.com/benfred/py-spy/blob/8a0d06d1b4ca986a061642b87e578112c2f5ab7b/src/python_bindings/mod.rs#L201
-func (i interpreter) tstateCurrentOffsetAmd64() (uint64, error) {
-	const3703, err := semver.NewConstraint(">=3.7.0 <=3.7.3")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const37, err := semver.NewConstraint("~3.7.4")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const380, err := semver.NewConstraint("=3.8.0")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const3810, err := semver.NewConstraint("~3.8.1")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const39_10, err := semver.NewConstraint("3.9 - 3.10")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	const311, err := semver.NewConstraint("3.11.x")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	switch {
-	case const3703.Check(i.version):
-		return 1392, nil
-	case const37.Check(i.version):
-		return 1480, nil
-	case const380.Check(i.version):
-		return 1368, nil
-	case const3810.Check(i.version):
-		return 1368, nil
-	case const39_10.Check(i.version):
-		return 568, nil
-	case const311.Check(i.version):
-		return 576, nil
-	default:
-		return 0, fmt.Errorf("unsupported version: %s", i.version.String())
-	}
-}
-
 func (i interpreter) interpreterAddress() (uint64, error) {
-	const37_11, err := semver.NewConstraint(">=3.7.x <=3.11.x")
+	const37_11, err := semver.NewConstraint(">=3.7.x")
 	if err != nil {
 		return 0, fmt.Errorf("new constraint: %w", err)
 	}
@@ -460,11 +357,11 @@ func (i interpreter) interpreterAddress() (uint64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("findAddressOf: %w", err)
 		}
-		offset, err := i.interpHeadOffset()
+		_, initialState, err := runtimedata.GetInitialState(i.version)
 		if err != nil {
-			return 0, fmt.Errorf("tstate current offset: %w", err)
+			return 0, fmt.Errorf("get initial state: %w", err)
 		}
-		return addr + offset, nil
+		return addr + uint64(initialState.InterpreterHead), nil
 	// Older versions (<3.7.0) of Python do not have the _PyRuntime struct.
 	default:
 		addr, err := i.findAddressOf(pythonInterpreterSymbol) // interp_head
@@ -472,33 +369,6 @@ func (i interpreter) interpreterAddress() (uint64, error) {
 			return 0, fmt.Errorf("findAddressOf: %w", err)
 		}
 		return addr, nil
-	}
-}
-
-// https://github.com/benfred/py-spy/blob/8a0d06d1b4ca986a061642b87e578112c2f5ab7b/src/python_bindings/mod.rs#L24
-func (i interpreter) interpHeadOffset() (uint64, error) {
-	const380, err := semver.NewConstraint("=3.8.0")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-	const3810, err := semver.NewConstraint(">=3.8.1 <=3.10.0")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-	const311, err := semver.NewConstraint("=3.11.0")
-	if err != nil {
-		return 0, fmt.Errorf("new constraint: %w", err)
-	}
-
-	switch {
-	case const380.Check(i.version):
-		return 32, nil
-	case const3810.Check(i.version):
-		return 32, nil
-	case const311.Check(i.version):
-		return 40, nil
-	default:
-		return 24, nil
 	}
 }
 

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -32,9 +32,10 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/prometheus/procfs"
 
+	runtimedata "github.com/parca-dev/runtime-data/pkg/python"
+
 	"github.com/parca-dev/parca-agent/pkg/elfreader"
 	"github.com/parca-dev/parca-agent/pkg/runtime"
-	runtimedata "github.com/parca-dev/runtime-data/pkg/python"
 )
 
 // Python symbols to look for:

--- a/test/integration/python/python_test.go
+++ b/test/integration/python/python_test.go
@@ -41,23 +41,23 @@ func TestPython(t *testing.T) {
 	}
 
 	tests := []struct {
-		images  []string
+		images  map[string]string
 		program string
 		want    []string
 		wantErr bool
 	}{
 		{
-			images: []string{
-				"2.7.18-slim",
-				"3.3.7-slim",
-				"3.4.8-slim",
-				"3.5.5-slim",
-				"3.6.6-slim",
-				"3.7.0-slim",
-				"3.8.0-slim",
-				"3.9.5-slim",
-				"3.10.0-slim",
-				"3.11.0-slim",
+			images: map[string]string{
+				"2.7.18": "2.7.18-slim",
+				"3.3.0":  "3.3.7-slim",
+				"3.4.0":  "3.4.8-slim",
+				"3.5.0":  "3.5.5-slim",
+				"3.6.0":  "3.6.6-slim",
+				"3.7.0":  "3.7.0-slim",
+				"3.8.0":  "3.8.0-slim",
+				"3.9.5":  "3.9.5-slim",
+				"3.10.0": "3.10.0-slim",
+				"3.11.0": "3.11.0-slim",
 			},
 			program: "testdata/cpu_hog.py",
 			want:    []string{"<module>", "a1", "b1", "c1", "cpu"},
@@ -65,11 +65,12 @@ func TestPython(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		for _, imageTag := range tt.images {
+		for version, imageTag := range tt.images {
 			var (
 				program = tt.program
 				want    = tt.want
 				name    = fmt.Sprintf("%s on python-%s", imageTag, program)
+				version = version
 			)
 			t.Run(name, func(t *testing.T) {
 				// Start a python container.
@@ -137,8 +138,13 @@ func TestPython(t *testing.T) {
 				},
 					&relabel.Config{
 						Action:       relabel.Keep,
-						SourceLabels: model.LabelNames{"comm"},
-						Regex:        relabel.MustNewRegexp("python"),
+						SourceLabels: model.LabelNames{"python"},
+						Regex:        relabel.MustNewRegexp("true"),
+					},
+					&relabel.Config{
+						Action:       relabel.Keep,
+						SourceLabels: model.LabelNames{"python_version"},
+						Regex:        relabel.MustNewRegexp(version),
 					},
 				)
 				require.NoError(t, err)


### PR DESCRIPTION
- Use new initial state API
- Use more precise label matches 05d3b97af3d0d759c35e24d7387fd2b78ecf0800
