### PR TITLE
Fix unwinder loading on 6.8 kernels

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -379,7 +379,6 @@ DEFINE_COUNTER(total_filter_misses);
 static __always_inline u32 opaquify(u32 val) {
     // We use inline asm to make sure clang doesn't optimize it out
     asm volatile(
-        /* "%0 = %1\n" */
         "%0 ^= 0xffffffff\n"
         "%0 ^= 0xffffffff\n"
         : "+r"(val)

--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -353,7 +353,7 @@ DEFINE_COUNTER(total_zero_pids);
 DEFINE_COUNTER(total_kthreads);
 DEFINE_COUNTER(total_filter_misses);
 
-// Hack to  thwart the verifier's detection of variable bounds.
+// Hack to thwart the verifier's detection of variable bounds.
 //
 // In recent kernels (6.8 and above) the verifier has gotten smarter
 // in its tracking of variable bounds. For example, after an if statement like
@@ -369,7 +369,7 @@ DEFINE_COUNTER(total_filter_misses);
 // a combinatorial explosion. This causes us to blow out the kernel's budget of
 // maximum number of instructions verified on program load (currently 1M).
 //
-// `scramble` is its own inverse; thus `scramble(scramble(x))` has the same value of x.
+// `opaquify` is a no-op; thus `opaquify(x)` has the same value as `x`.
 // However, the verifier is fortunately not smart enough to realize this,
 // and will not realize the result has the same bounds as `x`, subverting the feature
 // described above.


### PR DESCRIPTION
See comments, and mailing list thread linked therein, for details. Before this change, recent kernels (6.8 and later) cannot verify the native unwinder, because improvements in the precision of register bounds tracking cause an explosion in state space resulting in exceeding the limit of 1 million instructions processed per load.

This commit works around that issue, as the comment in the code explains.
