### PR TITLE
Allow running without syscall tracepoints

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -123,6 +123,7 @@ type Flags struct {
 	Hidden    FlagsHidden    `embed:"" hidden:""           prefix:""`
 
 	BPF FlagsBPF `embed:"" prefix:"bpf-"`
+	DisableTracepoints bool `default:"false" help:"Disable kernel tracepoints. Not recommended unless the agent fails to start otherwise."`
 }
 
 type ExitCode int

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -123,7 +123,6 @@ type Flags struct {
 	Hidden    FlagsHidden    `embed:"" hidden:""           prefix:""`
 
 	BPF FlagsBPF `embed:"" prefix:"bpf-"`
-	DisableTracepoints bool `default:"false" help:"Disable kernel tracepoints. Not recommended unless the agent fails to start otherwise."`
 }
 
 type ExitCode int

--- a/main.go
+++ b/main.go
@@ -248,12 +248,8 @@ func mainWithExitCode() flags.ExitCode {
 		return flags.Failure(fmt.Sprintf("Failed to probe eBPF syscall: %v", err))
 	}
 
-	if !f.DisableTracepoints {
-		log.Info("Probing tracepoint...")
-		if err = tracer.ProbeTracepoint(); err != nil {
-			return flags.Failure("Failed to probe tracepoint: %v", err)
-		}
-		log.Info("Success")
+	if err = tracer.ProbeTracepoint(); err != nil {
+		log.Warnf("Failed to probe tracepoint: %v. Parca-agent may fail to run on some kernel versions.", err)
 	}
 
 	externalLabels := reporter.Labels{}
@@ -365,10 +361,8 @@ func mainWithExitCode() flags.ExitCode {
 		}
 	}
 
-	if !f.DisableTracepoints {
-		if err := trc.AttachSchedMonitor(); err != nil {
-			return flags.Failure("Failed to attach scheduler monitor: %v", err)
-		}
+	if err := trc.AttachSchedMonitor(); err != nil {
+		return flags.Failure("Failed to attach scheduler monitor: %v", err)
 	}
 
 	// This log line is used in our system tests to verify if that the agent has started. So if you

--- a/main.go
+++ b/main.go
@@ -248,8 +248,12 @@ func mainWithExitCode() flags.ExitCode {
 		return flags.Failure(fmt.Sprintf("Failed to probe eBPF syscall: %v", err))
 	}
 
-	if err = tracer.ProbeTracepoint(); err != nil {
-		return flags.Failure("Failed to probe tracepoint: %v", err)
+	if !f.DisableTracepoints {
+		log.Info("Probing tracepoint...")
+		if err = tracer.ProbeTracepoint(); err != nil {
+			return flags.Failure("Failed to probe tracepoint: %v", err)
+		}
+		log.Info("Success")
 	}
 
 	externalLabels := reporter.Labels{}
@@ -361,8 +365,10 @@ func mainWithExitCode() flags.ExitCode {
 		}
 	}
 
-	if err := trc.AttachSchedMonitor(); err != nil {
-		return flags.Failure("Failed to attach scheduler monitor: %v", err)
+	if !f.DisableTracepoints {
+		if err := trc.AttachSchedMonitor(); err != nil {
+			return flags.Failure("Failed to attach scheduler monitor: %v", err)
+		}
 	}
 
 	// This log line is used in our system tests to verify if that the agent has started. So if you


### PR DESCRIPTION
Currently we fail to run if tracepoints can't be set on various sub-events of /sys/kernel/debug/tracing/events/syscalls/ . Currently these are used to detect various offsets when BTF is not available.

Since some kernel configurations don't have syscall tracepoints, but _do_ have BTF info, things might still work if we just keep running here.

I have confirmed that with this patch, the agent starts up and seems to work normally on a kernel without CONFIG_FTRACE_SYSCALLS, which fails without this patch.