### PR TITLE
Dynamically discover offsets for finding custom labels map

### DIFF
--- a/internal/dwarf/util/info.go
+++ b/internal/dwarf/util/info.go
@@ -1,0 +1,117 @@
+package util
+
+import (
+	"debug/dwarf"
+	"fmt"
+)
+
+func ReadEntry(reader *dwarf.Reader, name string, expectedTag dwarf.Tag) (*dwarf.Entry, error) {
+	reader.Seek(0)
+	for {
+		e, err := reader.Next()
+		if e == nil {
+			return nil, err
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !e.Children {
+			continue
+		}
+		for {
+			e, err := reader.Next()
+			if e == nil {
+				return nil, err
+			}
+			if err != nil {
+				return nil, err
+			}
+			if e.Tag == 0 {
+				break
+			}
+			for _, f := range e.Field {
+				if e.Tag != expectedTag {
+					continue
+				}
+				if f.Attr == dwarf.AttrName && f.Val == name {
+					return e, nil
+				}
+			}
+			reader.SkipChildren()
+		}
+	}
+}
+
+func ReadChild(reader *dwarf.Reader, name string) (*dwarf.Entry, error) {
+	for {
+		e, err := reader.Next()
+		if e == nil || e.Tag == 0 {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range e.Field {
+			if f.Attr == dwarf.AttrName && f.Val == name {
+				return e, nil
+			}
+		}
+		reader.SkipChildren()
+	}
+}
+
+func ReadField(e *dwarf.Entry, key dwarf.Attr) any {
+	for _, f := range e.Field {
+		if f.Attr == key {
+			return f.Val
+		}
+	}
+	return nil
+}
+
+func readType(r *dwarf.Reader, e *dwarf.Entry, seen map[dwarf.Offset]struct{}) (*dwarf.Entry, error) {
+	offset := e.Offset
+	if _, found := seen[offset]; found {
+		return nil, fmt.Errorf("infinite loop detected at %d", offset)
+	}
+	seen[offset] = struct{}{}
+	t, ok := ReadField(e, dwarf.AttrType).(dwarf.Offset)
+	if !ok {
+		return nil, fmt.Errorf("type not found")
+	}
+	r.Seek(t)
+	candidate, err := r.Next()
+	if err != nil {
+		return nil, err
+	}
+	if candidate.Tag == dwarf.TagTypedef {
+		return readType(r, candidate, seen)
+	}
+	return candidate, nil
+}
+
+func ReadType(r *dwarf.Reader, e *dwarf.Entry) (*dwarf.Entry, error) {
+	return readType(r, e, make(map[dwarf.Offset]struct{}))
+}
+
+func ReadChildTypeAndOffset(r *dwarf.Reader, name string) (*dwarf.Entry, int64, error) {
+	child, err := ReadChild(r, name)
+	if err != nil {
+		return nil, 0, err
+	}
+	if child == nil {
+		return nil, 0, fmt.Errorf("field %s not found", name)
+	}
+
+	offset, ok := ReadField(child, dwarf.AttrDataMemberLoc).(int64)
+	if !ok {
+		return nil, 0, fmt.Errorf("offset not found for field %s", name)
+	}
+
+	typ, err := ReadType(r, child)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return typ, offset, nil
+}

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -704,7 +704,6 @@ func (p *CPU) onDemandUnwindInfoBatcher(ctx context.Context, requestUnwindInfoCh
 func (p *CPU) addUnwindTableForProcess(ctx context.Context, pid int) {
 	executable := fmt.Sprintf("/proc/%d/exe", pid)
 	shouldUseFPByDefault, err := p.framePointerCache.HasFramePointers(executable) // nolint:contextcheck
-
 	if err != nil {
 		// It might not exist as reading procfs is racy. If the executable has no symbols
 		// that we use as a heuristic to detect whether it has frame pointers or not,

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -1,0 +1,166 @@
+package golang
+
+import (
+	"debug/dwarf"
+	"debug/elf"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/parca-dev/parca-agent/internal/dwarf/util"
+	"github.com/parca-dev/parca-agent/pkg/cache"
+	"github.com/parca-dev/parca-agent/pkg/runtime"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type GoCustomLabelOffsets struct {
+	M      uint32
+	Curg   uint32
+	Labels uint32
+
+	HmapCount           uint32
+	HmapLog2BucketCount uint32
+	HmapBuckets         uint32
+}
+
+// TODO[btv] Someday we will also store custom label
+// offsets for other runtimes here, but for now it's just go.
+type CustomLabelOffsetsCache struct {
+	cache        *cache.Cache[string, GoCustomLabelOffsets]
+	compilerInfo *runtime.CompilerInfoManager
+}
+
+func NewCustomLabelOffsetsCache(reg prometheus.Registerer, cim *runtime.CompilerInfoManager) CustomLabelOffsetsCache {
+	return CustomLabelOffsetsCache{
+		cache: cache.NewLRUCache[string, GoCustomLabelOffsets](
+			prometheus.WrapRegistererWith(prometheus.Labels{"cache": "custom_labels"}, reg),
+			10_000,
+		),
+		compilerInfo: cim,
+	}
+}
+
+func ReadOffsets(path string) (GoCustomLabelOffsets, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	d, err := f.DWARF()
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	r := d.Reader()
+	g, err := util.ReadEntry(r, "runtime.g", dwarf.TagStructType)
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+	if g == nil {
+		return GoCustomLabelOffsets{}, fmt.Errorf("type runtime.g not found")
+	}
+
+	mPType, mOffset, err := util.ReadChildTypeAndOffset(r, "m")
+
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	if mPType.Tag != dwarf.TagPointerType {
+		return GoCustomLabelOffsets{}, fmt.Errorf("type of m in runtime.g is not a pointer")
+	}
+
+	_, err = util.ReadType(r, mPType)
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	curgPType, curgOffset, err := util.ReadChildTypeAndOffset(r, "curg")
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	if curgPType.Tag != dwarf.TagPointerType {
+		return GoCustomLabelOffsets{}, fmt.Errorf("curg type is not a pointer")
+	}
+
+	_, err = util.ReadType(r, curgPType)
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	_, labelsOffset, err := util.ReadChildTypeAndOffset(r, "labels")
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	hmap, err := util.ReadEntry(r, "runtime.hmap", dwarf.TagStructType)
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+	if hmap == nil {
+		return GoCustomLabelOffsets{}, fmt.Errorf("type runtime.hmap not found")
+	}
+
+	_, countOffset, err := util.ReadChildTypeAndOffset(r, "count")
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+	r.Seek(hmap.Offset)
+	r.Next()
+	_, bOffset, err := util.ReadChildTypeAndOffset(r, "B")
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+	r.Seek(hmap.Offset)
+	r.Next()
+	_, bucketsOffset, err := util.ReadChildTypeAndOffset(r, "buckets")
+	if err != nil {
+		return GoCustomLabelOffsets{}, err
+	}
+
+	return GoCustomLabelOffsets{
+		M:                   uint32(mOffset),
+		Curg:                uint32(curgOffset),
+		Labels:              uint32(labelsOffset),
+		HmapCount:           uint32(countOffset),
+		HmapLog2BucketCount: uint32(bOffset),
+		HmapBuckets:         uint32(bucketsOffset),
+	}, nil
+
+}
+
+func (cloc *CustomLabelOffsetsCache) Fetch(executable string) (*GoCustomLabelOffsets, error) {
+	if gclo, found := cloc.cache.Get(executable); found {
+		return &gclo, nil
+	}
+
+	compiler, err := cloc.compilerInfo.Fetch(executable)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.Contains(compiler.Type, "Go") {
+		return nil, nil
+	}
+	// custom labels were added in 1.9
+	want, err := semver.NewVersion("1.9.0")
+	if err != nil {
+		panic(err)
+	}
+	compilerVersion, err := semver.NewVersion(compiler.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse semver for the compiler (%s): %w", compiler.Version, err)
+	}
+	if compilerVersion.LessThan(want) {
+		return nil, nil
+	}
+
+	gclo, err := ReadOffsets(executable)
+	if err != nil {
+		return nil, err
+	}
+	cloc.cache.Add(executable, gclo)
+
+	return &gclo, nil
+}

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Parca Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package golang
 
 import (
@@ -7,10 +20,11 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/parca-dev/parca-agent/internal/dwarf/util"
 	"github.com/parca-dev/parca-agent/pkg/cache"
 	"github.com/parca-dev/parca-agent/pkg/runtime"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type GoCustomLabelOffsets struct {
@@ -61,7 +75,6 @@ func ReadOffsets(path string) (GoCustomLabelOffsets, error) {
 	}
 
 	mPType, mOffset, err := util.ReadChildTypeAndOffset(r, "m")
-
 	if err != nil {
 		return GoCustomLabelOffsets{}, err
 	}
@@ -127,7 +140,6 @@ func ReadOffsets(path string) (GoCustomLabelOffsets, error) {
 		HmapLog2BucketCount: uint32(bOffset),
 		HmapBuckets:         uint32(bucketsOffset),
 	}, nil
-
 }
 
 func (cloc *CustomLabelOffsetsCache) Fetch(executable string) (*GoCustomLabelOffsets, error) {


### PR DESCRIPTION
This reads the DWARF info of a Go program to discover the offsets of the map containing custom pprof labels, and passes them to the unwinder, rather than hardcoding them manually. As before, the unwinder walks this label map to discover the OTEL thread ID, if it has been saved.

Future work will include extending this to Rust as well as making it work in more exotic situations (e.g. when the Go runtime has been loaded from a shared library rather than being part of the main executable)
