### PR TITLE
snap: expose config-file option

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -35,5 +35,6 @@ There are a small number of config options:
 | `http-address`          | Any string                       | `:7071`          | Address for HTTP server to bind to.                          |
 | `remote-store-address`  | Any string                       | `localhost:7071` | Remote store (gRPC) address to send profiles and symbols to. |
 | `remote-store-insecure` | `true`, `false`                  | `false`          | Send gRPC requests via plaintext instead of TLS.             |
+| `config-path`           | Any string                       | ``               | Path to config file.                                         |
 
 Config options can be set with `sudo snap set parca-agent <option>=<value>`

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -59,3 +59,9 @@ metadata_external_labels="$(snapctl get metadata-external-labels)"
 if [[ -z "$metadata_external_labels" ]]; then
     snapctl set metadata-external-labels=""
 fi
+
+# Set the config file path
+config_path="$(snapctl get config-path)"
+if [[ -z "$config_path" ]]; then
+    snapctl set config-path=""
+fi

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -26,6 +26,7 @@ store="$(snapctl get remote-store-address)"
 insecure="$(snapctl get remote-store-insecure)"
 token="$(snapctl get remote-store-bearer-token)"
 metadata_external_labels="$(snapctl get metadata-external-labels)"
+config_path="$(snapctl get config-path)"
 
 # Start building an array of command line options
 opts=(
@@ -35,6 +36,7 @@ opts=(
     "--remote-store-address=${store}"
     "--remote-store-insecure=${insecure}"
     "--metadata-external-labels=${metadata_external_labels}"
+    "--config-path=${config_path}"
 )
 
 # If the token has been changed from empty, append it to the command line args


### PR DESCRIPTION
Enables passing a `config-file` flag to `parca-agent` snap