### PR TITLE
fix x86 verification issues with custom labels

### DIFF
--- a/bpf/unwinders/common.h
+++ b/bpf/unwinders/common.h
@@ -1,6 +1,10 @@
 #ifndef __LINUX_PAGE_CONSTANTS_HACK__
 #define __LINUX_PAGE_CONSTANTS_HACK__
 
+// see https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html#Stringizing
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
 // Values for x86_64 as of 6.0.18-200.
 #define TOP_OF_KERNEL_STACK_PADDING 0
 #define THREAD_SIZE_ORDER 2
@@ -73,7 +77,7 @@ typedef struct {
         aggregate_stacks();                                                           \
     })
 
-// These must be divisible by 8
+// These must be powers of 2 and divisible by 8
 #define CUSTOM_LABEL_MAX_KEY_LEN 64
 #define CUSTOM_LABEL_MAX_VAL_LEN 64
 

--- a/bpf/unwinders/common.h
+++ b/bpf/unwinders/common.h
@@ -77,7 +77,7 @@ typedef struct {
         aggregate_stacks();                                                           \
     })
 
-// These must be powers of 2 and divisible by 8
+// These must be divisible by 8
 #define CUSTOM_LABEL_MAX_KEY_LEN 64
 #define CUSTOM_LABEL_MAX_VAL_LEN 64
 

--- a/bpf/unwinders/go_runtime.h
+++ b/bpf/unwinders/go_runtime.h
@@ -238,7 +238,8 @@ static __always_inline bool get_custom_labels(struct bpf_perf_event_data *ctx, s
                 "good%=:\n"
                 : "=r"(res)
                 : "r"(lbl->val), "r"(val_len), "r"(map_value->values[i].str)
-                : "r0", "r1", "r2", "r3"
+                  // all r0-r5 are clobbered since we make a function call.
+                : "r0", "r1", "r2", "r3", "r4", "r5", "memory"
             );
             // clang-format on
             if (res) {


### PR DESCRIPTION
Rewrite a problematic section of code in assembly language to force the verifier to accept our program.

Otherwise, clang does something with this code (on x86) that is too clever for the verifier to understand.