### PR TITLE
feat: add procfs cmdline

### DIFF
--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -185,7 +185,7 @@ type FlagsMetadata struct {
 	ContainerRuntimeSocketPath string            `help:"The filesystem path to the container runtimes socket. Leave this empty to use the defaults."`
 
 	DisableCaching       bool `default:"false" help:"Disable caching of metadata."`
-	EnableProcessCmdline bool `default:"false" help:"add /proc/[pid]/cmdline as a label."`
+	EnableProcessCmdline bool `default:"false" help:"Add /proc/[pid]/cmdline as a label, which may expose sensitive information like secrets in profiling data."`
 }
 
 // FlagsLocalStore provides local store configuration flags.

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -184,7 +184,8 @@ type FlagsMetadata struct {
 	ExternalLabels             map[string]string `help:"Label(s) to attach to all profiles."`
 	ContainerRuntimeSocketPath string            `help:"The filesystem path to the container runtimes socket. Leave this empty to use the defaults."`
 
-	DisableCaching bool `default:"false" help:"Disable caching of metadata."`
+	DisableCaching       bool `default:"false" help:"Disable caching of metadata."`
+	EnableProcessCmdline bool `default:"false" help:"add /proc/[pid]/cmdline as a label."`
 }
 
 // FlagsLocalStore provides local store configuration flags.
@@ -849,7 +850,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, cpus cpuinfo.
 		metadata.Target(flags.Node, flags.Metadata.ExternalLabels),
 		metadata.Compiler(logger, reg, pfs, compilerInfoManager),
 		metadata.Runtime(reg, pfs),
-		metadata.Process(pfs),
+		metadata.Process(pfs, flags.Metadata.EnableProcessCmdline),
 		metadata.System(),
 		metadata.PodHosts(),
 	}

--- a/pkg/metadata/process.go
+++ b/pkg/metadata/process.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/procfs"
@@ -48,6 +49,11 @@ func Process(procfs procfs.FS) Provider {
 			return nil, fmt.Errorf("failed to get comm for PID %d: %w", pid, err)
 		}
 
+		cmdline, err := p.CmdLine()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cmdline for PID %d: %w", pid, err)
+		}
+
 		executable, err := p.Executable()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get executable for PID %d: %w", pid, err)
@@ -61,6 +67,7 @@ func Process(procfs procfs.FS) Provider {
 		return model.LabelSet{
 			"cgroup_name": model.LabelValue(cgroup.Path),
 			"comm":        model.LabelValue(comm),
+			"cmdline":     model.LabelValue(strings.Join(cmdline, " ")),
 			"executable":  model.LabelValue(executable),
 			"ppid":        model.LabelValue(strconv.Itoa(stat.PPID)),
 		}, nil

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -235,7 +235,7 @@ func NewTestProfiler(
 		[]metadata.Provider{
 			metadata.Compiler(logger, reg, pfs, cim),
 			metadata.Runtime(reg, pfs),
-			metadata.Process(pfs),
+			metadata.Process(pfs, true),
 			metadata.System(),
 			metadata.PodHosts(),
 		},

--- a/test/integration/native/native_test.go
+++ b/test/integration/native/native_test.go
@@ -206,6 +206,7 @@ func TestCPUProfiler(t *testing.T) {
 				require.NotEmpty(t, sample.Profile.Mapping)
 
 				// Test expected metadata.
+				require.Equal(t, string(sample.Labels["cmdline"]), filepath.Join(testdataPath, fmt.Sprintf("out/%s/basic-cpp-no-fp-with-debuginfo", arch)))
 				require.Equal(t, string(sample.Labels["comm"]), "basic-cpp-no-fp-with-debuginfo"[:15]) // comm is limited to 16 characters including NUL.
 				require.True(t, strings.Contains(string(sample.Labels["executable"]), "basic-cpp-no-fp-with-debuginfo"))
 				require.True(t, strings.HasPrefix(string(sample.Labels["compiler"]), "GCC"))
@@ -245,6 +246,7 @@ func TestCPUProfiler(t *testing.T) {
 				require.NotEmpty(t, sample.Profile.Mapping)
 
 				// Test expected metadata.
+				require.Equal(t, string(sample.Labels["cmdline"]), filepath.Join(testdataPath, fmt.Sprintf("out/%s/basic-go 20000", arch)))
 				require.Equal(t, "basic-go", string(sample.Labels["comm"]))
 				require.True(t, strings.Contains(string(sample.Labels["executable"]), "basic-go"))
 				require.True(t, strings.HasPrefix(string(sample.Labels["compiler"]), "Go"))
@@ -289,6 +291,7 @@ func TestCPUProfiler(t *testing.T) {
 				require.NotEmpty(t, sample.Profile.Mapping)
 
 				// Test expected metadata.
+				require.Equal(t, string(sample.Labels["cmdline"]), filepath.Join(testdataPath, fmt.Sprintf("out/%s/basic-cpp-jit-no-fp", arch)))
 				require.Equal(t, string(sample.Labels["comm"]), "basic-cpp-jit-no-fp"[:15]) // comm is limited to 16 characters including NUL.
 				require.True(t, strings.Contains(string(sample.Labels["executable"]), "basic-cpp-jit-no-fp"))
 				require.True(t, strings.HasPrefix(string(sample.Labels["compiler"]), "GCC"))


### PR DESCRIPTION
### Why?
Add an extra label for distinguishing processes, especially for java processes where the `comm`s are the same.

### What?
Add a procfs label cmdline from `/proc/[pid]/cmdline`

### How?
The code is short and self-explanatory.

### Test Plan
See the modified integration test.
