### PR TITLE
Add "request read" event

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -1038,12 +1038,13 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         }
 
         u64 previous_rip = 0;
+        u64 previous_rip_addr;
 
 // HACK(javierhonduco): This is an architectural shortcut we can take. As we
 // only support x86_64 at the minute, we can assume that the return address
 // is *always* 8 bytes ahead of the previous stack pointer.
 #if __TARGET_ARCH_x86
-        u64 previous_rip_addr = previous_rsp - 8;
+        previous_rip_addr = previous_rsp - 8;
         int err = bpf_probe_read_user(&previous_rip, 8, (void *)(previous_rip_addr));
         if (err < 0) {
             LOG("\t[error] Failed to read previous rip with error: %d", err);

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -256,6 +256,7 @@ type FlagsHidden struct {
 	RateLimitUnwindInfo         uint32 `default:"50" hidden:""`
 	RateLimitProcessMappings    uint32 `default:"50" hidden:""`
 	RateLimitRefreshProcessInfo uint32 `default:"50" hidden:""`
+	RateLimitRead               uint32 `default:"50" hidden:""`
 }
 
 type FlagsBPF struct {
@@ -967,6 +968,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, cpus cpuinfo.
 				RateLimitUnwindInfo:               flags.Hidden.RateLimitUnwindInfo,
 				RateLimitProcessMappings:          flags.Hidden.RateLimitProcessMappings,
 				RateLimitRefreshProcessInfo:       flags.Hidden.RateLimitRefreshProcessInfo,
+				RateLimitRead:                     flags.Hidden.RateLimitRead,
 				CollectTraceID:                    flags.CollectTraceID,
 			},
 			bpfProgramLoaded,

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -169,9 +169,10 @@ const (
 )
 
 const (
-	RequestUnwindInformation = 1 << 63
-	RequestProcessMappings   = 1 << 62
-	RequestRefreshProcInfo   = 1 << 61
+	RequestUnwindInformation byte = iota
+	RequestProcessMappings
+	RequestRefreshProcInfo
+	RequestRead
 )
 
 var (
@@ -1527,6 +1528,10 @@ func (m *Maps) GetUnwindFailedReasons() (map[int]profiler.UnwindFailedReasons, e
 		ret[int(pid)] = reasons
 	}
 	return ret, nil
+}
+
+func (m *Maps) ByteOrder() binary.ByteOrder {
+	return m.byteOrder
 }
 
 // 1. Find executable sections

--- a/pkg/profiler/cpu/bpf/metrics/collector.go
+++ b/pkg/profiler/cpu/bpf/metrics/collector.go
@@ -52,6 +52,7 @@ type unwinderStats struct {
 	EventRequestUnwindInformation  uint64
 	EventRequestProcessMappings    uint64
 	EventRequestRefreshProcessInfo uint64
+	EventRequestRead               uint64
 
 	TotalZeroPids     uint64
 	TotalKthreads     uint64

--- a/pkg/profiler/cpu/metrics.go
+++ b/pkg/profiler/cpu/metrics.go
@@ -73,6 +73,8 @@ type metrics struct {
 
 	unwindTableAddErrors     *prometheus.CounterVec
 	unwindTablePersistErrors *prometheus.CounterVec
+
+	requestReadAttempts *prometheus.CounterVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -152,6 +154,14 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 				ConstLabels: map[string]string{"type": "cpu"},
 			},
 			[]string{"error"}),
+		requestReadAttempts: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name:        "parca_agent_request_read_attempts_total",
+				Help:        "Total number of attempts to read memory to force a page to become resident",
+				ConstLabels: map[string]string{"type": "cpu"},
+			},
+			[]string{"status"},
+		),
 	}
 	m.obtainAttempts.WithLabelValues(labelSuccess)
 	m.obtainAttempts.WithLabelValues(labelError)


### PR DESCRIPTION
If a page is not mapped in a process, `bpf_probe_read_user` will not be able to read it (even if the page is resident, so reading would have only caused a minor fault).

In this case, instead of giving up, we can ask the agent to fault it into the process by reading /proc/<pid>/mem at the specified offset.

To test, compile the following program with `-O0` and attempt to profile it:

    #include <stdint.h>
    #include <stdio.h>
    #include <stdlib.h>
    #include <unistd.h>

    void x(uint64_t orig_page) {
            uint64_t this_page = ((uint64_t)(&orig_page) >> 12);

            if (this_page != orig_page) {
                    pid_t pid = fork();
                    if (pid)
                            printf("Forked child pid: %d\n", pid);
                    else
                            for (;;)
                                    ;
            } else
                    x(orig_page);
    }

    int main(int argc, char *argv[]) {
            x((uint64_t)(&argc) >> 12);
    }

This program does the following:

1. Recurses until the stack crosses a page boundary
2. Forks -- the new process will initially not have any pages mapped in its address space
3. Loops forever -- thus it will never go back to the old stack frame and read it.

This program consistently produces 100% `PreviousRipZero` errors before this commit, but with this commit, it eventually starts bieng profiled successfully.

