### PR TITLE
feat(snap): add `off-cpu-threshold` option

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -65,3 +65,9 @@ config_path="$(snapctl get config-path)"
 if [[ -z "$config_path" ]]; then
     snapctl set config-path=""
 fi
+
+# Set off-cpu threshold
+off_cpu_threshold="$(snapctl get off-cpu-threshold)"
+if [[ -z "$off_cpu_threshold" ]]; then
+    snapctl set off-cpu-threshold="0"
+fi

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -27,6 +27,7 @@ insecure="$(snapctl get remote-store-insecure)"
 token="$(snapctl get remote-store-bearer-token)"
 metadata_external_labels="$(snapctl get metadata-external-labels)"
 config_path="$(snapctl get config-path)"
+off_cpu_threshold="$(snapctl get off-cpu-threshold)"
 
 # Start building an array of command line options
 opts=(
@@ -37,6 +38,7 @@ opts=(
     "--remote-store-insecure=${insecure}"
     "--metadata-external-labels=${metadata_external_labels}"
     "--config-path=${config_path}"
+    "--off-cpu-threshold=${off_cpu_threshold}"
 )
 
 # If the token has been changed from empty, append it to the command line args


### PR DESCRIPTION
Adds an `off-cpu-threshold` option to the Snap package, which defaults to `0`.