### PR TITLE
Oops, don't log unconditionally

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -489,8 +489,10 @@ func (p *CPU) listenEvents(ctx context.Context, eventsChan <-chan []byte, lostCh
 						p.bpfMaps.RefreshProcessInfo(pid, shouldUseFPByDefault)
 						return nil
 					}()
-					p.metrics.refreshInfoErrors.Inc()
-					level.Warn(p.logger).Log("msg", "failed to refresh process info", "pid", pid, "err", err)
+					if err != nil {
+						p.metrics.refreshInfoErrors.Inc()
+						level.Warn(p.logger).Log("msg", "failed to refresh process info", "pid", pid, "err", err)
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
We should only log an error if there is really an error... 