### PR TITLE
add failed reasons stacks even when there are no other stacks in the profile

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -936,6 +936,13 @@ func (p *CPU) Run(ctx context.Context) error {
 		p.metrics.obtainDuration.Observe(time.Since(obtainStart).Seconds())
 
 		groupedRawData := make(map[int]profile.ProcessRawData)
+
+		for pid := range failedReasons {
+			groupedRawData[pid] = profile.ProcessRawData{
+				PID: profile.PID(pid),
+			}
+		}
+
 		for _, perThreadRawData := range rawData {
 			pid := int(perThreadRawData.PID)
 			data, ok := groupedRawData[pid]


### PR DESCRIPTION
### Why?

Before this change, we will skip any profiles where unwinding failed every time, without any real stacks.  

### What?
<!-- Please explain to us what does it do? Or let the copilot handle it. -->

### How?
<!-- Please explain to us how should it work? Or let the copilot handle it. -->

### Test Plan
<!-- How did you test it? How can we test it? -->
