### PR TITLE
Warn on failure to get container metadata

### DIFF
--- a/reporter/metadata/containermetadata.go
+++ b/reporter/metadata/containermetadata.go
@@ -560,7 +560,7 @@ func (p *containerMetadataProvider) AddMetadata(pid libpf.PID, lb *labels.Builde
 	case isContainerEnvironment(env, envDocker) && p.dockerClient != nil:
 		metadata, err := p.getDockerContainerMetadata(pidContainerID)
 		if err != nil {
-			log.Debugf("Failed to get docker container metadata for container id %v: %v",
+			log.Warnf("Failed to get docker container metadata for container id %v: %v",
 				pidContainerID, err)
 			return false
 		}


### PR DESCRIPTION
Some users are reporting that container name isn't always showing up. Let's give them a fighting chance to see what's wrong by bumping the priority of this error.