### PR TITLE
Always use git tag for container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,15 @@ jobs:
       - name: Set snapshot tag
         id: vars
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
-        run: echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: |
+          echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "git_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Push snapshot images
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: |
+          docker tag ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.git_tag }}-amd64 ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }}-amd64
+          docker tag ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.git_tag }}-arm64 ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }}-arm64
           docker push ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }}-amd64
           docker push ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }}-arm64
           docker manifest create ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }} --amend ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }}-amd64 --amend ghcr.io/parca-dev/parca-agent:${{ steps.vars.outputs.tag }}-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,9 +77,9 @@ release:
     name: parca-agent
   prerelease: auto
   draft: false
-  name_template: 'v{{ .Tag }}'
+  name_template: '{{ .Tag }}'
 dockers:
-- image_templates: ["ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-amd64"]
+- image_templates: ["ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}-amd64"]
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:
@@ -89,10 +89,10 @@ dockers:
   - --label=org.opencontainers.image.description={{ .ProjectName }}
   - --label=org.opencontainers.image.url=https://parca.dev/
   - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-  - --label=org.opencontainers.image.version={{ .Version }}
+  - --label=org.opencontainers.image.version={{ .Tag }}
   - --label=org.opencontainers.image.revision={{ .FullCommit }}
   - --label=org.opencontainers.image.licenses=Apache-2.0
-- image_templates: ["ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64"]
+- image_templates: ["ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}-arm64"]
   goarch: arm64
   dockerfile: Dockerfile
   use: buildx
@@ -103,15 +103,15 @@ dockers:
   - --label=org.opencontainers.image.description={{ .ProjectName }}
   - --label=org.opencontainers.image.url=https://parca.dev/
   - --label=org.opencontainers.image.source=https://github.com/parca-dev/{{ .ProjectName }}
-  - --label=org.opencontainers.image.version={{ .Version }}
+  - --label=org.opencontainers.image.version={{ .Tag }}
   - --label=org.opencontainers.image.revision={{ .FullCommit }}
   - --label=org.opencontainers.image.licenses=Apache-2.0
 docker_manifests:
-- name_template: ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}
+- name_template: ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}
   image_templates:
-  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-amd64
-  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64
+  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}-amd64
+  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}-arm64
 - name_template: ghcr.io/parca-dev/{{ .ProjectName }}:latest
   image_templates:
-  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-amd64
-  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Version }}-arm64
+  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}-amd64
+  - ghcr.io/parca-dev/{{ .ProjectName }}:{{ .Tag }}-arm64


### PR DESCRIPTION
Version strips the "v" prefix, which we want to be in the container image tag.