### PR TITLE
Fix "open perf event: no such device" in systems with offline CPUs

### DIFF
--- a/pkg/cpuinfo/cpu.go
+++ b/pkg/cpuinfo/cpu.go
@@ -13,8 +13,31 @@
 
 package cpuinfo
 
-import "github.com/tklauser/numcpus"
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/tklauser/numcpus"
+)
+
+const sysfsCPUBasePath = "/sys/devices/system/cpu"
+
+var onlineCPUs = map[int]bool{}
 
 func NumCPU() (int, error) {
 	return numcpus.GetPresent()
+}
+
+func init() {
+	buf, _ := os.ReadFile(filepath.Join(sysfsCPUBasePath, "online"))
+	for _, i := range strings.Split(strings.Trim(string(buf), "\n "), ",") {
+		cpu, _ := strconv.Atoi(i)
+		onlineCPUs[cpu] = true
+	}
+}
+
+func IsOnlineCPU(cpu int) bool {
+	return onlineCPUs[cpu]
 }


### PR DESCRIPTION

### Why?
Some CPUs in a system could be offline because of mds mitigation or disabled by a user.  Perf could not procceed to open them and agent stops its execution. 

### What?
This patch adds a basic check for offline CPUs in such a way that agent could run.

### How?
Some changes in pkgs/cpuinfo and a basic filtering of offline CPUs in pkgs/profiler/cpu.go with no knowledge of Go language at all.

### Test Plan
No tests provided. Tested with one run in my system with offline CPUs (by mds mitigation).

Basic manual testing could be done with the following test case.
1. echo 0 > /sys/devices/kernel/cpu/cpu0/online
2. run agent
3. check:
- that agent does not terminate
- there is no error in log
`level=error name=parca-agent ts=2024-03-22T17:32:05.924131353Z caller=main.go:539 err="open perf event: no such device"`