### PR TITLE
Ensure nulls are written for non-present labels

### DIFF
--- a/reporter/arrow.go
+++ b/reporter/arrow.go
@@ -476,6 +476,12 @@ func (w *SampleWriter) LabelAll(labelName, labelValue string) {
 	b.bd.AppendString(labelValue)
 }
 
+func (w *SampleWriter) EnsureLabelLengths() {
+	for _, b := range(w.labelBuilders) {
+		b.EnsureLength(w.Value.Len())
+	}
+}
+
 func NewLocationsWriter(mem memory.Allocator) *LocationsWriter {
 	isComplete := array.NewBuilder(mem, arrow.FixedWidthTypes.Boolean).(*array.BooleanBuilder)
 

--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -182,13 +182,13 @@ func (r *ParcaReporter) ReportTraceEvent(trace *libpf.Trace,
 		r.sampleWriter.Label(k).AppendString(v)
 	}
 
-	r.sampleWriter.EnsureLabelLengths()
-
 	buf := [16]byte{}
 	trace.Hash.PutBytes16(&buf)
 	r.sampleWriter.StacktraceID.Append(buf[:])
 
 	r.sampleWriter.Value.Append(1)
+	r.sampleWriter.EnsureLabelLengths()
+
 	r.sampleWriter.Timestamp.Append(int64(meta.Timestamp))
 }
 

--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -182,6 +182,8 @@ func (r *ParcaReporter) ReportTraceEvent(trace *libpf.Trace,
 		r.sampleWriter.Label(k).AppendString(v)
 	}
 
+	r.sampleWriter.EnsureLabelLengths()
+
 	buf := [16]byte{}
 	trace.Hash.PutBytes16(&buf)
 	r.sampleWriter.StacktraceID.Append(buf[:])


### PR DESCRIPTION
When we write some labels for a trace, we need to make sure to write nulls for all the labels that are _not_ present, so the arrow arrays are still the correct length.