### PR TITLE
Surface unwind failure reasons in status page

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -253,7 +253,9 @@ typedef struct {
     u32 unsupported_fp_action;
     u32 unsupported_cfa;
     u32 truncated;
-    u32 catchall;  // TODO more granular?
+    u32 previous_rsp_zero;
+    u32 previous_rip_zero;
+    u32 previous_rbp_zero;
     u32 internal_error;
 } unwind_failed_reasons_t;
 
@@ -1005,7 +1007,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         if (previous_rsp == 0) {
             LOG("[error] previous_rsp should not be zero.");
             bump_unwind_error_catchall();
-            BUMP_UNWIND_FAILED_COUNT(per_process_id, catchall);
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, previous_rsp_zero);
             return 1;
         }
 
@@ -1045,13 +1047,14 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
                 LOG("[warn] mapping not added yet");
                 request_refresh_process_info(ctx, user_pid);
 
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, mapping_not_found);
                 bump_unwind_error_jit_unupdated_mapping();
                 return 1;
             }
 
             LOG("[error] previous_rip should not be zero. This can mean that the read failed, ret=%d while reading previous_rip_addr", err);
             bump_unwind_error_catchall();
-            BUMP_UNWIND_FAILED_COUNT(per_process_id, catchall);
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, previous_rip_zero);
             return 1;
         }
 
@@ -1068,7 +1071,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
                     "that the read has failed %d.",
                     ret);
                 bump_unwind_error_catchall();
-                BUMP_UNWIND_FAILED_COUNT(per_process_id, catchall);
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, previous_rbp_zero);
                 return 1;
             }
         }

--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -240,6 +240,23 @@ typedef struct {
     stack_unwind_row_t rows[MAX_UNWIND_TABLE_SIZE];
 } stack_unwind_table_t;
 
+typedef struct {
+    u32 pc_not_covered;
+    u32 no_unwind_info;
+    u32 missed_filter;
+    u32 mapping_not_found;
+    u32 chunk_not_found;
+    u32 null_unwind_table;
+    u32 table_not_found;
+    u32 rbp_failed;
+    u32 ra_failed;
+    u32 unsupported_fp_action;
+    u32 unsupported_cfa;
+    u32 truncated;
+    u32 catchall;  // TODO more granular?
+    u32 internal_error;
+} unwind_failed_reasons_t;
+
 /*================================ MAPS =====================================*/
 
 BPF_HASH(debug_threads_ids, int, u8, 1);  // Table size will be updated in userspace.
@@ -272,6 +289,18 @@ struct {
     __uint(value_size, sizeof(u32));
     __uint(max_entries, 8192);
 } events SEC(".maps");
+
+BPF_HASH(unwind_failed_reasons, pid_t, unwind_failed_reasons_t, MAX_PROCESSES)
+
+#define BUMP_UNWIND_FAILED_COUNT(_pid, _reason)                                                                      \
+    ({                                                                                                               \
+        pid_t pid = _pid;                                                                                            \
+        unwind_failed_reasons_t zero = {0};                                                                          \
+        unwind_failed_reasons_t *p_failed_reasons = bpf_map_lookup_or_try_init(&unwind_failed_reasons, &pid, &zero); \
+        if (p_failed_reasons) {                                                                                      \
+            __sync_fetch_and_add(&p_failed_reasons->_reason, 1);                                                     \
+        }                                                                                                            \
+    })
 
 /*=========================== HELPER FUNCTIONS ==============================*/
 
@@ -791,6 +820,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         } else if (unwind_table_result == FIND_UNWIND_MAPPING_NOT_FOUND) {
             LOG("[warn] mapping not found");
             request_refresh_process_info(ctx, per_process_id);
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, mapping_not_found);
             return 1;
         } else if (unwind_table_result == FIND_UNWIND_CHUNK_NOT_FOUND) {
             if (proc_info->should_use_fp_by_default) {
@@ -799,6 +829,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
                 goto unwind_with_frame_pointers;
             }
             LOG("[info] chunk not found but fp unwinding not allowed");
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, chunk_not_found);
             return 1;
         } else if (chunk_info == NULL) {
             LOG("[debug] chunks is null");
@@ -809,6 +840,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         stack_unwind_table_t *unwind_table = bpf_map_lookup_elem(&unwind_tables, &chunk_info->shard_index);
         if (unwind_table == NULL) {
             LOG("unwind table is null :( for shard %llu", chunk_info->shard_index);
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, null_unwind_table);
             return 0;
         }
 
@@ -821,6 +853,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
 
         if (BINARY_SEARCH_NOT_FOUND(table_idx) || BINARY_SEARCH_FAILED(table_idx)) {
             LOG("[error] binary search failed with %llx", table_idx);
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, table_not_found);
             return 1;
         }
 
@@ -831,6 +864,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         if (table_idx < 0 || table_idx >= MAX_UNWIND_TABLE_SIZE) {
             LOG("\t[error] this should never happen table_idx");
             bump_unwind_error_should_never_happen();
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, internal_error);
             return 1;
         }
 
@@ -877,12 +911,14 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
                     goto done_unwinding;
                 }
                 LOG("[error] rbp failed with err = %d, previous rbp %d", err, unwind_state->bp);
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, rbp_failed);
                 return 0;
             }
 
             err = bpf_probe_read_user(&ra, 8, (void *)unwind_state->bp + 8);
             if (err < 0) {
                 LOG("[error] ra failed with err = %d", err);
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, ra_failed);
                 return 0;
             }
 
@@ -923,6 +959,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         if (found_rbp_type == RBP_TYPE_REGISTER || found_rbp_type == RBP_TYPE_EXPRESSION) {
             LOG("\t[error] frame pointer is %d (register or exp), bailing out", found_rbp_type);
             bump_unwind_error_unsupported_frame_pointer_action();
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, unsupported_fp_action);
             return 1;
         }
 
@@ -935,6 +972,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
             if (found_cfa_offset == DWARF_EXPRESSION_UNKNOWN) {
                 LOG("[unsup] CFA is an unsupported expression, bailing out");
                 bump_unwind_error_unsupported_expression();
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, unsupported_cfa);
                 return 1;
             }
 
@@ -949,6 +987,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
 
             if (threshold == 0) {
                 bump_unwind_error_should_never_happen();
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, internal_error);
                 return 1;
             }
             previous_rsp = unwind_state->sp + 8 + ((((unwind_state->ip & 15) >= threshold)) << 3);
@@ -956,6 +995,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         } else {
             LOG("\t[unsup] register %d not valid (expected $rbp or $rsp)", found_cfa_type);
             bump_unwind_error_unsupported_cfa_register();
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, unsupported_cfa);
             return 1;
         }
 
@@ -965,6 +1005,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         if (previous_rsp == 0) {
             LOG("[error] previous_rsp should not be zero.");
             bump_unwind_error_catchall();
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, catchall);
             return 1;
         }
 
@@ -1010,6 +1051,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
 
             LOG("[error] previous_rip should not be zero. This can mean that the read failed, ret=%d while reading previous_rip_addr", err);
             bump_unwind_error_catchall();
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, catchall);
             return 1;
         }
 
@@ -1026,6 +1068,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
                     "that the read has failed %d.",
                     ret);
                 bump_unwind_error_catchall();
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, catchall);
                 return 1;
             }
         }
@@ -1069,6 +1112,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
 
             int user_pid = pid_tgid;
 
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, pc_not_covered);
             if (proc_info->is_jit_compiler) {
                 LOG("[warn] mapping not added yet to BPF maps, rbp %llx", unwind_state->bp);
                 request_refresh_process_info(ctx, user_pid);
@@ -1088,6 +1132,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         bpf_tail_call(ctx, &programs, NATIVE_UNWINDER_PROGRAM_ID);
     }
 
+    BUMP_UNWIND_FAILED_COUNT(per_process_id, truncated);
     // We couldn't get the whole stacktrace.
     bump_unwind_error_truncated();
     return 0;
@@ -1184,6 +1229,7 @@ int entrypoint(struct bpf_perf_event_data *ctx) {
     if (unwinder_config.filter_processes) {
         if (!is_debug_enabled_for_thread(per_process_id)) {
             bump_unwind_total_filter_misses();
+            BUMP_UNWIND_FAILED_COUNT(per_process_id, missed_filter);
             LOG("[debug] pid %u didn't match filter, ignoring.", per_process_id);
             return 0;
         } else {
@@ -1223,12 +1269,14 @@ int entrypoint(struct bpf_perf_event_data *ctx) {
                 LOG("[warn] IP 0x%llx not covered, mapping not found.", unwind_state->ip);
                 request_refresh_process_info(ctx, per_process_id);
                 bump_unwind_error_pc_not_covered();
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, pc_not_covered);
                 return 1;
             } else if (unwind_table_result == FIND_UNWIND_JITTED) {
                 if (!unwinder_config.mixed_stack_enabled) {
                     LOG("[warn] IP 0x%llx not covered, JIT (but mixed-mode unwinding disabled)!.", unwind_state->ip);
                     bump_unwind_error_pc_not_covered_jit();
                     bump_unwind_error_jit_mixed_mode_disabled();
+                    BUMP_UNWIND_FAILED_COUNT(per_process_id, pc_not_covered);
                     return 1;
                 }
             } else if (proc_info->is_jit_compiler) {
@@ -1237,6 +1285,7 @@ int entrypoint(struct bpf_perf_event_data *ctx) {
                 bump_unwind_error_pc_not_covered_jit();
                 // We assume this failed because of a new JIT segment so we refresh mappings to find JIT segment in updated mappings
                 bump_unwind_error_jit_unupdated_mapping();
+                BUMP_UNWIND_FAILED_COUNT(per_process_id, pc_not_covered);
                 return 1;
             }
         }
@@ -1246,6 +1295,7 @@ int entrypoint(struct bpf_perf_event_data *ctx) {
         return 0;
     }
 
+    BUMP_UNWIND_FAILED_COUNT(per_process_id, no_unwind_info);
     request_unwind_information(ctx, per_process_id);
     return 0;
 }

--- a/bpf/unwinders/rbperf.h
+++ b/bpf/unwinders/rbperf.h
@@ -36,7 +36,7 @@
 
 #define as_offset 0x10
 
-#define STRING_ON_HEAP(flags) flags&(1 << 13)
+#define STRING_ON_HEAP(flags) flags & (1 << 13)
 #define inline_method inline __attribute__((__always_inline__))
 
 // CRuby constants, from

--- a/bpf/unwinders/rbperf.h
+++ b/bpf/unwinders/rbperf.h
@@ -36,7 +36,7 @@
 
 #define as_offset 0x10
 
-#define STRING_ON_HEAP(flags) flags & (1 << 13)
+#define STRING_ON_HEAP(flags) flags&(1 << 13)
 #define inline_method inline __attribute__((__always_inline__))
 
 // CRuby constants, from

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -272,6 +272,7 @@ type Profiler interface {
 	LastProfileStartedAt() time.Time
 	LastError() error
 	ProcessLastErrors() map[int]error
+	FailedReasons() map[int]profiler.UnwindFailedReasons
 }
 
 func getRPCOptions(flags flags) []grpc.DialOption {
@@ -985,6 +986,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 			}
 
 			processLastErrors := map[string]map[int]error{}
+			unwindFailedReasons := map[string]map[int]profiler.UnwindFailedReasons{}
 
 			for _, profiler := range profilers {
 				statusPage.ActiveProfilers = append(statusPage.ActiveProfilers, template.ActiveProfiler{
@@ -994,6 +996,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 				})
 
 				processLastErrors[profiler.Name()] = profiler.ProcessLastErrors()
+				unwindFailedReasons[profiler.Name()] = profiler.FailedReasons()
 			}
 
 			processes, err := procfs.AllProcs()
@@ -1032,6 +1035,50 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 					default:
 						profilingStatus = profilerStatusInactive
 					}
+					failedReasons := unwindFailedReasons[prflr.Name()][pid]
+					failedReasonsStrs := make([]string, 0)
+					if failedReasons.PcNotCovered != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PcNotCovered: %d", failedReasons.PcNotCovered))
+					}
+					if failedReasons.NoUnwindInfo != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("NoUnwindInfo: %d", failedReasons.NoUnwindInfo))
+					}
+					if failedReasons.MissedFilter != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("MissedFilter: %d", failedReasons.MissedFilter))
+					}
+					if failedReasons.MappingNotFound != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("MappingNotFound: %d", failedReasons.MappingNotFound))
+					}
+					if failedReasons.ChunkNotFound != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("ChunkNotFound: %d", failedReasons.ChunkNotFound))
+					}
+					if failedReasons.NullUnwindTable != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("NullUnwindTable: %d", failedReasons.NullUnwindTable))
+					}
+					if failedReasons.TableNotFound != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("TableNotFound: %d", failedReasons.TableNotFound))
+					}
+					if failedReasons.RbpFailed != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("RbpFailed: %d", failedReasons.RbpFailed))
+					}
+					if failedReasons.RaFailed != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("RaFailed: %d", failedReasons.RaFailed))
+					}
+					if failedReasons.UnsupportedFpAction != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedFpAction: %d", failedReasons.UnsupportedFpAction))
+					}
+					if failedReasons.UnsupportedCfa != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedCfa: %d", failedReasons.UnsupportedCfa))
+					}
+					if failedReasons.Truncated != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Truncated: %d", failedReasons.Truncated))
+					}
+					if failedReasons.Catchall != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Catchall: %d", failedReasons.Catchall))
+					}
+					if failedReasons.InternalError != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("InternalError: %d", failedReasons.InternalError))
+					}
 
 					if !localStorageEnabled {
 						q := url.Values{}
@@ -1048,6 +1095,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 						Error:           lastError,
 						Link:            link,
 						ProfilingStatus: profilingStatus,
+						FailedReasons: failedReasonsStrs,
 					})
 				}
 			}

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -1095,7 +1095,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 						Error:           lastError,
 						Link:            link,
 						ProfilingStatus: profilingStatus,
-						FailedReasons: failedReasonsStrs,
+						FailedReasons:   failedReasonsStrs,
 					})
 				}
 			}

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -1073,8 +1073,14 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 					if failedReasons.Truncated != 0 {
 						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Truncated: %d", failedReasons.Truncated))
 					}
-					if failedReasons.Catchall != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Catchall: %d", failedReasons.Catchall))
+					if failedReasons.PreviousRspZero != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PreviousRspZero: %d", failedReasons.PreviousRspZero))
+					}
+					if failedReasons.PreviousRipZero != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PreviousRipZero: %d", failedReasons.PreviousRipZero))
+					}
+					if failedReasons.PreviousRbpZero != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PreviousRbpZero: %d", failedReasons.PreviousRbpZero))
 					}
 					if failedReasons.InternalError != 0 {
 						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("InternalError: %d", failedReasons.InternalError))

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	goruntime "runtime"
 	runtimepprof "runtime/pprof"
 	"strconv"
@@ -1038,22 +1037,47 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 					}
 					failedReasons := unwindFailedReasons[prflr.Name()][pid]
 					failedReasonsStrs := make([]string, 0)
-					v := reflect.ValueOf(failedReasons)
-					t := v.Type()
-					for i := 0; i < t.NumField(); i++ {
-						f := t.Field(i)
-						fv := v.Field(i)
-						if !fv.CanUint() {
-							http.Error(w,
-								fmt.Sprintf("internal error: field %s not uint", f.Name),
-								http.StatusInternalServerError,
-							)
-							return
-						}
-						n := fv.Uint()
-						if n > 0 {
-							failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("%s: %d", f.Name, n))
-						}
+					if failedReasons.PcNotCovered != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PcNotCovered: %d", failedReasons.PcNotCovered))
+					}
+					if failedReasons.NoUnwindInfo != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("NoUnwindInfo: %d", failedReasons.NoUnwindInfo))
+					}
+					if failedReasons.MissedFilter != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("MissedFilter: %d", failedReasons.MissedFilter))
+					}
+					if failedReasons.MappingNotFound != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("MappingNotFound: %d", failedReasons.MappingNotFound))
+					}
+					if failedReasons.ChunkNotFound != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("ChunkNotFound: %d", failedReasons.ChunkNotFound))
+					}
+					if failedReasons.NullUnwindTable != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("NullUnwindTable: %d", failedReasons.NullUnwindTable))
+					}
+					if failedReasons.TableNotFound != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("TableNotFound: %d", failedReasons.TableNotFound))
+					}
+					if failedReasons.RbpFailed != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("RbpFailed: %d", failedReasons.RbpFailed))
+					}
+					if failedReasons.RaFailed != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("RaFailed: %d", failedReasons.RaFailed))
+					}
+					if failedReasons.UnsupportedFpAction != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedFpAction: %d", failedReasons.UnsupportedFpAction))
+					}
+					if failedReasons.UnsupportedCfa != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedCfa: %d", failedReasons.UnsupportedCfa))
+					}
+					if failedReasons.Truncated != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Truncated: %d", failedReasons.Truncated))
+					}
+					if failedReasons.Catchall != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Catchall: %d", failedReasons.Catchall))
+					}
+					if failedReasons.InternalError != 0 {
+						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("InternalError: %d", failedReasons.InternalError))
 					}
 
 					if !localStorageEnabled {

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	goruntime "runtime"
 	runtimepprof "runtime/pprof"
 	"strconv"
@@ -1037,47 +1038,22 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, numCPU int) e
 					}
 					failedReasons := unwindFailedReasons[prflr.Name()][pid]
 					failedReasonsStrs := make([]string, 0)
-					if failedReasons.PcNotCovered != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PcNotCovered: %d", failedReasons.PcNotCovered))
-					}
-					if failedReasons.NoUnwindInfo != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("NoUnwindInfo: %d", failedReasons.NoUnwindInfo))
-					}
-					if failedReasons.MissedFilter != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("MissedFilter: %d", failedReasons.MissedFilter))
-					}
-					if failedReasons.MappingNotFound != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("MappingNotFound: %d", failedReasons.MappingNotFound))
-					}
-					if failedReasons.ChunkNotFound != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("ChunkNotFound: %d", failedReasons.ChunkNotFound))
-					}
-					if failedReasons.NullUnwindTable != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("NullUnwindTable: %d", failedReasons.NullUnwindTable))
-					}
-					if failedReasons.TableNotFound != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("TableNotFound: %d", failedReasons.TableNotFound))
-					}
-					if failedReasons.RbpFailed != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("RbpFailed: %d", failedReasons.RbpFailed))
-					}
-					if failedReasons.RaFailed != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("RaFailed: %d", failedReasons.RaFailed))
-					}
-					if failedReasons.UnsupportedFpAction != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedFpAction: %d", failedReasons.UnsupportedFpAction))
-					}
-					if failedReasons.UnsupportedCfa != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedCfa: %d", failedReasons.UnsupportedCfa))
-					}
-					if failedReasons.Truncated != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Truncated: %d", failedReasons.Truncated))
-					}
-					if failedReasons.Catchall != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Catchall: %d", failedReasons.Catchall))
-					}
-					if failedReasons.InternalError != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("InternalError: %d", failedReasons.InternalError))
+					v := reflect.ValueOf(failedReasons)
+					t := v.Type()
+					for i := 0; i < t.NumField(); i++ {
+						f := t.Field(i)
+						fv := v.Field(i)
+						if !fv.CanUint() {
+							http.Error(w,
+								fmt.Sprintf("internal error: field %s not uint", f.Name),
+								http.StatusInternalServerError,
+							)
+							return
+						}
+						n := fv.Uint()
+						if n > 0 {
+							failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("%s: %d", f.Name, n))
+						}
 					}
 
 					if !localStorageEnabled {

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -91,11 +91,12 @@ const (
 	JavaPIDToVMInfoMapName           = "pid_to_vm_info"
 	JavaVersionSpecificOffsetMapName = "version_specific_offsets"
 
-	UnwindInfoChunksMapName = "unwind_info_chunks"
-	UnwindTablesMapName     = "unwind_tables"
-	ProcessInfoMapName      = "process_info"
-	ProgramsMapName         = "programs"
-	PerCPUStatsMapName      = "percpu_stats"
+	UnwindInfoChunksMapName    = "unwind_info_chunks"
+	UnwindTablesMapName        = "unwind_tables"
+	ProcessInfoMapName         = "process_info"
+	ProgramsMapName            = "programs"
+	PerCPUStatsMapName         = "percpu_stats"
+	UnwindFailedReasonsMapName = "unwind_failed_reasons"
 
 	// With the current compact rows, the max items we can store in the kernels
 	// we have tested is 262k per map, which we rounded it down to 250k.
@@ -209,10 +210,11 @@ type Maps struct {
 	// Keeps track of synced process unwinder info.
 	syncedUnwinders *cache.Cache[int, runtime.UnwinderInfo]
 
-	unwindShards *libbpf.BPFMap
-	unwindTables *libbpf.BPFMap
-	programs     *libbpf.BPFMap
-	processInfo  *libbpf.BPFMap
+	unwindShards        *libbpf.BPFMap
+	unwindTables        *libbpf.BPFMap
+	programs            *libbpf.BPFMap
+	processInfo         *libbpf.BPFMap
+	unwindFailedReasons *libbpf.BPFMap
 
 	// Unwind stuff 🔬
 	processCache      *ProcessCache
@@ -1007,6 +1009,11 @@ func (m *Maps) Create() error {
 		return fmt.Errorf("get process info map: %w", err)
 	}
 
+	unwindFailedReasons, err := m.nativeModule.GetMap(UnwindFailedReasonsMapName)
+	if err != nil {
+		return fmt.Errorf("get unwind failed reasons map: %w", err)
+	}
+
 	m.debugPIDs = debugPIDs
 	m.StackCounts = stackCounts
 	m.stackTraces = stackTraces
@@ -1014,6 +1021,7 @@ func (m *Maps) Create() error {
 	m.unwindShards = unwindShards
 	m.unwindTables = unwindTables
 	m.processInfo = processInfo
+	m.unwindFailedReasons = unwindFailedReasons
 
 	if m.pyperfModule == nil && m.rbperfModule == nil && m.jvmModule == nil {
 		return nil
@@ -1362,6 +1370,10 @@ func (m *Maps) FinalizeProfileLoop() error {
 		result = errors.Join(result, err)
 	}
 
+	if err := m.cleanUnwindFailedReasons(); err != nil {
+		result = errors.Join(result, err)
+	}
+
 	return result
 }
 
@@ -1435,6 +1447,14 @@ func (m *Maps) cleanShardInfo() error {
 	return nil
 }
 
+func (m *Maps) cleanUnwindFailedReasons() error {
+	if err := clearMap(m.unwindFailedReasons); err != nil {
+		m.metrics.mapCleanErrors.WithLabelValues(m.unwindFailedReasons.Name()).Inc()
+		return err
+	}
+	return nil
+}
+
 func (m *Maps) resetMappingInfoBuffer() error {
 	// Extend length to match the capacity.
 	m.mappingInfoMemory = m.mappingInfoMemory[:cap(m.mappingInfoMemory)]
@@ -1483,6 +1503,82 @@ func (m *Maps) RefreshProcessInfo(pid int, shouldUseFPByDefault bool) {
 			level.Error(m.logger).Log("msg", "addUnwindTableForProcess failed", "err", err)
 		}
 	}
+}
+
+func (m *Maps) GetUnwindFailedReasons() (map[int]profiler.UnwindFailedReasons, error) {
+	ret := make(map[int]profiler.UnwindFailedReasons)
+	it := m.unwindFailedReasons.Iterator()
+	for it.Next() {
+		key := it.Key()
+		var pid int32
+		if err := binary.Read(bytes.NewBuffer(key), m.byteOrder, &pid); err != nil {
+			return nil, err
+		}
+		val, err := m.unwindFailedReasons.GetValue(unsafe.Pointer(&key[0]))
+		if err != nil {
+			return nil, err
+		}
+		var reasons profiler.UnwindFailedReasons
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.PcNotCovered); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.NoUnwindInfo); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.MissedFilter); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.MappingNotFound); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.ChunkNotFound); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.NullUnwindTable); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.TableNotFound); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.RbpFailed); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.RaFailed); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.UnsupportedFpAction); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.UnsupportedCfa); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.Truncated); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.Catchall); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.InternalError); err != nil {
+			return nil, err
+		}
+		val = val[4:]
+
+		ret[int(pid)] = reasons
+	}
+	return ret, nil
 }
 
 // 1. Find executable sections
@@ -1770,6 +1866,10 @@ func (m *Maps) resetUnwindState() error {
 	}
 	if err := m.cleanStacks(); err != nil {
 		level.Error(m.logger).Log("msg", "cleanStacks failed", "err", err)
+		return err
+	}
+	if err := m.cleanUnwindFailedReasons(); err != nil {
+		level.Error(m.logger).Log("msg", "cleanUnwindFailedReasons failed", "err", err)
 		return err
 	}
 

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1574,7 +1574,6 @@ func (m *Maps) GetUnwindFailedReasons() (map[int]profiler.UnwindFailedReasons, e
 		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons.InternalError); err != nil {
 			return nil, err
 		}
-		val = val[4:]
 
 		ret[int(pid)] = reasons
 	}

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"reflect"
 	goruntime "runtime"
 	"strconv"
 	"strings"
@@ -1512,7 +1511,6 @@ func (m *Maps) GetUnwindFailedReasons() (map[int]profiler.UnwindFailedReasons, e
 	for it.Next() {
 		key := it.Key()
 		var pid int32
-
 		if err := binary.Read(bytes.NewBuffer(key), m.byteOrder, &pid); err != nil {
 			return nil, err
 		}
@@ -1520,18 +1518,11 @@ func (m *Maps) GetUnwindFailedReasons() (map[int]profiler.UnwindFailedReasons, e
 		if err != nil {
 			return nil, err
 		}
-
-		buf := bytes.NewBuffer(val)
-		reasons := new(profiler.UnwindFailedReasons)
-		v := reflect.ValueOf(reasons)
-		for i := 0; i < v.Elem().NumField(); i++ {
-			fv := v.Elem().Field(i)
-			if err := binary.Read(buf, m.byteOrder, fv.Addr().Interface()); err != nil {
-				return nil, err
-			}
+		var reasons profiler.UnwindFailedReasons
+		if err := binary.Read(bytes.NewBuffer(val), m.byteOrder, &reasons); err != nil {
+			return nil, err
 		}
-
-		ret[int(pid)] = *reasons
+		ret[int(pid)] = reasons
 	}
 	return ret, nil
 }

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -131,6 +131,7 @@ type CPU struct {
 	mtx                            *sync.RWMutex
 	lastError                      error
 	processLastErrors              map[int]error
+	failedReasons                  map[int]profiler.UnwindFailedReasons
 	processErrorTracker            *errorTracker
 	lastSuccessfulProfileStartedAt time.Time
 	lastProfileStartedAt           time.Time
@@ -193,6 +194,12 @@ func (p *CPU) ProcessLastErrors() map[int]error {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 	return p.processLastErrors
+}
+
+func (p *CPU) FailedReasons() map[int]profiler.UnwindFailedReasons {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+	return p.failedReasons
 }
 
 // loadBPFModules loads the BPF programs and maps.
@@ -909,12 +916,13 @@ func (p *CPU) Run(ctx context.Context) error {
 		}
 
 		obtainStart := time.Now()
-		rawData, err := p.obtainRawData(ctx)
+		rawData, failedReasons, err := p.obtainRawData(ctx)
 		if err != nil {
 			p.metrics.obtainAttempts.WithLabelValues(labelError).Inc()
 			level.Warn(p.logger).Log("msg", "failed to obtain profiles from eBPF maps", "err", err)
 			continue
 		}
+
 		p.metrics.obtainAttempts.WithLabelValues(labelSuccess).Inc()
 		p.metrics.obtainDuration.Observe(time.Since(obtainStart).Seconds())
 
@@ -987,11 +995,11 @@ func (p *CPU) Run(ctx context.Context) error {
 				continue
 			}
 		}
-		p.report(err, processLastErrors)
+		p.report(err, processLastErrors, failedReasons)
 	}
 }
 
-func (p *CPU) report(lastError error, processLastErrors map[int]error) {
+func (p *CPU) report(lastError error, processLastErrors map[int]error, failedReasons map[int]profiler.UnwindFailedReasons) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
@@ -1001,6 +1009,7 @@ func (p *CPU) report(lastError error, processLastErrors map[int]error) {
 	}
 	p.lastError = lastError
 	p.processLastErrors = processLastErrors
+	p.failedReasons = failedReasons
 }
 
 type (
@@ -1070,13 +1079,13 @@ func (p *CPU) updateInterpreterSymbolTable() error {
 }
 
 // obtainProfiles collects profiles from the BPF maps.
-func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
+func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, map[int]profiler.UnwindFailedReasons, error) {
 	rawData := map[profileKey]map[bpfprograms.CombinedStack]uint64{}
 
 	it := p.bpfMaps.StackCounts.Iterator()
 	for it.Next() {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		}
 
 		// This byte slice is only valid for this iteration, so it must be
@@ -1088,7 +1097,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
 		// See the comment in stackCountKey for more details.
 		if err := binary.Read(bytes.NewBuffer(keyBytes), p.byteOrder, &key); err != nil {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonKey).Inc()
-			return nil, fmt.Errorf("read stack count key: %w", err)
+			return nil, nil, fmt.Errorf("read stack count key: %w", err)
 		}
 
 		// Profile aggregation key.
@@ -1108,7 +1117,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonUser).Inc()
 			if errors.Is(userErr, bpfmaps.ErrUnrecoverable) {
 				p.metrics.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelError).Inc()
-				return nil, userErr
+				return nil, nil, userErr
 			}
 			if errors.Is(userErr, bpfmaps.ErrUnwindFailed) {
 				p.metrics.readMapAttempts.WithLabelValues(labelUser, labelNativeUnwind, labelFailed).Inc()
@@ -1135,7 +1144,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonKernel).Inc()
 			if errors.Is(kernelErr, bpfmaps.ErrUnrecoverable) {
 				p.metrics.readMapAttempts.WithLabelValues(labelKernel, labelKernelUnwind, labelError).Inc()
-				return nil, kernelErr
+				return nil, nil, kernelErr
 			}
 			if errors.Is(kernelErr, bpfmaps.ErrUnwindFailed) {
 				p.metrics.readMapAttempts.WithLabelValues(labelKernel, labelKernelUnwind, labelFailed).Inc()
@@ -1156,7 +1165,7 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
 		value, err := p.bpfMaps.ReadStackCount(keyBytes)
 		if err != nil {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonCount).Inc()
-			return nil, fmt.Errorf("read value: %w", err)
+			return nil, nil, fmt.Errorf("read value: %w", err)
 		}
 		if value == 0 {
 			p.metrics.stackDrop.WithLabelValues(labelStackDropReasonZeroCount).Inc()
@@ -1176,14 +1185,19 @@ func (p *CPU) obtainRawData(ctx context.Context) (profile.RawData, error) {
 	}
 	if it.Err() != nil {
 		p.metrics.stackDrop.WithLabelValues(labelStackDropReasonIterator).Inc()
-		return nil, fmt.Errorf("failed iterator: %w", it.Err())
+		return nil, nil, fmt.Errorf("failed iterator: %w", it.Err())
+	}
+
+	failedReasons, err := p.bpfMaps.GetUnwindFailedReasons()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if err := p.bpfMaps.FinalizeProfileLoop(); err != nil {
 		level.Warn(p.logger).Log("msg", "failed to clean BPF maps that store stacktraces", "err", err)
 	}
 
-	return preprocessRawData(rawData), nil
+	return preprocessRawData(rawData), failedReasons, nil
 }
 
 // preprocessRawData takes the raw data from the BPF maps and converts it into

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -196,6 +196,8 @@ func (p *CPU) ProcessLastErrors() map[int]error {
 	return p.processLastErrors
 }
 
+// FailedReasons gets a map of PID to reasons unwinding failed for that PID
+// during the current profiling loop.
 func (p *CPU) FailedReasons() map[int]profiler.UnwindFailedReasons {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()

--- a/pkg/profiler/noop.go
+++ b/pkg/profiler/noop.go
@@ -45,3 +45,7 @@ func (p *NoopProfiler) LastError() error {
 func (p *NoopProfiler) ProcessLastErrors() map[int]error {
 	return map[int]error{}
 }
+
+func (p *NoopProfiler) FailedReasons() map[int]UnwindFailedReasons {
+	return map[int]UnwindFailedReasons{}
+}

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -35,6 +35,45 @@ type StackID struct {
 	TID PID
 }
 
+
+// TODO[btv]
+// We should come up with a way to auto-generate
+// matching C and Go structs from one description.
+//
+// typedef struct {
+//     u32 pc_not_covered;
+//     u32 no_unwind_info;
+//     u32 missed_filter;
+//     u32 mapping_not_found;
+//     u32 chunk_not_found;
+//     u32 null_unwind_table;
+//     u32 table_not_found;
+//     u32 rbp_failed;
+//     u32 ra_failed;
+//     u32 unsupported_fp_action;
+//     u32 unsupported_cfa;
+//     u32 truncated;
+//     u32 catchall; // TODO more granular?
+//     u32 internal_error;
+// } unwind_failed_reasons_t;
+
+type UnwindFailedReasons struct {
+	PcNotCovered uint32
+	NoUnwindInfo uint32
+	MissedFilter uint32
+	MappingNotFound uint32
+	ChunkNotFound uint32
+	NullUnwindTable uint32
+	TableNotFound uint32
+	RbpFailed uint32
+	RaFailed uint32
+	UnsupportedFpAction uint32
+	UnsupportedCfa uint32
+	Truncated uint32
+	Catchall uint32
+	InternalError uint32
+}
+
 // TODO: Unify PID types.
 type ProcessInfoManager interface {
 	Fetch(ctx context.Context, pid int) (process.Info, error)

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -52,7 +52,9 @@ type StackID struct {
 //     u32 unsupported_fp_action;
 //     u32 unsupported_cfa;
 //     u32 truncated;
-//     u32 catchall; // TODO more granular?
+//     u32 previous_rsp_zero;
+//     u32 previous_rip_zero;
+//     u32 previous_rbp_zero;
 //     u32 internal_error;
 // } unwind_failed_reasons_t;
 
@@ -69,7 +71,9 @@ type UnwindFailedReasons struct {
 	UnsupportedFpAction uint32
 	UnsupportedCfa      uint32
 	Truncated           uint32
-	Catchall            uint32
+	PreviousRspZero     uint32
+	PreviousRipZero     uint32
+	PreviousRbpZero     uint32
 	InternalError       uint32
 }
 

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -35,7 +35,6 @@ type StackID struct {
 	TID PID
 }
 
-
 // TODO[btv]
 // We should come up with a way to auto-generate
 // matching C and Go structs from one description.
@@ -58,20 +57,20 @@ type StackID struct {
 // } unwind_failed_reasons_t;
 
 type UnwindFailedReasons struct {
-	PcNotCovered uint32
-	NoUnwindInfo uint32
-	MissedFilter uint32
-	MappingNotFound uint32
-	ChunkNotFound uint32
-	NullUnwindTable uint32
-	TableNotFound uint32
-	RbpFailed uint32
-	RaFailed uint32
+	PcNotCovered        uint32
+	NoUnwindInfo        uint32
+	MissedFilter        uint32
+	MappingNotFound     uint32
+	ChunkNotFound       uint32
+	NullUnwindTable     uint32
+	TableNotFound       uint32
+	RbpFailed           uint32
+	RaFailed            uint32
 	UnsupportedFpAction uint32
-	UnsupportedCfa uint32
-	Truncated uint32
-	Catchall uint32
-	InternalError uint32
+	UnsupportedCfa      uint32
+	Truncated           uint32
+	Catchall            uint32
+	InternalError       uint32
 }
 
 // TODO: Unify PID types.

--- a/pkg/template/statuspage.html
+++ b/pkg/template/statuspage.html
@@ -110,6 +110,7 @@ tr:hover {
                             {{- if .ProfileLinksEnabled }}
                             <th>Profiles</th>
                             {{- end }}
+                            <th>Unwind Failed Reasons</th>
                         </tr>
                         {{- range $process := .Processes }}
                         <tr>
@@ -137,6 +138,11 @@ tr:hover {
                                 <a title='May take up to {{ $root.ProfilingInterval }} to display' href='{{ .Link }}'>Show next profile</a></br>
                             </td>
                             {{- end }}
+                            <td>
+                              {{- range $failedReason := .FailedReasons}}
+                              <p>{{ $failedReason }}</p>
+                              {{- end}}
+                            </td>
                         </tr>
                         {{- else }}
                         <tr>

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -40,6 +40,7 @@ type Process struct {
 	ProfilingStatus string
 	Error           error
 	Link            string
+	FailedReasons []string
 }
 
 type StatusPage struct {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -40,7 +40,7 @@ type Process struct {
 	ProfilingStatus string
 	Error           error
 	Link            string
-	FailedReasons []string
+	FailedReasons   []string
 }
 
 type StatusPage struct {


### PR DESCRIPTION
Each time we return from the eBPF program without a stack, bump a counter describing the reason for doing so. In user space, every time through the profiling loop, slurp these counters and surface them in the status page.

My hope is that this will be a first step towards helping us debug why some processes are not being unwound in some user environments.

### Why?

We are repeatedly hearing from users that some processes are not being profiled in various situations and they don't know why. It's a bit hard to figure this out from just the `/metrics` output, because that is not broken down per process.

### Test Plan

Tested by looking at the status page locally
