### PR TITLE
Validate that custom labels are utf-8.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,4 +154,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20250410153125-5a32c1ee04e2
+replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20250410225804-edfa6253a8b2

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20250410153125-5a32c1ee04e2 h1:LwYUA746rqSxP2K5zI+6lneLQVjOfwGDi5j6rCVeqJM=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20250410153125-5a32c1ee04e2/go.mod h1:G6CwyVZkF/90mTgEu6AVG6Qqn0gfgvpeoFiNniUBaHM=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20250410225804-edfa6253a8b2 h1:EZw+hZlMjVJQbRKNr6ZK7PfIzxLr3VMrPdhQagFuz5M=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20250410225804-edfa6253a8b2/go.mod h1:G6CwyVZkF/90mTgEu6AVG6Qqn0gfgvpeoFiNniUBaHM=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -174,17 +174,17 @@ func (r *ParcaReporter) SupportsReportTraceEvent() bool { return true }
 //
 // It returns the correctly truncated utf-8 string if possible;
 // otherwise "", false.
-func maybeFixTruncation(s string, maxLen uint) (string, bool) {
+func maybeFixTruncation(s string, maxLen int) (string, bool) {
 	if utf8.ValidString(s) {
 		return s, true
 	}
 	// maybe we truncated in the middle of a rune -- if that's the case,
 	// truncate the entire rune.
 	plausibleTruncatedRuneBegin := -1
-	if len(s) == support.CustomLabelMaxValLen {
+	if len(s) == maxLen {
 		i := 0
 		for ; i < 2; i += 1 {
-			idx := support.CustomLabelMaxValLen - i - 1
+			idx := maxLen - i - 1
 			if s[idx]&0xC0 != 0x80 {
 				plausibleTruncatedRuneBegin = idx
 				break
@@ -235,7 +235,7 @@ func (r *ParcaReporter) ReportTraceEvent(trace *libpf.Trace,
 			log.Warnf("ignoring non-UTF8 label: %s", hex.EncodeToString([]byte(k)))
 			continue
 		}
-		v, ok := maybeFixTruncation(v, support.CustomLabelMaxValLen)
+		v, ok := maybeFixTruncation(v, support.CustomLabelMaxValLen - 1)
 		if !ok {
 			log.Warnf("ignoring non-UTF8 value for label %s: %s", k, hex.EncodeToString([]byte(v)))
 			continue

--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"debug/elf"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	debuginfogrpc "buf.build/gen/go/parca-dev/parca/grpc/go/parca/debuginfo/v1alpha1/debuginfov1alpha1grpc"
 	profilestoregrpc "buf.build/gen/go/parca-dev/parca/grpc/go/parca/profilestore/v1alpha1/profilestorev1alpha1grpc"
@@ -167,6 +169,39 @@ func hashString(s string) uint32 {
 
 func (r *ParcaReporter) SupportsReportTraceEvent() bool { return true }
 
+// maybeFixTruncation fixes string truncation done at the byte level
+// (at maxLen) to be done at the rune level instead.
+//
+// It returns the correctly truncated utf-8 string if possible;
+// otherwise "", false.
+func maybeFixTruncation(s string, maxLen uint) (string, bool) {
+	if utf8.ValidString(s) {
+		return s, true
+	}
+	// maybe we truncated in the middle of a rune -- if that's the case,
+	// truncate the entire rune.
+	plausibleTruncatedRuneBegin := -1
+	if len(s) == support.CustomLabelMaxValLen {
+		i := 0
+		for ; i < 2; i += 1 {
+			idx := support.CustomLabelMaxValLen - i - 1
+			if s[idx]&0xC0 != 0x80 {
+				plausibleTruncatedRuneBegin = idx
+				break
+			}
+		}
+	}
+	if plausibleTruncatedRuneBegin != -1 {
+		s = s[0:plausibleTruncatedRuneBegin]
+		if !utf8.ValidString(s) {
+			return "", false
+		}
+	} else {
+		return "", false
+	}
+	return s, true
+}
+
 // ReportTraceEvent enqueues reported trace events for the OTLP reporter.
 func (r *ParcaReporter) ReportTraceEvent(trace *libpf.Trace,
 	meta *samples.TraceEventMeta) error {
@@ -196,6 +231,15 @@ func (r *ParcaReporter) ReportTraceEvent(trace *libpf.Trace,
 	}
 
 	for k, v := range trace.CustomLabels {
+		if !utf8.ValidString(k) {
+			log.Warnf("ignoring non-UTF8 label: %s", hex.EncodeToString([]byte(k)))
+			continue
+		}
+		v, ok := maybeFixTruncation(v, support.CustomLabelMaxValLen)
+		if !ok {
+			log.Warnf("ignoring non-UTF8 value for label %s: %s", k, hex.EncodeToString([]byte(v)))
+			continue
+		}
 		r.sampleWriter.Label(k).AppendString(v)
 	}
 

--- a/reporter/parca_reporter_test.go
+++ b/reporter/parca_reporter_test.go
@@ -1,0 +1,35 @@
+package reporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const Chinese string = "Go（又稱Golang[4]）是Google開發的一种静态强类型、編譯型、并发型，并具有垃圾回收功能的编程语言。"
+const Chinese2 string = "Linux是一种自由和开放源码的类Unix操作系统。"
+
+func TestMaybeFixTruncation(t *testing.T) {
+	for _, test := range []struct {
+		s      string
+		result string
+		ok     bool
+	}{
+		{"ASCII string", "ASCII string", true},
+		// truncated, but too early -- can't be valid utf8
+		{Chinese[0:4], "", false},
+		// truncated at the limit, in the middle of a rune
+		{Chinese[0:48], Chinese[0:47], true},
+		// Too long string that happened to be
+		// truncated on a rune boundary
+		{Chinese2[0:48], Chinese2[0:48], true},
+		// Too long string but valid UTF-8 --
+		// the function should pass it through unscathed
+		// (it is not responsible for doing its own truncation)
+		{Chinese2, Chinese2, true},
+	} {
+		result, ok := maybeFixTruncation(test.s, 48)
+		require.Equal(t, test.result, result)
+		require.Equal(t, test.ok, ok)
+	}
+}


### PR DESCRIPTION
Also, re-truncate a value that the tracer
might have truncated at a byte boundary at a
rune boundary instead.