### PR TITLE
fix: prevent cross-process label contamination from TID reuse

### DIFF
--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -62,6 +62,7 @@ type processInfo struct {
 type labelRetrievalResult struct {
 	labels labels.Labels
 	keep   bool
+	pid    libpf.PID
 }
 
 // sourceInfo allows to map a frame to its source origin.
@@ -315,7 +316,7 @@ func (r *ParcaReporter) addMetadataForPID(pid libpf.PID, lb *labels.Builder) boo
 }
 
 func (r *ParcaReporter) labelsForTID(tid, pid libpf.PID, comm string, cpu int, envVars map[string]string) labelRetrievalResult {
-	if labels, exists := r.labels.Get(tid); exists {
+	if labels, exists := r.labels.Get(tid); exists && labels.pid == pid {
 		return labels
 	}
 
@@ -348,6 +349,7 @@ func (r *ParcaReporter) labelsForTID(tid, pid libpf.PID, comm string, cpu int, e
 	res := labelRetrievalResult{
 		labels: lb.Labels(),
 		keep:   keep,
+		pid:    pid,
 	}
 
 	if cacheable {


### PR DESCRIPTION
Add PID validation to the TID-based label cache to detect when a
thread ID is reused by a different process. When a cache hit occurs
but the cached PID doesn't match the current PID, recompute labels
instead of returning stale data.

This fixes cases where profiling samples from one Java process
were incorrectly attributed with labels from another process due to Linux
reusing thread IDs across different processes.

The fix adds a `pid` field to `labelRetrievalResult` and validates
it on cache lookup, ensuring labels are always computed from the
correct process metadata.