### PR TITLE
fix duplicated leaf frame for dwarf unwinding

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -1081,9 +1081,6 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
             break;
         }
 
-        // Add the previously walked frame.
-        add_frame(unwind_state, unwind_state->ip);
-
         // Set unwind_state->unwinding_jit to false once we have checked for switch from JITed unwinding to DWARF unwinding
         if (unwind_state->unwinding_jit) {
             bump_unwind_success_jit_to_dwarf();
@@ -1235,6 +1232,7 @@ int native_unwind(struct bpf_perf_event_data *ctx) {
         unwind_state->bp = previous_rbp;
 
         // Frame finished! :)
+        add_frame(unwind_state, unwind_state->ip);
     }
 
     if (reached_bottom_of_stack) {


### PR DESCRIPTION
We already record the leaf frame in `set_initial_state`, so we don't need to record it again during the main unwinding loop.

The FP unwinder handles this by recording the frame that was reached in each iteration of the loop, whereas the DWARF unwinder records the frame from the _previous_ iteration of the loop. This PR changes the DWARF unwinder to match the behavior of the FP unwinder, fixing the issue.

FYI @metalmatze 