### PR TITLE
Bump Ainur to fix Go version misdetection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,9 @@ require (
 	github.com/rzajac/flexbuf v0.14.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.29.1
-	github.com/xyproto/ainur v1.3.3
+	// waiting for https://github.com/xyproto/ainur/commit/56a434f6d3a1f291861c8604b3bbe01ef7df63d1
+	// to go into a release.
+	github.com/xyproto/ainur v1.3.4-0.20240329114820-56a434f6d3a1
 	github.com/zcalusic/sysinfo v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0h
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tklauser/numcpus v0.7.0 h1:yjuerZP127QG9m5Zh/mSO4wqurYil27tHrqwRoRjpr4=
 github.com/tklauser/numcpus v0.7.0/go.mod h1:bb6dMVcj8A42tSE7i32fsIUCbQNllK5iDguyOZRUzAY=
-github.com/xyproto/ainur v1.3.3 h1:DjbkZg7iNblH1abwfIQG2siI0z3LOyVuWEmCq2S9GKc=
-github.com/xyproto/ainur v1.3.3/go.mod h1:Sn5x2wSx2Q9RoZHIqJr927vVeM0oKwBl4lCMG+My/rk=
+github.com/xyproto/ainur v1.3.4-0.20240329114820-56a434f6d3a1 h1:O1MasYEmTHPMKhJ5MOgfhh7cxrKuuirHoqfNrBucclQ=
+github.com/xyproto/ainur v1.3.4-0.20240329114820-56a434f6d3a1/go.mod h1:Sn5x2wSx2Q9RoZHIqJr927vVeM0oKwBl4lCMG+My/rk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
Include https://github.com/xyproto/ainur/commit/56a434f6d3a1f291861c8604b3bbe01ef7df63d1, which prevents misdetection of Go compiler version, which was causing unwinding to fail in some cases.

### Test Plan
Tested elfinfo locally with this version of ainur
