### PR TITLE
Run integration tests on namespace runners

### DIFF
--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -48,8 +48,9 @@ jobs:
 
   integration-tests:
     name: Integration Tests on AMD64
-    # runs-on: nscloud-ubuntu-22.04-amd64-4x16
-    runs-on: ubuntu-latest
+    runs-on:
+      - nscloud-ubuntu-22.04-amd64-4x16
+      - nscloud-exp-features:privileged;host-pid-namespace
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code

--- a/.github/workflows/test-integration-arm64.yml
+++ b/.github/workflows/test-integration-arm64.yml
@@ -48,7 +48,9 @@ jobs:
 
   integration-tests:
     name: Integration Tests on ARM64
-    runs-on: nscloud-ubuntu-22.04-arm64-4x16
+    runs-on:
+      - nscloud-ubuntu-22.04-arm64-4x16
+      - nscloud-exp-features:privileged;host-pid-namespace
     if: ${{ github.event.workflow_run.conclusion == 'success' }} && ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - name: Check out the code
@@ -62,51 +64,47 @@ jobs:
           if [ -f /boot/config-$(uname -r) ]; then cat /boot/config-$(uname -r); fi
           if [ -f /proc/config.gz ]; then zcat /proc/config.gz; fi
 
-      - name: Skip tests (temporary)
-        run: echo "Skipping tests on ARM64 temporarily"
-        continue-on-error: true
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: .go-version
 
-      # - name: Set up Go
-      #   uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-      #   with:
-      #     go-version-file: .go-version
+      - name: Set up Clang
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y llvm-14 clang-14 lld-14
+          sudo ln -s /usr/bin/clang-14 /usr/bin/clang
+          sudo ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld
+          sudo ln -s /usr/bin/llc-14 /usr/bin/llc
 
-      # - name: Set up Clang
-      #   run: |
-      #     sudo apt-get update -y
-      #     sudo apt-get install -y llvm-14 clang-14 lld-14
-      #     sudo ln -s /usr/bin/clang-14 /usr/bin/clang
-      #     sudo ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld
-      #     sudo ln -s /usr/bin/llc-14 /usr/bin/llc
+      - run: |
+          clang --version
+          ld.lld --version
 
-      # - run: |
-      #     clang --version
-      #     ld.lld --version
+      - name: Install libbpf dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -yq libelf-dev zlib1g-dev libzstd-dev
 
-      # - name: Install libbpf dependencies
-      #   run: |
-      #     sudo apt-get update -y
-      #     sudo apt-get install -yq libelf-dev zlib1g-dev libzstd-dev
+      - name: Initialize and update git submodules
+        run: git submodule init && git submodule update
 
-      # - name: Initialize and update git submodules
-      #   run: git submodule init && git submodule update
+      - name: Install Go dependencies
+        run: make go/deps
 
-      # - name: Install Go dependencies
-      #   run: make go/deps
+      - name: Build libbpf
+        run: make libbpf
 
-      # - name: Build libbpf
-      #   run: make libbpf
+      - name: Build BPF
+        run: make bpf
 
-      # - name: Build BPF
-      #   run: make bpf
+      - name: Integration Tests (Native)
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
 
-      # - name: Integration Tests (Native)
-      #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/native
+      - name: Integration Tests (Python)
+        if: ${{ always() }}
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
 
-      # - name: Integration Tests (Python)
-      #   if: ${{ always() }}
-      #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/python
-
-      # - name: Integration Tests (Ruby)
-      #   if: ${{ always() }}
-      #   run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby
+      - name: Integration Tests (Ruby)
+        if: ${{ always() }}
+        run: GOMODCACHE=$(go env GOMODCACHE) make GO=`which go` test/integration/ruby

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/parca-dev/parca v0.20.0
-	github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db
+	github.com/parca-dev/runtime-data v0.0.0-20240221144835-838a856ad496
 	github.com/planetscale/vtprotobuf v0.6.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/oracle/oci-go-sdk/v65 v65.53.0 h1:/h+rzaRw7W1eSTeDLhSMTRnyXg1oj5NTPeB
 github.com/oracle/oci-go-sdk/v65 v65.53.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/parca-dev/parca v0.20.0 h1:G/TdZLbZEArZzd86rI2RqMpUtz0verlvO3+NDP/d0m0=
 github.com/parca-dev/parca v0.20.0/go.mod h1:dKRKjo1MK83iEUygyINUYTAriHICGYejD4EWm5MGT+0=
-github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db h1:D0304Ys2rhlr0YCQVu5nrnfF8U7951iU65+LVtiTWZE=
-github.com/parca-dev/runtime-data v0.0.0-20240220191044-621d0aab00db/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
+github.com/parca-dev/runtime-data v0.0.0-20240221144835-838a856ad496 h1:sTUSBmbMriumcql8S8UwHtfpzYO2GfaivNEs9eY0Ty4=
+github.com/parca-dev/runtime-data v0.0.0-20240221144835-838a856ad496/go.mod h1:NRpa9nozMNUeyw6p6KeuSx+leWBMoJJE7+mN7XUNdpA=
 github.com/parquet-go/parquet-go v0.19.0 h1:xtHOBIE0/8CRhmf06V1GJ7q3qARY2/kXiSweFlscwUQ=
 github.com/parquet-go/parquet-go v0.19.0/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/internal/dwarf/frame/table.go
+++ b/internal/dwarf/frame/table.go
@@ -132,6 +132,9 @@ func (stack *StateStack) push(state RowState) {
 }
 
 func (stack *StateStack) pop() RowState {
+	if len(stack.items) == 0 {
+		return RowState{}
+	}
 	restored := stack.items[len(stack.items)-1]
 	stack.items = stack.items[0 : len(stack.items)-1]
 	return restored

--- a/pkg/runtime/erlang/erlang_test.go
+++ b/pkg/runtime/erlang/erlang_test.go
@@ -40,6 +40,10 @@ func testBinaryPath(p string) string {
 }
 
 func TestAll(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		// TODO(kakkoyun): Add erlang binaries for other architectures.
+		t.Skip("Skipping test for amd64")
+	}
 	file := testBinaryPath("beam.smp")
 
 	isBeam, err := IsBEAM(file)

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -114,7 +114,7 @@ func IsRunningOnCI() bool {
 // but we shouldn't have to pay this price during local dev.
 func ProfileDuration() time.Duration {
 	if IsRunningOnCI() {
-		return 20 * time.Second
+		return 30 * time.Second
 	}
 	return 5 * time.Second
 }


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

All the Python integration tests and a single case of Ruby (3.2.1) integration tests fail on ARM64.
The failures are because of a bug in DWARF-based unwinder on ARM64 (which we are currently working on). Hence, I will mark the ARM64 integration tests as not mandatory for our CI/CD.

But I will keep the tests running.

## Tests locally when partial stacks are enabled

### Python

![CleanShot 2024-02-21 at 18 40 09@2x](https://github.com/parca-dev/parca-agent/assets/536449/5a8f40b9-a6c4-4a20-b26c-209f2bb09501)

### Ruby

![CleanShot 2024-02-21 at 18 39 04@2x](https://github.com/parca-dev/parca-agent/assets/536449/767d0ef5-3134-44f4-9361-22642b535663)

