### PR TITLE
Revert "memset the entire unwind_state to make sure no"

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -31,7 +31,7 @@ JVM_SRC := unwinders/jvm.bpf.c
 OUT_PID_NAMESPACE_DETECTOR_SRC := pid_namespace.bpf.c
 BPF_INCLUDES := unwinders/
 
-BPF_HEADERS := unwinders/rbperf.h unwinders/pyperf.h unwinders/jvm.h
+BPF_HEADERS := unwinders/*.h
 
 .PHONY: build
 build: clang

--- a/bpf/unwinders/common.h
+++ b/bpf/unwinders/common.h
@@ -24,9 +24,9 @@
 #define MAX_STACK_DEPTH 127
 
 typedef struct {
-  u32 len;
-  bool truncated;
-  u64 addresses[MAX_STACK_DEPTH];
+    u32 len;
+    bool truncated;
+    u64 addresses[MAX_STACK_DEPTH];
 } stack_trace_t;
 // NOTICE: stack_t is defined in vmlinux.h.
 
@@ -35,9 +35,9 @@ typedef struct {
 #define PATH_MAXLEN 128
 
 typedef struct {
-  char class_name[CLASS_NAME_MAXLEN];
-  char method_name[METHOD_MAXLEN];
-  char path[PATH_MAXLEN];
+    char class_name[CLASS_NAME_MAXLEN];
+    char method_name[METHOD_MAXLEN];
+    char path[PATH_MAXLEN];
 } symbol_t;
 
 #endif

--- a/bpf/unwinders/hash.h
+++ b/bpf/unwinders/hash.h
@@ -7,21 +7,21 @@ typedef unsigned int uint32_t;
 // https://github.com/aappleby/smhasher/blob/92cf3702fcfaadc84eb7bef59825a23e0cd84f56/src/MurmurHash2.cpp/*  */
 
 unsigned long long hash_stack(stack_trace_t *stack, int seed) {
-  const unsigned long long m = 0xc6a4a7935bd1e995LLU;
-  const int r = 47;
-  unsigned long long hash = seed ^ (stack->len * m);
-  hash ^= stack->truncated;
+    const unsigned long long m = 0xc6a4a7935bd1e995LLU;
+    const int r = 47;
+    unsigned long long hash = seed ^ (stack->len * m);
+    hash ^= stack->truncated;
 
-  for(int i=0; i<MAX_STACK_DEPTH; i++){
-    unsigned long long k = stack->addresses[i];
+    for (int i = 0; i < MAX_STACK_DEPTH; i++) {
+        unsigned long long k = stack->addresses[i];
 
-    k *= m;
-    k ^= k >> r;
-    k *= m;
+        k *= m;
+        k ^= k >> r;
+        k *= m;
 
-    hash ^= k;
-    hash *= m;
-  }
+        hash ^= k;
+        hash *= m;
+    }
 
-  return hash;
+    return hash;
 }

--- a/bpf/unwinders/jvm.bpf.c
+++ b/bpf/unwinders/jvm.bpf.c
@@ -113,17 +113,12 @@ int unwind_java_stack(struct bpf_perf_event_data *ctx) {
     GET_STATE();
 
     // Reset state.
-    state->vm_info = (VMInfo){0};
+    bpf_large_memzero((void *)state, sizeof(State));
     state->vm_info = *vm_info;
-
-    state->stack_walker_prog_call_count = 0;
 
     state->sample.tid = tid;
     state->sample.pid = pid;
     state->sample.stack_status = STACK_COMPLETE;
-    state->sample.stack = (stack_trace_t){0};
-    state->sample.stack.len = 0;
-    __builtin_memset((void *)state->sample.stack.addresses, 0, sizeof(state->sample.stack.addresses));
 
     if (vm_info->code_cache_low_addr == 0) {
         goto submit_without_unwinding;

--- a/bpf/unwinders/pyperf.bpf.c
+++ b/bpf/unwinders/pyperf.bpf.c
@@ -185,27 +185,15 @@ int unwind_python_stack(struct bpf_perf_event_data *ctx) {
     GET_STATE();
 
     // Reset state.
-    state->interpreter_info = (InterpreterInfo){0};
+    bpf_large_memzero((void *)state, sizeof(State));
     state->interpreter_info = *interpreter_info;
 
-    state->thread_state = 0;
-    state->current_pthread = 0;
-
-    // state->base_stack = base_stack;
-    state->frame_ptr = 0;
-    state->stack_walker_prog_call_count = 0;
-
-    // state->sample = (Sample){0};
     state->sample.tid = tid;
     state->sample.pid = pid;
     state->sample.stack_status = STACK_COMPLETE;
 
-    state->sample.stack = (stack_trace_t){0};
-    state->sample.stack.len = 0;
-
     // TODO(kakkoyun): Implement stack bound checks.
     // state->stack.expected_size = (base_stack - cfp) / control_frame_t_sizeof;
-    __builtin_memset((void *)state->sample.stack.addresses, 0, sizeof(state->sample.stack.addresses));
 
     // Fetch thread state.
 

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -135,3 +135,13 @@ static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *k
       }                                                                                                                                                        \
     }                                                                                                                                                          \
   })
+
+
+// HACK: On failure, bpf_perf_prog_read_value() zeroes the buffer. We ensure that this always
+// fail with a compile time assert that ensures that the struct size is different to the size
+// of the expected structure.
+#define bpf_large_memzero(_d, _l)                                                                                        \
+    ({                                                                                                                   \
+        _Static_assert(_l != sizeof(struct bpf_perf_event_value), "stack size must be different to the valid argument"); \
+        bpf_perf_prog_read_value(ctx, _d, _l);                                                                           \
+    })

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -10,132 +10,131 @@
 #define STACK_COLLISION(err) (err == -EEXIST)
 
 typedef struct {
-  int pid;
-  int tgid;
-  u64 user_stack_id;
-  u64 kernel_stack_id;
-  u64 interpreter_stack_id;
-  unsigned char trace_id[16];
+    int pid;
+    int tgid;
+    u64 user_stack_id;
+    u64 kernel_stack_id;
+    u64 interpreter_stack_id;
+    unsigned char trace_id[16];
 } stack_count_key_t;
 
 typedef struct {
-  u64 ip;
-  u64 sp;
-  u64 bp;
+    u64 ip;
+    u64 sp;
+    u64 bp;
 #if __TARGET_ARCH_arm64
-  u64 leaf_lr;
+    u64 leaf_lr;
 #endif
-  u32 tail_calls;
-  stack_trace_t stack;
-  bool unwinding_jit;
-  bool use_fp;
+    u32 tail_calls;
+    stack_trace_t stack;
+    bool unwinding_jit;
+    bool use_fp;
 
-  u64 unwinder_type;
-  stack_count_key_t stack_key;
+    u64 unwinder_type;
+    stack_count_key_t stack_key;
 
-  u64 vdso_pc;
-  u64 vdso_sp;
+    u64 vdso_pc;
+    u64 vdso_sp;
 } unwind_state_t;
 
 struct {
-  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-  __uint(max_entries, 1);
-  __type(key, u32);
-  __type(value, unwind_state_t);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, unwind_state_t);
 } heap SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_HASH);
-  __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
-  __type(key, stack_count_key_t);
-  __type(value, u64);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
+    __type(key, stack_count_key_t);
+    __type(value, u64);
 } stack_counts SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_HASH);
-  __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
-  __type(key, u64);
-  __type(value, stack_trace_t);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_STACK_COUNTS_ENTRIES);
+    __type(key, u64);
+    __type(value, stack_trace_t);
 } stack_traces SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_LRU_HASH);
-  __uint(max_entries, 1); // Set in the user-space.
-  __type(key, symbol_t);
-  __type(value, u32);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 1);  // Set in the user-space.
+    __type(key, symbol_t);
+    __type(value, u32);
 } symbol_table SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-  __uint(max_entries, 1);
-  __type(key, u32);
-  __type(value, u32);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, u32);
 } symbol_index_storage SEC(".maps");
 
-const volatile int num_cpus = 200; // Hard-limit of 200 CPUs.
+const volatile int num_cpus = 200;  // Hard-limit of 200 CPUs.
 
 static inline __attribute__((__always_inline__)) u32 get_symbol_id(symbol_t *sym) {
-  int *found_id = bpf_map_lookup_elem(&symbol_table, sym);
-  if (found_id) {
-    return *found_id;
-  }
+    int *found_id = bpf_map_lookup_elem(&symbol_table, sym);
+    if (found_id) {
+        return *found_id;
+    }
 
-  u32 zero = 0;
-  u32 *sym_idx = bpf_map_lookup_elem(&symbol_index_storage, &zero);
-  if (sym_idx == NULL) {
-    // Appease the verifier, this will never fail.
-    return 0;
-  }
+    u32 zero = 0;
+    u32 *sym_idx = bpf_map_lookup_elem(&symbol_index_storage, &zero);
+    if (sym_idx == NULL) {
+        // Appease the verifier, this will never fail.
+        return 0;
+    }
 
-  // u32 idx = __sync_fetch_and_add(sym_idx, 1);
-  // The previous __sync_fetch_and_add does not seem to work in 5.4 and 5.10
-  //  > libbpf: prog 'walk_ruby_stack': -- BEGIN PROG LOAD LOG --\nBPF_STX uses reserved fields
-  //
-  // Checking for the version does not work as these branches are not pruned
-  // in older kernels, so we shard the id generation per CPU.
-  u32 idx = *sym_idx * num_cpus + bpf_get_smp_processor_id();
-  *sym_idx += 1;
+    // u32 idx = __sync_fetch_and_add(sym_idx, 1);
+    // The previous __sync_fetch_and_add does not seem to work in 5.4 and 5.10
+    //  > libbpf: prog 'walk_ruby_stack': -- BEGIN PROG LOAD LOG --\nBPF_STX uses reserved fields
+    //
+    // Checking for the version does not work as these branches are not pruned
+    // in older kernels, so we shard the id generation per CPU.
+    u32 idx = *sym_idx * num_cpus + bpf_get_smp_processor_id();
+    *sym_idx += 1;
 
-  int err;
-  err = bpf_map_update_elem(&symbol_table, sym, &idx, BPF_ANY);
-  if (err) {
-    return 0;
-  }
-  return idx;
+    int err;
+    err = bpf_map_update_elem(&symbol_table, sym, &idx, BPF_ANY);
+    if (err) {
+        return 0;
+    }
+    return idx;
 }
 
 static __always_inline void *bpf_map_lookup_or_try_init(void *map, const void *key, const void *init) {
-  void *val;
-  long err;
+    void *val;
+    long err;
 
-  val = bpf_map_lookup_elem(map, key);
-  if (val) {
-    return val;
-  }
+    val = bpf_map_lookup_elem(map, key);
+    if (val) {
+        return val;
+    }
 
-  err = bpf_map_update_elem(map, key, init, BPF_NOEXIST);
-  if (err && !STACK_COLLISION(err)) {
-    bpf_printk("[error] bpf_map_lookup_or_try_init with ret: %d", err);
-    return 0;
-  }
+    err = bpf_map_update_elem(map, key, init, BPF_NOEXIST);
+    if (err && !STACK_COLLISION(err)) {
+        bpf_printk("[error] bpf_map_lookup_or_try_init with ret: %d", err);
+        return 0;
+    }
 
-  return bpf_map_lookup_elem(map, key);
+    return bpf_map_lookup_elem(map, key);
 }
 
 // To be called once we are completely done walking stacks and we are ready to
 // aggregate them in the 'counts' map and end the execution of the BPF program(s).
-#define aggregate_stacks()                                                                                                                                     \
-  ({                                                                                                                                                           \
-    u64 zero = 0;                                                                                                                                              \
-    unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero);                                                                                          \
-    if (unwind_state != NULL) {                                                                                                                                \
-      u64 *scount = bpf_map_lookup_or_try_init(&stack_counts, &unwind_state->stack_key, &zero);                                                                \
-      if (scount) {                                                                                                                                            \
-        __sync_fetch_and_add(scount, 1);                                                                                                                       \
-      }                                                                                                                                                        \
-    }                                                                                                                                                          \
-  })
-
+#define aggregate_stacks()                                                                            \
+    ({                                                                                                \
+        u64 zero = 0;                                                                                 \
+        unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero);                             \
+        if (unwind_state != NULL) {                                                                   \
+            u64 *scount = bpf_map_lookup_or_try_init(&stack_counts, &unwind_state->stack_key, &zero); \
+            if (scount) {                                                                             \
+                __sync_fetch_and_add(scount, 1);                                                      \
+            }                                                                                         \
+        }                                                                                             \
+    })
 
 // HACK: On failure, bpf_perf_prog_read_value() zeroes the buffer. We ensure that this always
 // fail with a compile time assert that ensures that the struct size is different to the size

--- a/bpf/unwinders/tls.h
+++ b/bpf/unwinders/tls.h
@@ -10,15 +10,15 @@
 #include <bpf/bpf_core_read.h>
 
 static inline __attribute__((__always_inline__)) long unsigned int read_tls_base(struct task_struct *task) {
-  long unsigned int tls_base;
+    long unsigned int tls_base;
 // This changes depending on arch and kernel version.
 // task->thread.fs, task->thread.uw.tp_value, etc.
 #if __TARGET_ARCH_x86
-  tls_base = BPF_CORE_READ(task, thread.fsbase);
+    tls_base = BPF_CORE_READ(task, thread.fsbase);
 #elif __TARGET_ARCH_arm64
-  tls_base = BPF_CORE_READ(task, thread.uw.tp_value);
+    tls_base = BPF_CORE_READ(task, thread.uw.tp_value);
 #else
 #error "Unsupported platform"
 #endif
-  return tls_base;
+    return tls_base;
 }


### PR DESCRIPTION
This reverts commit cce2bd4700764fe242e44a30ee1bda0ac55eec4a.

Instead use the bpf_perf_prog_read_value trick for all large memzeros
