### PR TITLE
fix(snap): ensure arm64 build can be performed from an amd64 machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all crossbuild build build-debug
+.PHONY: all crossbuild build build-debug snap
 
 all: crossbuild
 
@@ -18,3 +18,12 @@ build:
 
 build-debug:
 	go build -o parca-agent-debug -buildvcs=false -ldflags="-extldflags=-static" -tags osusergo,netgo -gcflags "all=-N -l"
+
+snap: crossbuild
+	cp ./dist/metadata.json snap/local/metadata.json
+
+	cp ./dist/linux-amd64_linux_amd64_v1/parca-agent snap/local/parca-agent
+	snapcraft pack --verbose --build-for amd64
+
+	cp ./dist/linux-arm64_linux_arm64/parca-agent snap/local/parca-agent
+	snapcraft pack --verbose --build-for arm64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,8 @@ compression: lzo
 platforms:
   amd64:
   arm64:
+    build-on: [amd64, arm64]
+    build-for: [arm64]
 
 parts:
   local-parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,8 +31,14 @@ parts:
       - jq
       - libjq1
     override-build: |
-      # Set the version of Parca Agent snap based on goreleaser build
-      craftctl set version="$(cat metadata.json | jq -r '.version')"
+      # Set the version of Parca Agent snap based on goreleaser build. Use the tag if one is
+      # present, otherwise use the version field which produces a string like "HEAD-c1986c91"
+      tag="$(cat metadata.json | jq -r '.tag')"
+      if [[ "$tag" == "v0.0.0" ]]; then
+        craftctl set version="$(cat metadata.json | jq -r '.version')"
+      else
+        craftctl set version="$tag"
+      fi
 
       # Copy the binary and wrapper into place
       cp parca-agent $CRAFT_PART_INSTALL/


### PR DESCRIPTION
The primary reason for this PR is to address the [failing snap release job](https://github.com/parca-dev/parca-agent/actions/runs/10943881277/job/30384811867).

This job fails because there is no `arm64` build to upload, despite the build artifacts being fetched from the previous steps in the process.

Further investigation showed that the `snapcraft pack` for the `arm64` snap [finished abruptly](https://github.com/parca-dev/parca-agent/actions/runs/10943881277/job/30384611839#step:6:48) having not actually generated an artefact. This turns out to be a [known bug](https://github.com/canonical/craft-application/issues/225), which should be addressed in the next snapcraft release. In the mean time, we can work around by just explicitly stating that the `arm64` snap can be `built-on` an `amd64` machine.

As a drive-by, https://github.com/parca-dev/parca-agent/commit/a3fefff51e11603f5f5451832c14b92919324eb3 ensures that when there is a tag present in the goreleaser `metadata.json,` it's used to set the version of the snap accordingly.