### PR TITLE
remove no-op Close statement

### DIFF
--- a/pkg/stack/unwind/unwind_table.go
+++ b/pkg/stack/unwind/unwind_table.go
@@ -204,7 +204,6 @@ func ReadFDEs(file *objectfile.ObjectFile) (frame.FrameDescriptionEntries, elf.M
 	if err != nil {
 		return nil, elf.EM_NONE, fmt.Errorf("failed to open elf: %w", err)
 	}
-	defer obj.Close()
 
 	arch := obj.Machine
 


### PR DESCRIPTION
We always use `elf.NewFile` to open elf files, so closing them is always a no-op.
