### PR TITLE
reporter: Fix io.EOF handling

### DIFF
--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -617,7 +617,7 @@ func (r *ParcaReporter) reportDataToBackend(ctx context.Context, buf *bytes.Buff
 	if err != nil && err != io.EOF {
 		return err
 	}
-	if len(resp.Record) == 0 || err == io.EOF {
+	if err == io.EOF || len(resp.Record) == 0 {
 		// The backend didn't want any more information.
 		return nil
 	}


### PR DESCRIPTION
The way the if statement was written, if there is an io.EOF error, then we still first try reading the response object, however, in the io.EOF case it's null, therefore the if statement needs to be swapped around so it would never try to read something on the nil pointer if an io.EOF error is returned.