### PR TITLE
Increase warning level when failing to fetch unwinder info

### DIFF
--- a/pkg/process/info.go
+++ b/pkg/process/info.go
@@ -297,7 +297,7 @@ func (im *InfoManager) fetch(ctx context.Context, pid int, checkMappings bool) (
 	// we will pay the cost for the excluded one if only one of them enabled.
 	unwinderInfo, err := unwinderinfo.Fetch(proc, im.compilerInfoManager)
 	if err != nil {
-		level.Debug(im.logger).Log("msg", "failed to fetch runtime unwinder information", "err", err, "pid", pid)
+		level.Warn(im.logger).Log("msg", "failed to fetch runtime unwinder information", "err", err, "pid", pid)
 	}
 	if unwinderInfo != nil {
 		rt := unwinderInfo.Runtime()


### PR DESCRIPTION
If this happens, it's a real issue that can break a lot of functionality, so we want to see it in the logs