### PR TITLE
Run amd64 integration tests on public github actions runners

### DIFF
--- a/.github/workflows/test-integration-amd64.yml
+++ b/.github/workflows/test-integration-amd64.yml
@@ -21,7 +21,7 @@ jobs:
   skip-check:
     name: Skip check
     continue-on-error: true
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip-check.outputs.should_skip }}
     permissions:


### PR DESCRIPTION
The namespace cloud runners are nice, but a little expensive (compared to free).
