### PR TITLE
Collect custom labels

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -24,7 +24,7 @@ BPF_BUNDLE := $(OUT_DIR)/parca-agent.bpf.tar.gz
 LIBBPF_HEADERS := $(OUT_DIR)/libbpf/$(ARCH)/usr/include
 
 VMLINUX_INCLUDE_PATH := $(SHORT_ARCH)
-BPF_SRC := unwinders/native.bpf.c unwinders/go_runtime.h unwinders/hash.h unwinders/common.h unwinders/shared.h
+BPF_SRC := unwinders/native.bpf.c unwinders/go_runtime.h
 RBPERF_SRC := unwinders/rbperf.bpf.c
 PYPERF_SRC := unwinders/pyperf.bpf.c
 JVM_SRC := unwinders/jvm.bpf.c

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -24,7 +24,7 @@ BPF_BUNDLE := $(OUT_DIR)/parca-agent.bpf.tar.gz
 LIBBPF_HEADERS := $(OUT_DIR)/libbpf/$(ARCH)/usr/include
 
 VMLINUX_INCLUDE_PATH := $(SHORT_ARCH)
-BPF_SRC := unwinders/native.bpf.c unwinders/go_runtime.h
+BPF_SRC := unwinders/native.bpf.c unwinders/go_runtime.h unwinders/hash.h unwinders/common.h unwinders/shared.h
 RBPERF_SRC := unwinders/rbperf.bpf.c
 PYPERF_SRC := unwinders/pyperf.bpf.c
 JVM_SRC := unwinders/jvm.bpf.c

--- a/bpf/unwinders/common.h
+++ b/bpf/unwinders/common.h
@@ -73,4 +73,23 @@ typedef struct {
         aggregate_stacks();                                                           \
     })
 
+// These must be divisible by 8
+#define CUSTOM_LABEL_MAX_KEY_LEN 64
+#define CUSTOM_LABEL_MAX_VAL_LEN 64
+
+typedef struct custom_label {
+    unsigned key_len;
+    unsigned val_len;
+    // If we use unaligned `unsigned char` instead of `u64`
+    // buffers, the hash function becomes too complex to verify.
+    u64 key[CUSTOM_LABEL_MAX_KEY_LEN / 8];
+    u64 val[CUSTOM_LABEL_MAX_VAL_LEN / 8];
+} custom_label_t;
+
+#define MAX_CUSTOM_LABELS 16
+
+typedef struct custom_labels_array {
+    int len;
+    struct custom_label labels[MAX_CUSTOM_LABELS];
+} custom_labels_array_t;
 #endif

--- a/bpf/unwinders/hash.h
+++ b/bpf/unwinders/hash.h
@@ -1,12 +1,12 @@
-#include "common.h"
+#include "shared.h"
 
 // Avoid pulling in any other headers.
 typedef unsigned int uint32_t;
 
 // murmurhash2 from
-// https://github.com/aappleby/smhasher/blob/92cf3702fcfaadc84eb7bef59825a23e0cd84f56/src/MurmurHash2.cpp/*  */
+// https://github.com/aappleby/smhasher/blob/92cf3702fcfaadc84eb7bef59825a23e0cd84f56/src/MurmurHash2.cpp
 
-unsigned long long hash_stack(stack_trace_t *stack, int seed) {
+static __always_inline u64 hash_stack(stack_trace_t *stack, int seed) {
     const unsigned long long m = 0xc6a4a7935bd1e995LLU;
     const int r = 47;
     unsigned long long hash = seed ^ (stack->len * m);
@@ -25,3 +25,86 @@ unsigned long long hash_stack(stack_trace_t *stack, int seed) {
 
     return hash;
 }
+
+#define ROUNDUP_8(x) ((x + 7) & ~7)
+static __always_inline bool hash_custom_labels(custom_labels_array_t *lbls, int seed, u64 *out) {
+    // apply murmurhash2 as though this is an array of
+    // the number of labels (8 bytes), followed by all the key/val lengths,
+    // followed by all the keys/vals.
+    const u64 m = 0xc6a4a7935bd1e995LLU;
+    const int r = 47;
+
+    int len = 8;
+    for (int i = 0; i < MAX_CUSTOM_LABELS; ++i) {
+        if (i >= lbls->len)
+            break;
+        len += 8;
+        len += ROUNDUP_8(lbls->labels[i].key_len);
+        len += ROUNDUP_8(lbls->labels[i].val_len);
+    }
+
+    u64 h = seed ^ (len * m);
+
+    // hash the number of labels
+    {
+        u64 k = lbls->len;
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+    }
+
+    // hash each k/v len
+    for (int i = 0; i < MAX_CUSTOM_LABELS; ++i) {
+        if (i >= lbls->len)
+            break;
+        u64 k = (((u64)lbls->labels[i].key_len) << 32) | ((u64)lbls->labels[i].val_len);
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+    }
+
+    // hash each k/v
+    for (int i = 0; i < MAX_CUSTOM_LABELS; ++i) {
+        if (i >= lbls->len)
+            break;
+        custom_label_t *lbl = &lbls->labels[i];
+        u64 kl = ROUNDUP_8(lbl->key_len);
+        for (int j = 0; j < CUSTOM_LABEL_MAX_VAL_LEN / 8; ++j) {
+            if (j >= kl)
+                return false;
+            u64 k = lbl->key[j];
+            k *= m;
+            k ^= k >> r;
+            k *= m;
+
+            h ^= k;
+            h *= m;
+        }
+        u64 vl = ROUNDUP_8(lbl->val_len);
+        for (int j = 0; j < CUSTOM_LABEL_MAX_VAL_LEN / 8; ++j) {
+            if (j >= vl)
+                return false;
+            u64 k = lbl->val[j];
+            k *= m;
+            k ^= k >> r;
+            k *= m;
+
+            h ^= k;
+            h *= m;
+        }
+    }
+
+    h ^= h >> r;
+    h *= m;
+    h ^= h >> r;
+
+    *out = h;
+    return true;
+}
+#undef ROUNDUP_8

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -145,7 +145,8 @@ type flags struct {
 	RubyUnwindingDisable   bool                `default:"false" help:"Disable Ruby unwinder."`
 	JavaUnwindingDisable   bool                `default:"true"  help:"Disable Java unwinder."`
 
-	CollectTraceID bool `default:"false" help:"Attempt to collect trace ID from the process."`
+	CollectTraceID      bool `help:"[deprecated] Use --collect-custom-labels."`
+	CollectCustomLabels bool `default:"false"                                  help:"Collect goroutine-local custom labels, e.g. trace ID."`
 
 	AnalyticsOptOut bool `default:"false" help:"Opt out of sending anonymous usage statistics."`
 
@@ -578,6 +579,10 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, cpus cpuinfo.
 		return errors.New("this flag has been renamed to --bpf-verbose-logging")
 	}
 
+	if flags.CollectTraceID {
+		return errors.New("--collect-trace-id has been renamed to --collect-custom-labels")
+	}
+
 	if !isPowerOfTwo(flags.BPF.EventsBufferSize) {
 		return errors.New("the BPF events buffer size should be a power of 2")
 	}
@@ -975,7 +980,7 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, cpus cpuinfo.
 				RateLimitProcessMappings:          flags.Hidden.RateLimitProcessMappings,
 				RateLimitRefreshProcessInfo:       flags.Hidden.RateLimitRefreshProcessInfo,
 				RateLimitRead:                     flags.Hidden.RateLimitRead,
-				CollectTraceID:                    flags.CollectTraceID,
+				CollectCustomLabels:               flags.CollectCustomLabels,
 			},
 			bpfProgramLoaded,
 			ofp,

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -15,7 +15,6 @@ package pprof
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"io/fs"
 	"strconv"
@@ -191,15 +190,6 @@ const (
 	threadNameLabel = "thread_name"
 )
 
-func isNonEmptyTraceID(traceID [16]byte) bool {
-	for _, b := range traceID {
-		if b != 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // Convert converts a profile to a pprof profile. It is intended to only be
 // used once.
 func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, failedReasons profiler.UnwindFailedReasons) (*pprofprofile.Profile, []*profilestorepb.ExecutableInfo) {
@@ -298,8 +288,8 @@ func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, fa
 		if threadName != "" {
 			pprofSample.Label[threadNameLabel] = append(pprofSample.Label[threadNameLabel], threadName)
 		}
-		if isNonEmptyTraceID(sample.TraceID) {
-			pprofSample.Label["trace_id"] = append(pprofSample.Label["trace_id"], hex.EncodeToString(sample.TraceID[:]))
+		for _, lbl := range sample.CustomLabels {
+			pprofSample.Label[lbl.Key] = append(pprofSample.Label[lbl.Key], lbl.Val)
 		}
 
 		c.result.Sample = append(c.result.Sample, pprofSample)

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -34,6 +34,11 @@ type StackFrame struct {
 	Status int
 }
 
+type CustomLabel struct {
+	Key string
+	Val string
+}
+
 type RawSample struct {
 	TID         PID
 	UserStack   []StackFrame
@@ -43,7 +48,7 @@ type RawSample struct {
 	// frame.
 	InterpreterStack []StackFrame
 	Value            uint64
-	TraceID          [16]byte
+	CustomLabels     []CustomLabel
 }
 
 type RawData []ProcessRawData


### PR DESCRIPTION
This causes the agent to collect arbitrary Go trace IDs, not just `otel.traceid`.

The maximum size of keys and values is 64, and the maximum number of custom labels is 16. The maximum number of unique sets of custom labels is 1000, which we store in a map by their hash. Thus the total increase in memory usage for the native unwinder is ~2MB.