### PR TITLE
Properly get return address for leaf frames on ARM during syscalls

### DIFF
--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -22,6 +22,9 @@ typedef struct {
   u64 ip;
   u64 sp;
   u64 bp;
+#if __TARGET_ARCH_arm64
+  u64 leaf_lr;
+#endif
   u32 tail_calls;
   stack_trace_t stack;
   bool unwinding_jit;


### PR DESCRIPTION
In the leaf frame on ARM, we read the return address directly from x30. But this is wrong during syscalls, where we need to read it from the user task state, like we do for all the other registers during initial startup.

To test, run this program, which spins with high CPU in kernel mode:

```c
// kernspin.c
#include <unistd.h>

int main() {
    while (1) {
        (void)getpid();  // Repeatedly call getpid to consume CPU in kernel mode
    }
    return 0;
}
```
