### PR TITLE
fix(snap): remove `slots` - not applicable to `classic` snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,12 +48,7 @@ parts:
 
       chmod 0755 $CRAFT_PART_INSTALL/parca-agent
       chmod 0755 $CRAFT_PART_INSTALL/parca-agent-wrapper
-slots:
-  logs:
-    interface: content
-    source:
-      read:
-        - $SNAP_COMMON
+
 apps:
   parca-agent:
     command: parca-agent


### PR DESCRIPTION
Fixes https://github.com/parca-dev/parca-agent/actions/runs/15159720812/job/43044883883