### PR TITLE
Fix bug where event processors exit on error

### DIFF
--- a/pkg/profiler/cpu/metrics.go
+++ b/pkg/profiler/cpu/metrics.go
@@ -69,6 +69,8 @@ type metrics struct {
 	eventsReceived *prometheus.CounterVec
 	eventsLost     prometheus.Counter
 
+	refreshInfoErrors prometheus.Counter
+
 	unwindTableAddErrors     *prometheus.CounterVec
 	unwindTablePersistErrors *prometheus.CounterVec
 }
@@ -126,6 +128,13 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			prometheus.CounterOpts{
 				Name:        "parca_agent_profiler_events_lost_total",
 				Help:        "Total number of profile events lost.",
+				ConstLabels: map[string]string{"type": "cpu"},
+			},
+		),
+		refreshInfoErrors: promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Name:        "parca_agent_profiler_refresh_info_errors_total",
+				Help:        "Total number of errors when refreshing process info.",
 				ConstLabels: map[string]string{"type": "cpu"},
 			},
 		),


### PR DESCRIPTION
When there are errors in processing `prefetch` events, the goroutine that processes them would exit silently. If this happened to all the workers, the entire agent would seize up as no more events could be processed.
This commit fixes that behavior.

### Why?
It's easy to reproduce this if I run something that creates a lot of short-lived processes (e.g. C/C++/Rust compilation). The agent eventually gets into a permanently broken state.

