### PR TITLE
Various fixes for aarch64

### DIFF
--- a/internal/dwarf/frame/entries.go
+++ b/internal/dwarf/frame/entries.go
@@ -2,6 +2,7 @@
 package frame
 
 import (
+	"debug/elf"
 	"encoding/binary"
 	"fmt"
 	"sort"
@@ -19,6 +20,7 @@ type CommonInformationEntry struct {
 	ReturnAddressRegister uint64
 	InitialInstructions   []byte
 	staticBase            uint64
+	arch                  elf.Machine
 
 	// eh_frame pointer encoding
 	ptrEncAddr ptrEnc

--- a/internal/dwarf/frame/entries_test.go
+++ b/internal/dwarf/frame/entries_test.go
@@ -1,6 +1,7 @@
 package frame
 
 import (
+	"debug/elf"
 	"encoding/binary"
 	"io"
 	"os"
@@ -65,7 +66,7 @@ func BenchmarkFDEForPC(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	fdes, _ := Parse(data, binary.BigEndian, 0, ptrSizeByRuntimeArch(), 0)
+	fdes, _ := Parse(data, binary.BigEndian, 0, ptrSizeByRuntimeArch(), 0, elf.EM_X86_64)
 
 	for i := 0; i < b.N; i++ {
 		// bench worst case, exhaustive search

--- a/internal/dwarf/frame/parser_test.go
+++ b/internal/dwarf/frame/parser_test.go
@@ -119,7 +119,7 @@ func TestParse(t *testing.T) {
 				byteOrder = DWARFEndian(data)
 			}
 
-			fde, err := Parse(data, byteOrder, tt.args.staticBase, ptrSizeByRuntimeArch(), ehFrameAddr)
+			fde, err := Parse(data, byteOrder, tt.args.staticBase, ptrSizeByRuntimeArch(), ehFrameAddr, elf.EM_X86_64)
 			if err != nil {
 				t.Fatalf("failed to parse frame data: %v", err)
 			}
@@ -146,6 +146,6 @@ func BenchmarkParse(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Parse(data, binary.BigEndian, 0, ptrSizeByRuntimeArch(), 0)
+		Parse(data, binary.BigEndian, 0, ptrSizeByRuntimeArch(), 0, elf.EM_X86_64)
 	}
 }

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1960,6 +1960,19 @@ func (m *Maps) setUnwindTableForMapping(buf *profiler.EfficientBuffer, pid int, 
 			// As we can't split an unwind table mid-function, let's create a new
 			// shard.
 			if threshold == 0 {
+				if m.highIndex == 0 {
+					// If we got here then we will never succeed because the current shard
+					// is empty anyway.
+					// Either we misparsed the DWARF frame info and went off the rails,
+					// or there is a genuinely huge FDE. In either case,
+					// bail to avoid an infinite loop.
+					//
+					// TODO[btv] - Investigate why this is happening.
+					// It reproduces with the /usr/lib64/libLLVM-17.so
+					// that ships with Fedora 39 for ARM64
+					// (build ID: 1a88857c9cdd11711b657790b740b057f3db8165)
+					return fmt.Errorf("never found end of chunk %d despite max available entries", chunkIndex)
+				}
 				level.Debug(m.logger).Log("msg", "creating a new shard to avoid splitting the unwind table for a function")
 				if err := m.allocateNewShard(); err != nil {
 					return err

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -2009,7 +2009,7 @@ func (m *Maps) setUnwindTableForMapping(buf *profiler.EfficientBuffer, pid int, 
 
 			// Add shard information.
 
-			level.Debug(m.logger).Log("executableID", m.executableID, "executable", mapping.Executable, "current shard", chunkIndex)
+			level.Debug(m.logger).Log("executableID", m.executableID, "executable", mapping.Executable, "current chunk", chunkIndex, "current shard", m.shardIndex)
 
 			// Dealing with the first chunk, we must add the lowest known PC.
 			minPc := currentChunk[0].Pc()

--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -221,7 +221,7 @@ func ReadFDEs(file *objectfile.ObjectFile) (frame.FrameDescriptionEntries, elf.M
 	}
 
 	// TODO: Byte order of a DWARF section can be different.
-	fdes, err := frame.Parse(ehFrame, obj.ByteOrder, 0, pointerSize(obj.Machine), sec.Addr)
+	fdes, err := frame.Parse(ehFrame, obj.ByteOrder, 0, pointerSize(obj.Machine), sec.Addr, arch)
 	if err != nil {
 		return nil, arch, fmt.Errorf("failed to parse frame data: %w", err)
 	}


### PR DESCRIPTION
### Why?

I was trying to run parca-agent on my new work laptop which has Fedora 39 in a VM on a mac host, i.e. aarch64. I encountered various problems trying to do so, which this PR fixes.

Probably the reason nobody has fixed this before is that Fedora is building their OS using some special compiler flags for security hardening.

Note that this PR contains two logically distinct changes in separate commits (plus one commit for a minor logging fix).

### What?

Please see the individual commit messages for details.

### How?

Please see the individual commit messages for details.

### Test Plan

parca-agent works on my machine now and generates reasonable-looking output.
