### PR TITLE
build: reintroduce snap packaging, test, and release flows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,14 @@ jobs:
           path: |
             deploy/manifests.tar.gz
 
+      - name: Archive generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: parca-agent-dist-release
+          if-no-files-found: error
+          path: |
+            dist/
+
       - name: Release
         uses: softprops/action-gh-release@v0.1.15
         if: startsWith(github.ref, 'refs/tags/')
@@ -97,6 +105,126 @@ jobs:
             deploy/manifests.tar.gz
             deploy/manifests/kubernetes-manifest.yaml
             deploy/manifests/openshift-manifest.yaml
+
+  snap:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    needs: artifacts
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: parca-agent-dist-release
+          path: dist
+
+      - name: Setup LXD (for Snapcraft)
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+
+      - name: Setup Snapcraft
+        run: |
+          sudo snap install snapcraft --channel 8.x/stable --classic
+
+      - name: Build snaps
+        run: |
+          # Copy the metadata.json is so snapcraft can parse it for version info
+          cp ./dist/metadata.json snap/local/metadata.json
+
+          # Build the amd64 snap
+          cp ./dist/linux-amd64_linux_amd64_v1/parca-agent snap/local/parca-agent
+          snapcraft pack --verbose --build-for amd64
+
+          # Build the arm64 snap
+          cp ./dist/linux-arm64_linux_arm64/parca-agent snap/local/parca-agent
+          snapcraft pack --verbose --build-for arm64
+
+      - name: Upload locally built snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-snaps
+          path: |
+            *.snap
+
+  test-snap:
+    name: Test Snap
+    needs: snap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch built snap
+        uses: actions/download-artifact@v4
+        with:
+          name: built-snaps
+
+      - name: Install snap & invoke Parca Agent
+        run: |
+          sudo snap install --classic --dangerous *_amd64.snap
+
+          sudo snap set parca-agent log-level=debug
+          parca-agent --help
+
+      - name: Start Parca Agent - default config
+        run: |
+          sudo snap start parca-agent
+
+          # Set some options to allow retries while Parca Agent comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+
+      - name: Configure snap - node name
+        run: |
+          sudo snap set parca-agent node=foobar
+          sudo snap restart parca-agent
+
+          # Set some options to allow retries while Parca Agent comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:7071/
+          curl ${CURL_OPTS[@]} http://localhost:7071/metrics
+
+      - name: Configure snap - http address
+        run: |
+          sudo snap set parca-agent http-address=":8081"
+          sudo snap restart parca-agent
+
+          # Set some options to allow retries while Parca comes back up
+          CURL_OPTS=(--max-time 20 --retry 5 --retry-delay 3 --retry-connrefused)
+
+          curl ${CURL_OPTS[@]} http://localhost:8081/
+          curl ${CURL_OPTS[@]} http://localhost:8081/metrics
+
+      # In case the above tests fail, dump the logs for inspection
+      - name: Dump snap service logs
+        if: failure()
+        run: |
+          sudo snap logs parca-agent -n=all
+
+  release-snap-edge:
+    name: Release Snap (latest/edge)
+    needs: test-snap
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: built-snaps
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic --channel=8.x/stable
+
+      - name: Release to latest/edge
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          snapcraft upload *_amd64.snap --release edge
+          snapcraft upload *_arm64.snap --release edge
 
   docs:
     if: startsWith(github.ref, 'refs/tags/')

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,39 @@
+# Parca Agent Snap
+
+This directory contains files used to build the [Parca Agent](https://parca.dev) snap.
+
+## Parca Agent App
+
+The snap provides a base `parca-agent` app, which can be executed as per the upstream
+documentation.
+
+You can start Parca Agent manually like so:
+
+```bash
+# Install from the 'edge' channel
+$ sudo snap install parca-agent --channel edge
+
+# Start the agent with simple defaults for testing
+parca-agent --node="foobar" --remote-store-address="localhost:7070" --remote-store-insecure
+```
+
+## Parca Agent Service
+
+Additionally, the snap provides a service for Parca Agent with a limited set of configuration
+options. You can start the service like so:
+
+```bash
+$ snap start parca-agent
+```
+
+There are a small number of config options:
+
+| Name                    | Valid Options                    | Default          | Description                                                  |
+| :---------------------- | :------------------------------- | :--------------- | :----------------------------------------------------------- |
+| `node`                  | Any string                       | `$(hostname)`    | Name node the process is running on.                         |
+| `log-level`             | `error`, `warn`, `info`, `debug` | `info`           | Log level for Parca Agent.                                   |
+| `http-address`          | Any string                       | `:7071`          | Address for HTTP server to bind to.                          |
+| `remote-store-address`  | Any string                       | `localhost:7071` | Remote store (gRPC) address to send profiles and symbols to. |
+| `remote-store-insecure` | `true`, `false`                  | `false`          | Send gRPC requests via plaintext instead of TLS.             |
+
+Config options can be set with `sudo snap set parca-agent <option>=<value>`

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2022-2024 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# We need to handle that case and reset $SNAP
+SNAP="${SNAP//\/var\/lib\/snapd/}"
+
+log_level="$(snapctl get log-level)"
+if [[ -z "$log_level" ]]; then
+    snapctl set log-level=info
+fi
+
+# Name node the process is running on. If on Kubernetes, this must match the Kubernetes node name.
+node="$(snapctl get node)"
+if [[ -z "$node" ]]; then
+    snapctl set node="$(hostname)"
+fi
+
+# Address to bind HTTP server to.
+http_address="$(snapctl get http-address)"
+if [[ -z "$http_address" ]]; then
+    snapctl set http-address=":7071"
+fi
+
+# gRPC address to send profiles and symbols to.
+remote_store="$(snapctl get remote-store-address)"
+if [[ -z "$remote_store" ]]; then
+    snapctl set remote-store-address="grpc.polarsignals.com:443"
+fi
+
+# Send gRPC requests via plaintext instead of TLS
+remote_store_insecure="$(snapctl get remote-store-insecure)"
+if [[ -z "$remote_store_insecure" ]]; then
+    snapctl set remote-store-insecure=false
+fi
+
+# Set the bearer token for the remote store
+remote_store_token="$(snapctl get remote-store-bearer-token)"
+if [[ -z "$remote_store_token" ]]; then
+    snapctl set remote-store-bearer-token=""
+fi
+
+# Set the metadata extra labels
+metadata_external_labels="$(snapctl get metadata-external-labels)"
+if [[ -z "$metadata_external_labels" ]]; then
+    snapctl set metadata-external-labels=""
+fi

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2022-2024 The Parca Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Run the configure hook which sets defaults for any config options
+"${SNAP}/meta/hooks/configure"
+
+# Grab the config options
+log_level="$(snapctl get log-level)"
+node="$(snapctl get node)"
+http_address="$(snapctl get http-address)"
+store="$(snapctl get remote-store-address)"
+insecure="$(snapctl get remote-store-insecure)"
+token="$(snapctl get remote-store-bearer-token)"
+metadata_external_labels="$(snapctl get metadata-external-labels)"
+
+# Start building an array of command line options
+opts=(
+    "--node=${node}"
+    "--log-level=${log_level}"
+    "--http-address=${http_address}"
+    "--remote-store-address=${store}"
+    "--remote-store-insecure=${insecure}"
+    "--metadata-external-labels=${metadata_external_labels}"
+)
+
+# If the token has been changed from empty, append it to the command line args
+if [[ -n "${token}" ]]; then
+    opts+=("--remote-store-bearer-token=${token}")
+fi
+
+# Run parca-agent with the gathered arguments
+exec "${SNAP}/parca-agent" "${opts[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,51 @@
+name: parca-agent
+adopt-info: local-parts
+summary: Parca Agent is an always-on sampling profiler that uses eBPF
+description: |
+  Parca Agent is an always-on sampling profiler that uses eBPF to capture raw
+  profiling data with very low overhead. It observes user-space and
+  kernel-space stacktraces 100 times per second and builds pprof formatted
+  profiles from the extracted data.
+
+  The collected data can be viewed locally via HTTP endpoints and then be
+  configured to be sent to a Parca server to be queried and analyzed over time.
+license: Apache-2.0
+contact: https://parca.dev
+issues: https://github.com/parca-dev/parca-agent/issues
+source-code: https://github.com/parca-dev/parca-agent
+website: https://parca.dev
+confinement: classic
+grade: stable
+base: core24
+compression: lzo
+platforms:
+  amd64:
+  arm64:
+
+parts:
+  local-parts:
+    plugin: dump
+    source: ./snap/local
+    source-type: local
+    build-packages:
+      - jq
+      - libjq1
+    override-build: |
+      # Set the version of Parca Agent snap based on goreleaser build
+      craftctl set version="$(cat metadata.json | jq -r '.version')"
+
+      # Copy the binary and wrapper into place
+      cp parca-agent $CRAFT_PART_INSTALL/
+      cp parca-agent-wrapper $CRAFT_PART_INSTALL/
+
+      chmod 0755 $CRAFT_PART_INSTALL/parca-agent
+      chmod 0755 $CRAFT_PART_INSTALL/parca-agent-wrapper
+
+apps:
+  parca-agent:
+    command: parca-agent
+  parca-agent-svc:
+    command: parca-agent-wrapper
+    daemon: simple
+    install-mode: disable
+    restart-condition: always


### PR DESCRIPTION
This PR reintroduces the snap package, and the test/release workflow.

Unfortunately, we cannot use the plain `goreleaser` setup for building/releasing the snap, as the project is currently using a Goreleaser Docker image, which is unable to run `snapcraft`.

That said, it makes this job slightly easier, as much of what was in place before will still work. There are a couple of places where we might need to tweak artifact paths and suchlike, but otherwise this should work.

@brancz - at the moment I've tagged on the snap build, and test, and release into one workflow to avoid too much duplication, but we can adjust if you'd prefer.