### PR TITLE
fix wrong computation of current goroutine in kernel code on arm

### DIFF
--- a/bpf/unwinders/go_runtime.h
+++ b/bpf/unwinders/go_runtime.h
@@ -86,6 +86,7 @@ static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct g
     g_addr = state->x28;
 #endif
 
+    LOG("[debug] reading m_ptr_addr at 0x%lx + 0x%lx", g_addr, offs->m);
     void *m_ptr_addr;
     res = bpf_probe_read_user(&m_ptr_addr, sizeof(void *), (void *)(g_addr + offs->m));
     if (res < 0) {

--- a/bpf/unwinders/go_runtime.h
+++ b/bpf/unwinders/go_runtime.h
@@ -97,7 +97,9 @@ static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct g
     return m_ptr_addr;
 }
 
-static __always_inline bool get_go_vdso_state(struct bpf_perf_event_data *ctx, unwind_state_t *state, struct go_runtime_offsets *offs, u64 *vdso_sp, u64 *vdso_pc) {
+static __always_inline bool get_go_vdso_state(
+    struct bpf_perf_event_data *ctx, unwind_state_t *state, struct go_runtime_offsets *offs, u64 *vdso_sp, u64 *vdso_pc
+) {
     long res;
     size_t m_ptr_addr = (size_t)get_m_ptr(ctx, offs, state);
     if (!m_ptr_addr) {
@@ -126,7 +128,9 @@ static __always_inline bool get_go_vdso_state(struct bpf_perf_event_data *ctx, u
 // may be nil if there is no user g, such as when running in the scheduler. If
 // curg is nil, then g is either a system stack (called g0) or a signal handler
 // g (gsignal). Neither one will ever have labels.
-static __always_inline bool get_custom_labels(struct bpf_perf_event_data *ctx, unwind_state_t *state, struct go_runtime_offsets *offs, custom_labels_array_t *out) {
+static __always_inline bool get_custom_labels(
+    struct bpf_perf_event_data *ctx, unwind_state_t *state, struct go_runtime_offsets *offs, custom_labels_array_t *out
+) {
     bpf_large_memzero((void *)out, sizeof(*out));
     long res;
     size_t m_ptr_addr = (size_t)get_m_ptr(ctx, offs, state);

--- a/bpf/unwinders/go_runtime.h
+++ b/bpf/unwinders/go_runtime.h
@@ -86,7 +86,6 @@ static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct g
     g_addr = state->x28;
 #endif
 
-    LOG("trying to read m_ptr_addr from 0x%llx + 0x%llx (pc=0x%llx)", g_addr, offs->m, ctx->regs.pc);
     void *m_ptr_addr;
     res = bpf_probe_read_user(&m_ptr_addr, sizeof(void *), (void *)(g_addr + offs->m));
     if (res < 0) {

--- a/bpf/unwinders/go_runtime.h
+++ b/bpf/unwinders/go_runtime.h
@@ -67,7 +67,7 @@ static __always_inline void hex_string_to_bytes(char *str, u32 size, unsigned ch
     }
 }
 
-static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct go_runtime_offsets *offs) {
+static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct go_runtime_offsets *offs, unwind_state_t *state) {
     long res;
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     if (task == NULL) {
@@ -83,9 +83,10 @@ static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct g
         return NULL;
     }
 #elif __TARGET_ARCH_arm64
-    g_addr = ctx->regs.regs[28];
+    g_addr = state->x28;
 #endif
 
+    LOG("trying to read m_ptr_addr from 0x%llx + 0x%llx (pc=0x%llx)", g_addr, offs->m, ctx->regs.pc);
     void *m_ptr_addr;
     res = bpf_probe_read_user(&m_ptr_addr, sizeof(void *), (void *)(g_addr + offs->m));
     if (res < 0) {
@@ -96,9 +97,9 @@ static __always_inline void *get_m_ptr(struct bpf_perf_event_data *ctx, struct g
     return m_ptr_addr;
 }
 
-static __always_inline bool get_go_vdso_state(struct bpf_perf_event_data *ctx, struct go_runtime_offsets *offs, u64 *vdso_sp, u64 *vdso_pc) {
+static __always_inline bool get_go_vdso_state(struct bpf_perf_event_data *ctx, unwind_state_t *state, struct go_runtime_offsets *offs, u64 *vdso_sp, u64 *vdso_pc) {
     long res;
-    size_t m_ptr_addr = (size_t)get_m_ptr(ctx, offs);
+    size_t m_ptr_addr = (size_t)get_m_ptr(ctx, offs, state);
     if (!m_ptr_addr) {
         bpf_printk("Failed to get m");
         return false;
@@ -125,10 +126,10 @@ static __always_inline bool get_go_vdso_state(struct bpf_perf_event_data *ctx, s
 // may be nil if there is no user g, such as when running in the scheduler. If
 // curg is nil, then g is either a system stack (called g0) or a signal handler
 // g (gsignal). Neither one will ever have labels.
-static __always_inline bool get_custom_labels(struct bpf_perf_event_data *ctx, struct go_runtime_offsets *offs, custom_labels_array_t *out) {
+static __always_inline bool get_custom_labels(struct bpf_perf_event_data *ctx, unwind_state_t *state, struct go_runtime_offsets *offs, custom_labels_array_t *out) {
     bpf_large_memzero((void *)out, sizeof(*out));
     long res;
-    size_t m_ptr_addr = (size_t)get_m_ptr(ctx, offs);
+    size_t m_ptr_addr = (size_t)get_m_ptr(ctx, offs, state);
     if (!m_ptr_addr) {
         return false;
     }

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -29,7 +29,7 @@ typedef struct {
     u64 bp;
 #if __TARGET_ARCH_arm64
     u64 leaf_lr;
-    u64 x28; // value of register 28, meaningful to the Go runtime
+    u64 x28;  // value of register 28, meaningful to the Go runtime
 #endif
     u32 tail_calls;
     stack_trace_t stack;

--- a/bpf/unwinders/shared.h
+++ b/bpf/unwinders/shared.h
@@ -29,6 +29,7 @@ typedef struct {
     u64 bp;
 #if __TARGET_ARCH_arm64
     u64 leaf_lr;
+    u64 x28; // value of register 28, meaningful to the Go runtime
 #endif
     u32 tail_calls;
     stack_trace_t stack;


### PR DESCRIPTION
If we are in kernel code, the registers will have the kernel values of various registers, rather than the user-mode ones. We need to get x28 (the current goroutine register) at the beginning of unwinding the same way we do for other registers.