### PR TITLE
Fix function end detection

### DIFF
--- a/cmd/eh-frame/main.go
+++ b/cmd/eh-frame/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	if flags.Final {
-		ut, arch, err := unwind.GenerateCompactUnwindTable(file)
+		ut, arch, _, err := unwind.GenerateCompactUnwindTable(file)
 		if err != nil {
 			// nolint:forbidigo
 			fmt.Println("failed with:", err)

--- a/internal/dwarf/frame/entries.go
+++ b/internal/dwarf/frame/entries.go
@@ -36,6 +36,18 @@ type FrameDescriptionEntry struct {
 	order        binary.ByteOrder
 }
 
+func NewFrameDescriptionEntry(length uint32, cie *CommonInformationEntry, instructions []byte, begin, size uint64, order binary.ByteOrder) *FrameDescriptionEntry {
+	fde := FrameDescriptionEntry{
+		Length:       length,
+		CIE:          cie,
+		Instructions: instructions,
+		begin:        begin,
+		size:         size,
+		order:        order,
+	}
+	return &fde
+}
+
 // Cover returns whether or not the given address is within the
 // bounds of this frame.
 func (fde *FrameDescriptionEntry) Cover(addr uint64) bool {
@@ -47,7 +59,8 @@ func (fde *FrameDescriptionEntry) Begin() uint64 {
 	return fde.begin
 }
 
-// End returns address of last location for this frame.
+// End returns address of the first location that is not part
+// of this frame.
 func (fde *FrameDescriptionEntry) End() uint64 {
 	return fde.begin + fde.size
 }

--- a/pkg/profiler/cpu/bpf/maps/maps_test.go
+++ b/pkg/profiler/cpu/bpf/maps/maps_test.go
@@ -1,0 +1,118 @@
+// Copyright 2024 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bpfmaps
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/parca-dev/parca-agent/internal/dwarf/frame"
+	"github.com/parca-dev/parca-agent/pkg/stack/unwind"
+)
+
+func TestTakeChunk(t *testing.T) {
+	const Max int = 5
+	inner := func(ut unwind.CompactUnwindTable, fdes frame.FrameDescriptionEntries, expectedChunkOffsets []int) {
+		totalLen := 0
+		i := 0
+		remaining := Max
+		origLen := len(ut)
+		for len(ut) > 0 {
+			var chunk unwind.CompactUnwindTable
+			chunk, ut = takeChunk(ut, fdes, uint64(remaining))
+			if len(chunk) == 0 {
+				require.NotEqual(t, Max, remaining)
+				require.Equal(t, expectedChunkOffsets[i], totalLen)
+				i++
+				remaining = Max
+				continue
+			}
+			require.LessOrEqual(t, len(chunk), remaining)
+			remaining -= len(chunk)
+			totalLen += len(chunk)
+		}
+		require.Equal(t, expectedChunkOffsets[i], origLen)
+		require.Equal(t, len(expectedChunkOffsets)-1, i)
+	}
+	// two functions that fit in the same chunk
+	inner([]unwind.CompactUnwindTableRow{
+		unwind.NewCompactUnwindTableRow(0, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(4, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(17, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(22, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(36, 0, 0, 0, 0, 0),
+	}, []*frame.FrameDescriptionEntry{
+		frame.NewFrameDescriptionEntry(0, nil, nil, 0, 18, binary.LittleEndian),
+		frame.NewFrameDescriptionEntry(0, nil, nil, 18, (37 - 18), binary.LittleEndian),
+	}, []int{5})
+
+	// two functions that barely don't fit in the same chunk
+	inner([]unwind.CompactUnwindTableRow{
+		unwind.NewCompactUnwindTableRow(0, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(4, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(17, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(22, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(36, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(39, 0, 0, 0, 0, 0),
+	}, []*frame.FrameDescriptionEntry{
+		frame.NewFrameDescriptionEntry(0, nil, nil, 0, 18, binary.LittleEndian),
+		frame.NewFrameDescriptionEntry(0, nil, nil, 18, (40 - 18), binary.LittleEndian),
+	}, []int{3, 6})
+
+	// the first two fit, but the third doesn't
+	inner([]unwind.CompactUnwindTableRow{
+		unwind.NewCompactUnwindTableRow(0, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(4, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(17, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(22, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(36, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(39, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(42, 0, 0, 0, 0, 0),
+	}, []*frame.FrameDescriptionEntry{
+		frame.NewFrameDescriptionEntry(0, nil, nil, 0, 18, binary.LittleEndian),
+		frame.NewFrameDescriptionEntry(0, nil, nil, 18, (23 - 18), binary.LittleEndian),
+		frame.NewFrameDescriptionEntry(0, nil, nil, 23, (43 - 23), binary.LittleEndian),
+	}, []int{4, 7})
+
+	// two functions that fit in the same chunk,
+	// bounded by an end marker
+	inner([]unwind.CompactUnwindTableRow{
+		unwind.NewCompactUnwindTableRow(0, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(4, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(17, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(22, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(36, 0, 4, 0, 0, 0),
+	}, []*frame.FrameDescriptionEntry{
+		frame.NewFrameDescriptionEntry(0, nil, nil, 0, 18, binary.LittleEndian),
+		frame.NewFrameDescriptionEntry(0, nil, nil, 18, (36 - 18), binary.LittleEndian),
+	}, []int{5})
+
+	// two functions that barely don't fit in the same chunk,
+	// both bounded by end markers
+	inner([]unwind.CompactUnwindTableRow{
+		unwind.NewCompactUnwindTableRow(0, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(4, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(17, 0, 4, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(22, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(36, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(39, 0, 0, 0, 0, 0),
+		unwind.NewCompactUnwindTableRow(40, 0, 4, 0, 0, 0),
+	}, []*frame.FrameDescriptionEntry{
+		frame.NewFrameDescriptionEntry(0, nil, nil, 0, 18, binary.LittleEndian),
+		frame.NewFrameDescriptionEntry(0, nil, nil, 18, (40 - 18), binary.LittleEndian),
+	}, []int{3, 7})
+}

--- a/pkg/stack/unwind/compact_unwind_table_test.go
+++ b/pkg/stack/unwind/compact_unwind_table_test.go
@@ -479,7 +479,7 @@ func TestIsSorted(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, match := range matches {
-		ut, _, err := GenerateCompactUnwindTable(objectFile(t, match))
+		ut, _, _, err := GenerateCompactUnwindTable(objectFile(t, match))
 		require.NoError(t, err)
 		requireSorted(t, ut)
 	}
@@ -491,7 +491,7 @@ func TestNoRepeatedPCs(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, match := range matches {
-		ut, _, err := GenerateCompactUnwindTable(objectFile(t, match))
+		ut, _, _, err := GenerateCompactUnwindTable(objectFile(t, match))
 		require.NoError(t, err)
 		requireNoDuplicatedPC(t, ut)
 	}
@@ -502,7 +502,7 @@ func TestNoRedundantRows(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, match := range matches {
-		ut, _, err := GenerateCompactUnwindTable(objectFile(t, match))
+		ut, _, _, err := GenerateCompactUnwindTable(objectFile(t, match))
 		require.NoError(t, err)
 		requireNoRedundantRows(t, ut)
 	}
@@ -518,7 +518,7 @@ func BenchmarkGenerateCompactUnwindTable(b *testing.B) {
 	var cut CompactUnwindTable
 	var err error
 	for n := 0; n < b.N; n++ {
-		cut, _, err = GenerateCompactUnwindTable(objectFile(b, objectFilePath))
+		cut, _, _, err = GenerateCompactUnwindTable(objectFile(b, objectFilePath))
 	}
 
 	require.NoError(b, err)


### PR DESCRIPTION
When constructing unwind tables, we add a synthetic entry marking the end of functions. This serves to allow the unwinder to detect program counters that fall between two functions. We only insert this synthetic row if it's possible to give it a program counter that doesn't overlap with anything else; that is, if there is a gap between the end of the function in question and the beginning of the next.

It's fine to omit the synthetic entries in the case where there is no gap, because in those cases, there isn't any way the PC can lie between to functions.

However, currently we _also_ use the synthetic entries for another purpose: determining where it's okay to break the unwind table into shards (as it's not acceptable for a function to cross a shard boundary). This is imprecise, because the synthetic entries are not added in all cases, as described above. Indeed, binaries that have no gaps in a long enough sequence of functions can't be split anywhere and thus fail to be profiled.

This commit fixes that issue by looking at the original FDEs (which have actual function begin and end information) directly, rather than trying to find function boundaries by using the synthetic rows. It also factors out the chunk-splitting logic into a separate function so it can be tested.

