### PR TITLE
Only attempt to profile online CPUs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/rzajac/flexbuf v0.14.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.29.1
-	github.com/tklauser/numcpus v0.7.0
 	github.com/xyproto/ainur v1.3.3
 	github.com/zcalusic/sysinfo v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
@@ -195,6 +194,7 @@ require (
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.45 // indirect
 	github.com/thanos-io/objstore v0.0.0-20231231041903-61cfed8cbb9d // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
+	github.com/tklauser/numcpus v0.7.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"go.opentelemetry.io/otel/trace/noop"
 
+	"github.com/parca-dev/parca-agent/pkg/cpuinfo"
 	"github.com/parca-dev/parca-agent/pkg/debuginfo"
 	"github.com/parca-dev/parca-agent/pkg/ksym"
 	"github.com/parca-dev/parca-agent/pkg/metadata"
@@ -219,6 +220,11 @@ func NewTestProfiler(
 		level.Error(logger).Log("msg", "failed to create optimized symtabs directory", "err", err)
 	}
 
+	cpus, err := cpuinfo.OnlineCPUs()
+	if err != nil {
+		return nil, err
+	}
+
 	profiler := cpu.NewCPUProfiler(
 		logger,
 		reg,
@@ -248,6 +254,7 @@ func NewTestProfiler(
 		config,
 		bpfProgramLoaded,
 		ofp,
+		cpus,
 	)
 
 	// Wait for the BPF program to be loaded.


### PR DESCRIPTION
Previously we counted the number of present CPUs, e.g. n, and then turned on all CPUs from 0 to n-1 inclusive.

This has two defects:

1. It counts present CPUs, not online CPUs, whereas we don't want to attempt to profile an offline-but-present CPU.
2. It doesn't account for the possiblity that there can be gaps in the set of CPUs; e.g., the ranges might be 0-11,13-15 if cpu 12 is offline.

numcpus doesn't have a public API to get the set of online CPUs, so let's implement it ourselves (based on reading numcpus internal code).

### Why?

Fixes https://github.com/parca-dev/parca-agent/issues/2639

### Test Plan
`sudo chcpu -d 12 && sudo dist/parca-agent --log-level=debug` and manually verify that all CPUs except 12 are profiled. Before this would exit with an error.
