### PR TITLE
fix incorrect zeroing of unwind_state

### DIFF
--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -1328,7 +1328,7 @@ static __always_inline bool set_initial_state(struct bpf_perf_event_data *ctx) {
     // previous values past the stack length will hash the stack to a different value in the map.
     bpf_perf_prog_read_value(ctx, (void *)&(unwind_state->stack), sizeof(unwind_state->stack));
 
-    zero_mem(unwind_state, sizeof(*unwind_state));
+    set_mem(unwind_state, 0, sizeof(*unwind_state));
 
     u64 ip = 0;
     u64 sp = 0;

--- a/bpf/unwinders/native.bpf.c
+++ b/bpf/unwinders/native.bpf.c
@@ -1327,15 +1327,8 @@ static __always_inline bool set_initial_state(struct bpf_perf_event_data *ctx) {
     // By zeroing the stack we will ensure that stack aggregates work more effectively as otherwise
     // previous values past the stack length will hash the stack to a different value in the map.
     bpf_perf_prog_read_value(ctx, (void *)&(unwind_state->stack), sizeof(unwind_state->stack));
-    // clear the unwind_state memory in 64 byte chunks, verifier pukes on big memsets
-    char *unw_space = (char *)unwind_state;
-    for (char *end = unw_space + sizeof(unwind_state); unw_space < end;) {
-        __builtin_memset(unw_space, 0, 64);
-        unw_space += 64;
-    }
-    if (sizeof(unwind_state) % 64 != 0) {
-        __builtin_memset(unw_space - 64, 0, sizeof(unwind_state) % 64);
-    }
+
+    zero_mem(unwind_state, sizeof(*unwind_state));
 
     u64 ip = 0;
     u64 sp = 0;

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -141,12 +141,13 @@ static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *k
 static __always_inline void zero_mem(void *mem, u64 size) {
   char *p = mem;
   char *end = p + size;
+  u64 zero = 0;
   while (p + 8 <= end) {
-    asm volatile("*(u64*)(%0 + 0) = 0\n" : : "r"(p) : "memory");
+    asm volatile("*(u64*)(%0 + 0x0) = %1\n" : : "r"(p), "r"(zero) : "memory");
     p += 8;
   }
   while (p < end) {
-    asm volatile("*(u8*)(%0 + 0) = 0\n" : : "r"(p) : "memory");
+    asm volatile("*(u8*)(%0 + 0x0) = %1\n" : : "r"(p), "r"(zero) : "memory");
     p += 1;
   }
 }

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -136,18 +136,17 @@ static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *k
     }                                                                                                                                                          \
   })
 
-// Like memset(mem, 0, size), but written to prevent clang
+// Like memset(mem, c, size), but written to prevent clang
 // from optimizing it to __builtin_memset which is illegal for bpf.
-static __always_inline void zero_mem(void *mem, u64 size) {
+static __always_inline void set_mem(void *mem, u8 c, u64 size) {
   char *p = mem;
   char *end = p + size;
-  u64 zero = 0;
   while (p + 8 <= end) {
-    asm volatile("*(u64*)(%0 + 0x0) = %1\n" : : "r"(p), "r"(zero) : "memory");
+    asm volatile("*(u64*)(%0 + 0x0) = %1\n" : : "r"(p), "r"(c) : "memory");
     p += 8;
   }
   while (p < end) {
-    asm volatile("*(u8*)(%0 + 0x0) = %1\n" : : "r"(p), "r"(zero) : "memory");
+    asm volatile("*(u8*)(%0 + 0x0) = %1\n" : : "r"(p), "r"(c) : "memory");
     p += 1;
   }
 }


### PR DESCRIPTION
### Why?
The original code was wrong for a few reasons (most importantly using `sizeof(ptr)` instead of `sizeof(*ptr)`).

Fixing it causes clang to replace the entire loop with a call to `__builtin_memset`, which is broken for bpf, so we write our own `zero_mem` function that can't be optimized in that way.
