### PR TITLE
Remove synthetic unwinder error frames from agent and instead generate them in the unwinder with more context

### DIFF
--- a/bpf/unwinders/common.h
+++ b/bpf/unwinders/common.h
@@ -38,7 +38,15 @@ typedef struct {
     char class_name[CLASS_NAME_MAXLEN];
     char method_name[METHOD_MAXLEN];
     char path[PATH_MAXLEN];
+    // Only set for errors.
+    u8 bpf_program_id_plus_one;
 } symbol_t;
+
+// Programs.
+#define NATIVE_UNWINDER_PROGRAM_ID 0
+#define RUBY_UNWINDER_PROGRAM_ID 1
+#define PYTHON_UNWINDER_PROGRAM_ID 2
+#define JAVA_UNWINDER_PROGRAM_ID 3
 
 // Use ERROR_SAMPLE to report one stack frame of an error message as an interpreter symbol.
 // class -> msg provided in macro
@@ -54,6 +62,7 @@ typedef struct {
         __builtin_strncpy(sym.path, __FILE__, sizeof(sym.path));                      \
         __builtin_strncpy(sym.method_name, __FUNCTION__, sizeof(sym.method_name));    \
         __builtin_strncpy(sym.class_name, msg, sizeof(sym.class_name));               \
+        sym.bpf_program_id_plus_one = BPF_PROGRAM + 1;                                \
         u64 id = get_symbol_id(&sym);                                                 \
         u64 lineno = __LINE__;                                                        \
         unw_state->stack.addresses[0] = (lineno << 32) | id;                          \
@@ -63,4 +72,5 @@ typedef struct {
         bpf_map_update_elem(&stack_traces, &stack_id, &unwind_state->stack, BPF_ANY); \
         aggregate_stacks();                                                           \
     })
+
 #endif

--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -17,11 +17,6 @@
 #include "go_runtime.h"
 
 /*================================ CONSTANTS =================================*/
-// Programs.
-#define NATIVE_UNWINDER_PROGRAM_ID 0
-#define RUBY_UNWINDER_PROGRAM_ID 1
-#define PYTHON_UNWINDER_PROGRAM_ID 2
-#define JAVA_UNWINDER_PROGRAM_ID 3
 
 #if __TARGET_ARCH_x86
 // Number of frames to walk per tail call iteration.
@@ -364,6 +359,9 @@ DEFINE_COUNTER(event_request_read)
 DEFINE_COUNTER(total_zero_pids);
 DEFINE_COUNTER(total_kthreads);
 DEFINE_COUNTER(total_filter_misses);
+
+// For ERROR_SAMPLE.
+static const int BPF_PROGRAM = NATIVE_UNWINDER_PROGRAM_ID;
 
 // Hack to thwart the verifier's detection of variable bounds.
 //

--- a/bpf/unwinders/pyperf.bpf.c
+++ b/bpf/unwinders/pyperf.bpf.c
@@ -176,6 +176,7 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
     InterpreterInfo *interpreter_info = bpf_map_lookup_elem(&pid_to_interpreter_info, &pid);
     if (!interpreter_info) {
         LOG("[error] interpreter_info is NULL, not a Python process or unknown Python version");
+        ERROR_SAMPLE(unwind_state, "interpreter_info was NULL");
         return 0;
     }
 
@@ -202,6 +203,7 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
         int err = bpf_probe_read_user(&state->thread_state, sizeof(state->thread_state), (void *)(long)interpreter_info->thread_state_addr);
         if (err != 0) {
             LOG("[error] failed to read interpreter_info->thread_state_addr with %d", err);
+            ERROR_SAMPLE(unwind_state, "failed read of thread_state_addr");
             goto submit_without_unwinding;
         }
         LOG("thread_state 0x%llx", state->thread_state);
@@ -220,11 +222,13 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
         // }
         if (tls_read((void *)tls_base, interpreter_info, &state->thread_state)) {
             LOG("[error] failed to read thread state from TLS 0x%lx", (unsigned long)interpreter_info->tls_key);
+            ERROR_SAMPLE(unwind_state, "failed read of TLS");
             goto submit_without_unwinding;
         }
 
         if (state->thread_state == 0) {
             LOG("[error] thread_state was NULL");
+            ERROR_SAMPLE(unwind_state, "thread_state was NULL");
             goto submit_without_unwinding;
         }
         LOG("thread_state 0x%llx", state->thread_state);
@@ -238,6 +242,7 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
     pthread_t pthread_id;
     if (bpf_probe_read_user(&pthread_id, sizeof(pthread_id), state->thread_state + offsets->py_thread_state.thread_id)) {
         LOG("[error] failed to read thread_state->thread_id");
+        ERROR_SAMPLE(unwind_state, "failed read of thread_state->thread_id");
         goto submit_without_unwinding;
     }
 
@@ -250,6 +255,7 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
         LOG("offsets->py_thread_state.frame %d", offsets->py_thread_state.frame);
         if (bpf_probe_read_user(&state->frame_ptr, sizeof(void *), state->thread_state + offsets->py_thread_state.frame)) {
             LOG("[error] failed to read thread_state->frame");
+            ERROR_SAMPLE(unwind_state, "failed read of thread_state->frame");
             goto submit_without_unwinding;
         }
     } else {
@@ -257,10 +263,12 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
         void *cframe;
         if (bpf_probe_read_user(&cframe, sizeof(cframe), (void *)(state->thread_state + offsets->py_thread_state.cframe))) {
             LOG("[error] failed to read thread_state->cframe");
+            ERROR_SAMPLE(unwind_state, "failed read of thread_state->cframe");
             goto submit_without_unwinding;
         }
         if (cframe == 0) {
             LOG("[error] cframe was NULL");
+            ERROR_SAMPLE(unwind_state, "cframe was NULL");
             goto submit_without_unwinding;
         }
         LOG("cframe 0x%llx", cframe);
@@ -270,6 +278,7 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
     }
     if (state->frame_ptr == 0) {
         LOG("[error] frame_ptr was NULL");
+        ERROR_SAMPLE(unwind_state, "frame_ptr was NULL");
         goto submit_without_unwinding;
     }
 

--- a/bpf/unwinders/pyperf.bpf.c
+++ b/bpf/unwinders/pyperf.bpf.c
@@ -95,6 +95,9 @@ struct {
         }                                              \
     })
 
+// Context for ERROR_SAMPLE.
+static const int BPF_PROGRAM = PYTHON_UNWINDER_PROGRAM_ID;
+
 // tls_read reads from the TLS associated with the provided key depending on the libc implementation.
 static inline __attribute__((__always_inline__)) int tls_read(void *tls_base, InterpreterInfo *interpreter_info, void **out) {
     LibcOffsets *libc_offsets;

--- a/bpf/unwinders/rbperf.bpf.c
+++ b/bpf/unwinders/rbperf.bpf.c
@@ -285,6 +285,7 @@ int unwind_ruby_stack(struct bpf_perf_event_data *ctx) {
         struct task_struct *task = (void *)bpf_get_current_task();
         if (task == NULL) {
             LOG("[error] task_struct was NULL");
+            ERROR_SAMPLE(unwind_state, "task_struct was NULL");
             return 0;
         }
 
@@ -307,6 +308,7 @@ int unwind_ruby_stack(struct bpf_perf_event_data *ctx) {
                 // Let's check that the start time matches what we saw before
                 if (interp_info->start_time != process_start_time) {
                     LOG("[error] the process has probably changed...");
+                    ERROR_SAMPLE(unwind_state, "task_struct was NULL");
                     return 0;
                 }
             }
@@ -320,6 +322,7 @@ int unwind_ruby_stack(struct bpf_perf_event_data *ctx) {
         RubyVersionOffsets *version_offsets = bpf_map_lookup_elem(&version_specific_offsets, &interp_info->rb_version_index);
         if (version_offsets == NULL) {
             LOG("[error] can't find offsets for version");
+            ERROR_SAMPLE(unwind_state, "offsets not found");
             return 0;
         }
 

--- a/bpf/unwinders/rbperf.bpf.c
+++ b/bpf/unwinders/rbperf.bpf.c
@@ -55,6 +55,9 @@ const volatile bool use_ringbuf = false;
 const volatile bool enable_pid_race_detector = false;
 const volatile enum rbperf_event_type event_type = RBPERF_EVENT_UNKNOWN;
 
+// For ERROR_SAMPLE
+static const int BPF_PROGRAM = RUBY_UNWINDER_PROGRAM_ID;
+
 #define LOG(fmt, ...)                                  \
     ({                                                 \
         if (verbose) {                                 \

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -18,9 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io/fs"
-	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -400,14 +398,9 @@ func (c *Converter) AddUnwinderInfoLocation(frameID uint64) *pprofprofile.Locati
 	}
 
 	mapping := c.interpreterMapping
-	for idx, prog := range bpfprograms.ProgNames {
-		if base, found := strings.CutSuffix(interpreterSymbol.Filename, ".c"); found {
-			_, file := path.Split(base)
-			if strings.HasSuffix(prog, file+".o") {
-				mapping = c.bpfProgMappings[idx]
-				break
-			}
-		}
+	if interpreterSymbol.BPFProgID != 0 {
+		// -1 because the BPFProgID is 1-indexed.
+		mapping = c.bpfProgMappings[interpreterSymbol.BPFProgID-1]
 	}
 
 	l := &pprofprofile.Location{

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -204,7 +204,7 @@ func isNonEmptyTraceID(traceID [16]byte) bool {
 
 // Convert converts a profile to a pprof profile. It is intended to only be
 // used once.
-func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, failedReasons profiler.UnwindFailedReasons) (*pprofprofile.Profile, []*profilestorepb.ExecutableInfo, error) {
+func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, failedReasons profiler.UnwindFailedReasons) (*pprofprofile.Profile, []*profilestorepb.ExecutableInfo) {
 	kernelAddresses := map[uint64]struct{}{}
 	for _, sample := range rawData {
 		for _, frame := range sample.KernelStack {
@@ -312,7 +312,7 @@ func (c *Converter) Convert(ctx context.Context, rawData []profile.RawSample, fa
 		c.executableInfos = append(c.executableInfos, &profilestorepb.ExecutableInfo{})
 	}
 
-	return c.result, c.executableInfos, nil
+	return c.result, c.executableInfos
 }
 
 func mappingForAddr(mappings []*pprofprofile.Mapping, addr uint64) int {

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -13,7 +13,9 @@
 
 package profile
 
-import "io"
+import (
+	"io"
+)
 
 type PID uint32
 
@@ -51,6 +53,7 @@ type Function struct {
 	Name       string
 	Filename   string
 	StartLine  int
+	BPFProgID  int
 }
 
 func (f Function) FullName() string {

--- a/pkg/profiler/cpu/bpf/common_headers.go
+++ b/pkg/profiler/cpu/bpf/common_headers.go
@@ -23,4 +23,5 @@ type Symbol struct {
 	ClassName  [ClassNameLen]byte
 	MethodName [MethodNameLen]byte
 	Path       [PathLen]byte
+	BPFProgID  uint8
 }

--- a/pkg/profiler/cpu/bpf/programs/programs.go
+++ b/pkg/profiler/cpu/bpf/programs/programs.go
@@ -27,6 +27,15 @@ const (
 	tripleStackDepth = StackDepth * 3
 )
 
+type ProfilerModuleType int
+
+const (
+	NativeModule ProfilerModuleType = iota
+	RbperfModule
+	PyperfModule
+	JVMModule
+)
+
 var (
 	//go:embed objects/*
 	objects embed.FS
@@ -50,20 +59,22 @@ var (
 
 type CombinedStack [tripleStackDepth]profile.StackFrame
 
+var ProgNames = []string{"native.bpf.o", "rbperf.bpf.o", "pyperf.bpf.o", "jvm.bpf.o"}
+
 func OpenNative() ([]byte, error) {
-	return open(fmt.Sprintf("objects/%s/native.bpf.o", runtime.GOARCH))
+	return open(fmt.Sprintf("objects/%s/%s", runtime.GOARCH, ProgNames[NativeModule]))
 }
 
 func OpenRbperf() ([]byte, error) {
-	return open(fmt.Sprintf("objects/%s/rbperf.bpf.o", runtime.GOARCH))
+	return open(fmt.Sprintf("objects/%s/%s", runtime.GOARCH, ProgNames[RbperfModule]))
 }
 
 func OpenPyperf() ([]byte, error) {
-	return open(fmt.Sprintf("objects/%s/pyperf.bpf.o", runtime.GOARCH))
+	return open(fmt.Sprintf("objects/%s/%s", runtime.GOARCH, ProgNames[PyperfModule]))
 }
 
 func OpenJVM() ([]byte, error) {
-	return open(fmt.Sprintf("objects/%s/jvm.bpf.o", runtime.GOARCH))
+	return open(fmt.Sprintf("objects/%s/%s", runtime.GOARCH, ProgNames[JVMModule]))
 }
 
 func open(file string) ([]byte, error) {

--- a/pkg/profiler/cpu/bpf/programs/programs.go
+++ b/pkg/profiler/cpu/bpf/programs/programs.go
@@ -18,13 +18,6 @@ import (
 	"fmt"
 	"io"
 	"runtime"
-
-	"github.com/parca-dev/parca-agent/pkg/profile"
-)
-
-const (
-	StackDepth       = 128 // Always needs to be sync with MAX_STACK_DEPTH + 1 in BPF program. The +1 is because we can have an extra error frame.
-	tripleStackDepth = StackDepth * 3
 )
 
 type ProfilerModuleType int
@@ -56,8 +49,6 @@ var (
 	ProgramName               = "entrypoint"
 	NativeUnwinderProgramName = "native_unwind"
 )
-
-type CombinedStack [tripleStackDepth]profile.StackFrame
 
 var ProgNames = []string{"native.bpf.o", "rbperf.bpf.o", "pyperf.bpf.o", "jvm.bpf.o"}
 

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -1104,7 +1104,7 @@ func (p *CPU) Run(ctx context.Context) error {
 			if err != nil {
 				level.Debug(p.logger).Log("msg", "failed to get interpreter symbol table", "pid", pid, "err", err)
 			}
-			pprof, executableInfos, err := p.profileConverter.NewConverter(
+			pprof, executableInfos := p.profileConverter.NewConverter(
 				pfs,
 				pid,
 				pi.Mappings.Executables(),
@@ -1112,11 +1112,6 @@ func (p *CPU) Run(ctx context.Context) error {
 				samplingPeriod,
 				interpreterSymbolTable,
 			).Convert(ctx, perProcessRawData.RawSamples, failedReasons[pid])
-			if err != nil {
-				level.Warn(p.logger).Log("msg", "failed to convert profile to pprof", "pid", pid, "err", err)
-				processLastErrors[pid] = err
-				continue
-			}
 
 			labelSet, err := pi.Labels(ctx)
 			if err != nil {

--- a/pkg/profiler/cpu/cpu.go
+++ b/pkg/profiler/cpu/cpu.go
@@ -1096,7 +1096,8 @@ func (p *CPU) Run(ctx context.Context) error {
 				p.metrics.profileDrop.WithLabelValues(labelProfileDropReasonProcessInfo).Inc()
 				level.Debug(p.logger).Log("msg", "failed to get process info", "pid", pid, "err", err)
 				processLastErrors[pid] = err
-				continue
+				// We used to bail here but now we keep going to get error samples and samples from
+				// short lived processes.
 			}
 
 			interpreterSymbolTable, err := p.interpreterSymbolTable(perProcessRawData.RawSamples)


### PR DESCRIPTION
The main benefit here is getting line numbers from the errors, there is roughly a couple dozen error sites so having line numbers is nice.  The symbol "class" is the error message, a little clunky but works.  Additionally we add the samples from exitted processes now instead of throwing them away.