### PR TITLE
update clang to v18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,9 @@ jobs:
         run: ./env.sh
 
       - name: Set up Clang
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@82fd451e4380968e8336eefc5b8b9292a619de01
         with:
-          version: "14"
+          version: "18"
 
       - name: clang version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@82fd451e4380968e8336eefc5b8b9292a619de01
         with:
-          version: "18"
+          version: "18.1"
 
       - name: clang version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Clang
         uses: KyleMayes/install-llvm-action@82fd451e4380968e8336eefc5b8b9292a619de01
         with:
-          version: "18.1"
+          version: "18.1.4"
 
       - name: clang version
         run: |

--- a/bpf/unwinders/rbperf.h
+++ b/bpf/unwinders/rbperf.h
@@ -36,7 +36,7 @@
 
 #define as_offset 0x10
 
-#define STRING_ON_HEAP(flags) flags&(1 << 13)
+#define STRING_ON_HEAP(flags) flags & (1 << 13)
 #define inline_method inline __attribute__((__always_inline__))
 
 // CRuby constants, from


### PR DESCRIPTION
Update clang version.

The changes to rbperf.h are due to clang-format changes.