### PR TITLE
Add support for mTLS

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -338,6 +338,9 @@ type FlagsRemoteStore struct {
 	GRPCConnectionTimeout    time.Duration     `default:"3s" help:"The timeout duration for gRPC connection establishment."`
 	GRPCMaxConnectionRetries uint32            `default:"5" help:"The maximum number of retries to establish a gRPC connection."`
 	GRPCHeaders              map[string]string `help:"Additional gRPC headers to send with each request (key=value pairs)."`
+
+	ClientCert string `help:"Client certificate for mTLS"`
+	ClientKey  string `help:"Client key for mTLS"`
 }
 
 // FlagsDebuginfo contains flags to configure debuginfo.


### PR DESCRIPTION
This PR adds two new flags to the agent to accept a client certificate and a client key, so it can authenticate with the server via `mTLS`.