### PR TITLE
bpf/unwinders/pyperf: Use an LRU map and increase the size

### DIFF
--- a/bpf/unwinders/pyperf.bpf.c
+++ b/bpf/unwinders/pyperf.bpf.c
@@ -36,8 +36,8 @@ struct {
 } programs SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 4096);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 16384);
     __type(key, pid_t);
     __type(value, InterpreterInfo);
 } pid_to_interpreter_info SEC(".maps");


### PR DESCRIPTION
In high PID churn environments we can quickly exceed 4096 PIDs, which currently is a hard limit for the agent. This both changes the map type to be an LRU so newer processes get the same chance of being profiled as old processes as well as increase the number of active python processes to 16384.

Each map entry is 26 bytes, so the total map size is around 450kb after this change.

Having this be an LRU is safe because it gets refreshed with all other process information:
* https://github.com/parca-dev/parca-agent/blob/29d408cd1f9e40c6f63524415cab462fd51cdab2/pkg/profiler/cpu/cpu.go#L523
* https://github.com/parca-dev/parca-agent/blob/29d408cd1f9e40c6f63524415cab462fd51cdab2/pkg/profiler/cpu/cpu.go#L655
* https://github.com/parca-dev/parca-agent/blob/29d408cd1f9e40c6f63524415cab462fd51cdab2/pkg/profiler/cpu/bpf/maps/maps.go#L1162
* https://github.com/parca-dev/parca-agent/blob/29d408cd1f9e40c6f63524415cab462fd51cdab2/pkg/profiler/cpu/bpf/maps/maps.go#L589