### PR TITLE
Deduplicate list of PIDs in processEventBatcher

### DIFF
--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -768,7 +770,9 @@ func processEventBatcher(ctx context.Context, eventsChannel <-chan int, duration
 			}
 			batch = append(batch, pid)
 		case <-timer.C:
-			callback(batch)
+			// remove duplicates
+			sort.Ints(batch)
+			callback(slices.Compact(batch))
 			batch = batch[:0]
 			timerOn = false
 			timer.Stop()


### PR DESCRIPTION
### Why?

If unwind info is requested for the same PID multiple times, there's no reason to repeatedly attempt to extract it, so let's just deduplicate them here.
