### PR TITLE
fix: upload size when stripping is disabled

### DIFF
--- a/reporter/parca_uploader.go
+++ b/reporter/parca_uploader.go
@@ -261,7 +261,7 @@ func (u *ParcaSymbolUploader) attemptUpload(ctx context.Context, fileID libpf.Fi
 		}
 		defer f.Close()
 
-		size, err := readAtCloserSize(f)
+		size, err = readAtCloserSize(f)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Same as https://github.com/parca-dev/parca-agent/pull/3031 with fixed merge conflicts