### PR TITLE
Set CGO_ENABLED in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ crossbuild:
 		release --snapshot --clean --skip=publish --verbose
 
 build:
-	go build -o parca-agent -buildvcs=false -ldflags="-extldflags=-static" -tags osusergo,netgo
+	CGO_ENABLED=1 go build -o parca-agent -buildvcs=false -ldflags="-extldflags=-static" -tags osusergo,netgo
 
 build-debug:
-	go build -o parca-agent-debug -buildvcs=false -ldflags="-extldflags=-static" -tags osusergo,netgo -gcflags "all=-N -l"
+	CGO_ENABLED=1 go build -o parca-agent-debug -buildvcs=false -ldflags="-extldflags=-static" -tags osusergo,netgo -gcflags "all=-N -l"
 
 snap: crossbuild
 	cp ./dist/metadata.json snap/local/metadata.json


### PR DESCRIPTION
Without this flag, Go will silently determine whether to enable Cgo or not based on whether a program called "gcc" exists in the PATH. This is a bad default that leads to very difficult-to-understand error messages when it's not available.