### PR TITLE
Add docker and containerd meta labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,13 @@ Using relabeling the following labels can be attached to profiles:
 * `__meta_kubernetes_node_annotationpresent_*`: Whether the annotation `*` of the node the process is running on is present.
 * `__meta_docker_container_id`: The ID of the container the process is running in.
 * `__meta_docker_container_name`: The name of the container the process is running in.
+* `__meta_docker_container_label_*`: The value of the label `*` of the container the process is running in.
+* `__meta_docker_container_labelpresent_*`: Whether the label `*` of the container the process is running in is present.
 * `__meta_docker_build_kit_container_id`: The ID of the container the process is running in.
 * `__meta_containerd_container_id`: The ID of the container the process is running in.
 * `__meta_containerd_container_name`: The name of the container the process is running in.
+* `__meta_containerd_container_label_*`: The value of the label `*` of the container the process is running in.
+* `__meta_containerd_container_labelpresent_*`: Whether the label `*` of the container the process is running in is present.
 * `__meta_containerd_pod_name`: The name of the pod the process is running in.
 * `__meta_lxc_container_id`: The ID of the container the process is running in.
 * `__meta_cpu`: The CPU the sample was taken on.

--- a/reporter/metadata/agent.go
+++ b/reporter/metadata/agent.go
@@ -1,8 +1,10 @@
 package metadata
 
 import (
-	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"context"
+
 	"github.com/prometheus/prometheus/model/labels"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
 type agentMetadataProvider struct {
@@ -13,7 +15,7 @@ func NewAgentMetadataProvider(revision string) MetadataProvider {
 	return &agentMetadataProvider{revision: revision}
 }
 
-func (p *agentMetadataProvider) AddMetadata(_ libpf.PID, lb *labels.Builder) bool {
+func (p *agentMetadataProvider) AddMetadata(_ context.Context, _ libpf.PID, lb *labels.Builder) bool {
 	lb.Set("__meta_agent_revision", p.revision)
 	return true
 }

--- a/reporter/metadata/process.go
+++ b/reporter/metadata/process.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,9 +13,9 @@ import (
 	"strings"
 
 	lru "github.com/elastic/go-freelru"
-	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"github.com/prometheus/prometheus/model/labels"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
 var ErrFileParse = errors.New("Error Parsing File")
@@ -167,6 +168,7 @@ func NewMainExecutableMetadataProvider(
 
 // AddMetadata adds metadata labels for the main executable of a process to the given labels.Builder.
 func (p *mainExecutableMetadataProvider) AddMetadata(
+	_ context.Context,
 	pid libpf.PID,
 	lb *labels.Builder,
 ) bool {
@@ -202,7 +204,7 @@ func NewProcessMetadataProvider() MetadataProvider {
 }
 
 // AddMetadata adds metadata labels for a process to the given labels.Builder.
-func (pmp *processMetadataProvider) AddMetadata(pid libpf.PID, lb *labels.Builder) bool {
+func (pmp *processMetadataProvider) AddMetadata(_ context.Context, pid libpf.PID, lb *labels.Builder) bool {
 	cache := true
 	lb.Set("__meta_process_pid", strconv.Itoa(int(pid)))
 

--- a/reporter/metadata/system.go
+++ b/reporter/metadata/system.go
@@ -1,11 +1,12 @@
 package metadata
 
 import (
+	"context"
 	"strings"
 	"syscall"
 
-	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"github.com/prometheus/prometheus/model/labels"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
 )
 
 type systemMetadataProvider struct {
@@ -37,7 +38,7 @@ func NewSystemMetadataProvider() (MetadataProvider, error) {
 	}, nil
 }
 
-func (p *systemMetadataProvider) AddMetadata(_ libpf.PID, lb *labels.Builder) bool {
+func (p *systemMetadataProvider) AddMetadata(_ context.Context, _ libpf.PID, lb *labels.Builder) bool {
 	lb.Set("__meta_system_kernel_machine", p.kernelMachine)
 	lb.Set("__meta_system_kernel_release", p.kernelRelease)
 	return true

--- a/reporter/parca_reporter.go
+++ b/reporter/parca_reporter.go
@@ -285,11 +285,11 @@ func (r *ParcaReporter) ReportTraceEvent(trace *libpf.Trace,
 	return nil
 }
 
-func (r *ParcaReporter) addMetadataForPID(pid libpf.PID, lb *labels.Builder) bool {
+func (r *ParcaReporter) addMetadataForPID(ctx context.Context, pid libpf.PID, lb *labels.Builder) bool {
 	cache := true
 
 	for _, p := range r.metadataProviders {
-		cacheable := p.AddMetadata(pid, lb)
+		cacheable := p.AddMetadata(ctx, pid, lb)
 		cache = cache && cacheable
 	}
 
@@ -315,7 +315,7 @@ func (r *ParcaReporter) labelsForTID(tid, pid libpf.PID, comm string, cpu int, e
 		lb.Set("job", "oomprof")
 	}
 
-	cacheable := r.addMetadataForPID(pid, lb)
+	cacheable := r.addMetadataForPID(context.TODO(), pid, lb)
 
 	keep := relabel.ProcessBuilder(lb, r.relabelConfigs...)
 


### PR DESCRIPTION
This adds docker and containerd container labels as meta labels so users can relabel them onto samples the same way as it is possible with eg. kubernetes pod labels.