### PR TITLE
Add metric debuginfo_upload_request_bytes

### DIFF
--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -142,6 +142,7 @@ type ParcaReporter struct {
 	// Our own metrics
 	sampleWriteRequestBytes     prometheus.Counter
 	stacktraceWriteRequestBytes prometheus.Counter
+	debuginfoUploadRequestBytes prometheus.Counter
 
 	offlineModeConfig *OfflineModeConfig
 
@@ -584,9 +585,14 @@ func New(
 		Name: "stacktrace_write_request_bytes",
 		Help: "the total number of bytes written in WriteRequest calls for stacktrace records",
 	})
+	debuginfoUploadRequestBytes := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "debuginfo_upload_request_bytes",
+		Help: "the total number of bytes uploaded in debuginfo upload requests",
+	})
 
 	reg.MustRegister(sampleWriteRequestBytes)
 	reg.MustRegister(stacktraceWriteRequestBytes)
+	reg.MustRegister(debuginfoUploadRequestBytes)
 
 	r := &ParcaReporter{
 		stopSignal:          make(chan libpf.Void),
@@ -614,6 +620,7 @@ func New(
 		otelLibraryMetrics:          make(map[string]prometheus.Metric),
 		sampleWriteRequestBytes:     sampleWriteRequestBytes,
 		stacktraceWriteRequestBytes: stacktraceWriteRequestBytes,
+		debuginfoUploadRequestBytes: debuginfoUploadRequestBytes,
 		offlineModeConfig:           offlineModeConfig,
 		offlineModeLoggedStacks:     loggedStacks,
 	}
@@ -628,6 +635,7 @@ func New(
 			uploaderQueueSize,
 			symbolUploadConcurrency,
 			cacheDir,
+			debuginfoUploadRequestBytes,
 		)
 		if err != nil {
 			close(r.stopSignal)


### PR DESCRIPTION
Currently, parca-agent exposes the following network-related metrics:

- process_network_receive_bytes_total
- process_network_transmit_bytes_total
- sample_write_request_bytes
- stacktrace_write_request_bytes

The `process_network_*` metrics are tied to the process's network namespace. When parca-agent runs outside a container or dedicated network namespace, these metrics capture the entire node's network traffic rather than parca-agent-specific traffic.

This PR adds a new metric `debuginfo_upload_request_bytes` to track the total bytes uploaded in debuginfo upload requests. This complements the existing `sample_write_request_bytes` and `stacktrace_write_request_bytes` metrics, providing complete visibility into parca-agent's application-level network usage.