### PR TITLE
Add "unwind failed" synthetic stacks

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -976,7 +976,7 @@ func (p *CPU) Run(ctx context.Context) error {
 				p.LastProfileStartedAt(),
 				samplingPeriod,
 				interpreterSymbolTable,
-			).Convert(ctx, perProcessRawData.RawSamples)
+			).Convert(ctx, perProcessRawData.RawSamples, failedReasons[pid])
 			if err != nil {
 				level.Warn(p.logger).Log("msg", "failed to convert profile to pprof", "pid", pid, "err", err)
 				processLastErrors[pid] = err


### PR DESCRIPTION
For each unwind failed reason, add a fake stack with two frames: one for a fake function named "unwind failed" and the other for a fake function whose name describes the failure reason.

This will let users see the true CPU usage of their processes in the UI, even when unwinding failed for many stacks. It will also give people an idea that something is going wrong without having to look at the status page.

### Why?
<!-- author to complete -->
<!-- Please explain to us why we need this change. -->

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->

### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan

pprof from my machine while compiling some rust software: https://pprof.me/96be0e68ef27e71e3621c163c02e2e2b
