### PR TITLE
pkg/profiler/cpu/bpf/maps: Improve too many mappings error message

### DIFF
--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1525,7 +1525,7 @@ func (m *Maps) AddUnwindTableForProcess(pid int, executableMappings unwind.Execu
 	}
 
 	if len(executableMappings) >= maxMappingsPerProcess {
-		return ErrTooManyExecutableMappings
+		return fmt.Errorf("%d max mappings per process, found %d: %w", maxMappingsPerProcess, len(executableMappings), ErrTooManyExecutableMappings)
 	}
 
 	mappingInfoMemory := m.mappingInfoMemory.Slice(mappingInfoSizeBytes)


### PR DESCRIPTION
### Why?

Every now and then we get reports about a user's process having too many mappings. As is we have to riddle about how many they have, when the error could just say it.

### What?

Include the number of mappings found in the error message.

### How?

Add it to the error message.

### Test Plan

No testing, it compiles.