### PR TITLE
Fix Python version detection

### DIFF
--- a/pkg/runtime/version.go
+++ b/pkg/runtime/version.go
@@ -73,7 +73,7 @@ func scanProcessBSSForVersion(pid int, f *os.File, loadBase uint64, rgx *regexp.
 				continue
 			}
 			data := make([]byte, sec.Size)
-			if err := CopyFromProcessMemory(pid, uintptr(loadBase+sec.Offset), data); err != nil {
+			if err := CopyFromProcessMemory(pid, uintptr(loadBase+sec.Addr), data); err != nil {
 				return "", fmt.Errorf("copy address: %w", err)
 			}
 			r := bytes.NewReader(data)


### PR DESCRIPTION
We were looking for the .bss section by parsing the ELF file and getting its address. Unfortunately, we used the `Offset` field instead, which points to a section's file offset rather than its location in memory. These can be the same, but don't have to be.

This was causing python version detection to break in at least some cases.

With this change, I am able to profile Python programs run from the python-test:3.7.17-slim container, which didn't work before.
