### PR TITLE
snap: Add remote-store-grpc-headers config option

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -35,6 +35,7 @@ There are a small number of config options:
 | `http-address`          | Any string                       | `:7071`          | Address for HTTP server to bind to.                          |
 | `remote-store-address`  | Any string                       | `localhost:7071` | Remote store (gRPC) address to send profiles and symbols to. |
 | `remote-store-insecure` | `true`, `false`                  | `false`          | Send gRPC requests via plaintext instead of TLS.             |
+| `remote-store-grpc-headers` | Comma-separated key=value pairs | ``               | Additional gRPC headers to send with each request.           |
 | `config-path`           | Any string                       | ``               | Path to config file.                                         |
 
 Config options can be set with `sudo snap set parca-agent <option>=<value>`

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -71,3 +71,9 @@ off_cpu_threshold="$(snapctl get off-cpu-threshold)"
 if [[ -z "$off_cpu_threshold" ]]; then
     snapctl set off-cpu-threshold="0"
 fi
+
+# Set gRPC headers
+remote_store_grpc_headers="$(snapctl get remote-store-grpc-headers)"
+if [[ -z "$remote_store_grpc_headers" ]]; then
+    snapctl set remote-store-grpc-headers=""
+fi

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -28,6 +28,7 @@ token="$(snapctl get remote-store-bearer-token)"
 metadata_external_labels="$(snapctl get metadata-external-labels)"
 config_path="$(snapctl get config-path)"
 off_cpu_threshold="$(snapctl get off-cpu-threshold)"
+grpc_headers="$(snapctl get remote-store-grpc-headers)"
 
 # Start building an array of command line options
 opts=(
@@ -44,6 +45,15 @@ opts=(
 # If the token has been changed from empty, append it to the command line args
 if [[ -n "${token}" ]]; then
     opts+=("--remote-store-bearer-token=${token}")
+fi
+
+# If gRPC headers have been set, append them to the command line args
+# Headers should be comma-separated key=value pairs, e.g., "X-Custom-Header=value1,X-Another=value2"
+if [[ -n "${grpc_headers}" ]]; then
+    IFS=',' read -ra headers <<< "${grpc_headers}"
+    for header in "${headers[@]}"; do
+        opts+=("--remote-store-grpc-headers=${header}")
+    done
 fi
 
 # Run parca-agent with the gathered arguments


### PR DESCRIPTION
Allow users to specify additional gRPC headers via snap configuration. Headers are specified as comma-separated key=value pairs.