### PR TITLE
add the stack anyway in the case of truncation for native frames.

### DIFF
--- a/bpf/unwinders/basic_types.h
+++ b/bpf/unwinders/basic_types.h
@@ -1,3 +1,6 @@
+#ifndef __PARCA_AGENT_BASIC_TYPES_H__
+#define __PARCA_AGENT_BASIC_TYPES_H__
+
 typedef signed char __s8;
 typedef unsigned char __u8;
 typedef short int __s16;
@@ -15,3 +18,7 @@ typedef __s32 s32;
 typedef __u32 u32;
 typedef __s64 s64;
 typedef __u64 u64;
+
+typedef _Bool bool;
+
+#endif

--- a/bpf/unwinders/common.h
+++ b/bpf/unwinders/common.h
@@ -24,7 +24,8 @@
 #define MAX_STACK_DEPTH 127
 
 typedef struct {
-  u64 len;
+  u32 len;
+  bool truncated;
   u64 addresses[MAX_STACK_DEPTH];
 } stack_trace_t;
 // NOTICE: stack_t is defined in vmlinux.h.

--- a/bpf/unwinders/hash.h
+++ b/bpf/unwinders/hash.h
@@ -10,6 +10,7 @@ unsigned long long hash_stack(stack_trace_t *stack, int seed) {
   const unsigned long long m = 0xc6a4a7935bd1e995LLU;
   const int r = 47;
   unsigned long long hash = seed ^ (stack->len * m);
+  hash ^= stack->truncated;
 
   for(int i=0; i<MAX_STACK_DEPTH; i++){
     unsigned long long k = stack->addresses[i];

--- a/cmd/parca-agent/main.go
+++ b/cmd/parca-agent/main.go
@@ -1080,9 +1080,6 @@ func run(logger log.Logger, reg *prometheus.Registry, flags flags, cpus cpuinfo.
 					if failedReasons.UnsupportedCfa != 0 {
 						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("UnsupportedCfa: %d", failedReasons.UnsupportedCfa))
 					}
-					if failedReasons.Truncated != 0 {
-						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("Truncated: %d", failedReasons.Truncated))
-					}
 					if failedReasons.PreviousRspZero != 0 {
 						failedReasonsStrs = append(failedReasonsStrs, fmt.Sprintf("PreviousRspZero: %d", failedReasons.PreviousRspZero))
 					}

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -193,7 +193,7 @@ func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, fa
 	kernelAddresses := map[uint64]struct{}{}
 	for _, sample := range rawData {
 		for _, frame := range sample.KernelStack {
-			if frame.Status == profile.FRAME_STATUS_OK {
+			if frame.Status == profile.FrameStatusOk {
 				kernelAddresses[frame.Addr] = struct{}{}
 			}
 		}
@@ -219,7 +219,7 @@ func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, fa
 
 		for _, frame := range sample.KernelStack {
 			var l *pprofprofile.Location
-			if frame.Status == profile.FRAME_STATUS_OK {
+			if frame.Status == profile.FrameStatusOk {
 				l = c.addKernelLocation(c.kernelMapping, kernelSymbols, frame.Addr)
 			} else {
 				l = c.addErrorFrame(frame.Status)
@@ -229,7 +229,7 @@ func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, fa
 
 		for _, frame := range sample.InterpreterStack {
 			var l *pprofprofile.Location
-			if frame.Status == profile.FRAME_STATUS_OK {
+			if frame.Status == profile.FrameStatusOk {
 				l = c.AddUnwinderInfoLocation(frame.Addr)
 			} else {
 				l = c.addErrorFrame(frame.Status)
@@ -240,7 +240,7 @@ func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, fa
 		failedToNormalize := false
 
 		for _, frame := range sample.UserStack {
-			if frame.Status != profile.FRAME_STATUS_OK {
+			if frame.Status != profile.FrameStatusOk {
 				l := c.addErrorFrame(frame.Status)
 				pprofSample.Location = append(pprofSample.Location, l)
 				continue
@@ -395,7 +395,7 @@ func (c *Converter) addErrorFrame(
 ) *pprofprofile.Location {
 	var name string
 	switch status {
-	case profile.FRAME_STATUS_ERR_TRUNCATED:
+	case profile.FrameStatusErrTruncated:
 		name = "<truncated>"
 	default:
 		name = "<unknown error>"

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -22,14 +22,24 @@ type ProcessRawData struct {
 	RawSamples []RawSample
 }
 
+const (
+	FRAME_STATUS_OK            = 0
+	FRAME_STATUS_ERR_TRUNCATED = 1
+)
+
+type StackFrame struct {
+	Addr   uint64
+	Status int
+}
+
 type RawSample struct {
 	TID         PID
-	UserStack   []uint64
-	KernelStack []uint64
+	UserStack   []StackFrame
+	KernelStack []StackFrame
 	// The interpreter stack is formed of the ids we need to fetch
 	// from the corresponding BPF map in order to fetch the interpreter
 	// frame.
-	InterpreterStack []uint64
+	InterpreterStack []StackFrame
 	Value            uint64
 	TraceID          [16]byte
 }

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -23,8 +23,8 @@ type ProcessRawData struct {
 }
 
 const (
-	FRAME_STATUS_OK            = 0
-	FRAME_STATUS_ERR_TRUNCATED = 1
+	FrameStatusOk           = 0
+	FrameStatusErrTruncated = 1
 )
 
 type StackFrame struct {

--- a/pkg/profiler/cpu/bpf/maps/maps.go
+++ b/pkg/profiler/cpu/bpf/maps/maps.go
@@ -1330,12 +1330,12 @@ func (m *Maps) ReadStack(stackID uint64, stack []profile.StackFrame) error {
 		if i >= bpfprograms.StackDepth || i >= int(rawStackWithLength.Len) || addr == 0 {
 			break
 		}
-		stack[i] = profile.StackFrame{Addr: addr, Status: profile.FRAME_STATUS_OK}
+		stack[i] = profile.StackFrame{Addr: addr, Status: profile.FrameStatusOk}
 		i += 1
 	}
 
 	if rawStackWithLength.Truncated {
-		stack[i] = profile.StackFrame{Addr: 0, Status: profile.FRAME_STATUS_ERR_TRUNCATED}
+		stack[i] = profile.StackFrame{Addr: 0, Status: profile.FrameStatusErrTruncated}
 	}
 
 	return nil

--- a/pkg/profiler/cpu/bpf/programs/programs.go
+++ b/pkg/profiler/cpu/bpf/programs/programs.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+
+	"github.com/parca-dev/parca-agent/pkg/profile"
 )
 
 const (
-	StackDepth       = 127 // Always needs to be sync with MAX_STACK_DEPTH in BPF program.
+	StackDepth       = 128 // Always needs to be sync with MAX_STACK_DEPTH + 1 in BPF program. The +1 is because we can have an extra error frame.
 	tripleStackDepth = StackDepth * 3
 )
 
@@ -46,7 +48,7 @@ var (
 	NativeUnwinderProgramName = "native_unwind"
 )
 
-type CombinedStack [tripleStackDepth]uint64
+type CombinedStack [tripleStackDepth]profile.StackFrame
 
 func OpenNative() ([]byte, error) {
 	return open(fmt.Sprintf("objects/%s/native.bpf.o", runtime.GOARCH))

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -1194,7 +1194,7 @@ func (p *CPU) interpreterSymbolTable(samples []profile.RawSample) (profile.Inter
 		}
 
 		for _, frame := range sample.InterpreterStack {
-			if frame.Status != profile.FRAME_STATUS_OK {
+			if frame.Status != profile.FrameStatusOk {
 				continue
 			}
 			id := frame.Addr

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -1193,7 +1193,11 @@ func (p *CPU) interpreterSymbolTable(samples []profile.RawSample) (profile.Inter
 			continue
 		}
 
-		for _, id := range sample.InterpreterStack {
+		for _, frame := range sample.InterpreterStack {
+			if frame.Status != profile.FRAME_STATUS_OK {
+				continue
+			}
+			id := frame.Addr
 			if _, ok := p.interpSymTab[uint32(id)]; !ok {
 				if err := p.updateInterpreterSymbolTable(); err != nil {
 					// Return the old version of the symbol table if we failed to update it.
@@ -1358,30 +1362,31 @@ func preprocessRawData(rawData map[profileKey]map[bpfprograms.CombinedStack]uint
 			interpreterStackDepth := 0
 
 			// We count the number of frames in the stack to be able to preallocate.
-			// If an address in the stack is 0 then the stack ended.
-			for _, addr := range stack[:bpfprograms.StackDepth] {
-				if addr == 0 {
+			// If the stack frame is the default then the stack ended.
+			zero := profile.StackFrame{}
+			for _, frame := range stack[:bpfprograms.StackDepth] {
+				if frame == zero {
 					break
 				}
 				userStackDepth++
 			}
-			for _, addr := range stack[bpfprograms.StackDepth : bpfprograms.StackDepth*2] {
-				if addr == 0 {
+			for _, frame := range stack[bpfprograms.StackDepth : bpfprograms.StackDepth*2] {
+				if frame == zero {
 					break
 				}
 				kernelStackDepth++
 			}
 
-			for _, addr := range stack[bpfprograms.StackDepth*2:] {
-				if addr == 0 {
+			for _, frame := range stack[bpfprograms.StackDepth*2:] {
+				if frame == zero {
 					break
 				}
 				interpreterStackDepth++
 			}
 
-			userStack := make([]uint64, userStackDepth)
-			kernelStack := make([]uint64, kernelStackDepth)
-			interpreterStack := make([]uint64, interpreterStackDepth)
+			userStack := make([]profile.StackFrame, userStackDepth)
+			kernelStack := make([]profile.StackFrame, kernelStackDepth)
+			interpreterStack := make([]profile.StackFrame, interpreterStackDepth)
 
 			copy(userStack, stack[:userStackDepth])
 			copy(kernelStack, stack[bpfprograms.StackDepth:bpfprograms.StackDepth+kernelStackDepth])

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -70,7 +70,6 @@ type UnwindFailedReasons struct {
 	RaFailed            uint32
 	UnsupportedFpAction uint32
 	UnsupportedCfa      uint32
-	Truncated           uint32
 	PreviousRspZero     uint32
 	PreviousRipZero     uint32
 	PreviousRbpZero     uint32


### PR DESCRIPTION
### What?

Instead of giving up when a native stack is too deep, we add a synthetic error from (`<truncated>`)

### Why?

This has two benefits:

1. It lets the user see something instead of nothing for native frames. If they are most interested in the frames near the leaf, their profile will still be useful.
2. It lets us continue to unwind the interpreted stack in case we are running in a python or ruby program.
