### PR TITLE
Separate flag for reading trace pipe to logging

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -391,7 +391,8 @@ type FlagsHidden struct {
 }
 
 type FlagsBPF struct {
-	VerboseLogging   bool   `help:"Enable verbose BPF logging."`
+	VerboseLogging   bool   `help:"Enable verbose BPF logging from eBPF code to ebpf trace_pipe."`
+	LogTracePipe     bool   `help:"Copy bpf trace_pipe to info logging."`
 	EventsBufferSize uint32 `default:"8192"                     help:"Size in pages of the events buffer."`
 	MapScaleFactor   int    `default:"${default_map_scale_factor}" help:"Scaling factor for eBPF map sizes. Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. Default is ${default_map_scale_factor} corresponding to 4GB of executable address space, max is ${max_map_scale_factor}."`
 	VerifierLogLevel uint32 `default:"0" help:"Log level of the eBPF verifier output (0,1,2). Default is 0."`

--- a/main.go
+++ b/main.go
@@ -536,7 +536,7 @@ func mainWithExitCode() flags.ExitCode {
 		return flags.Failure("Failed to start trace handler: %v", err)
 	}
 
-	if f.BPF.VerboseLogging {
+	if f.BPF.LogTracePipe {
 		go readTracePipe(mainCtx)
 	}
 
@@ -656,7 +656,7 @@ func readTracePipe(ctx context.Context) {
 		}
 		line = strings.TrimSpace(line)
 		if len(line) > 0 {
-			log.Debugf("%s", line)
+			log.Infof("bpf: %s", line)
 		}
 	}
 }


### PR DESCRIPTION
Conflating verbose BPF logging with reading the trace pipe resulted in
some operatational functionality loss, seperate the two. Sometimes its
nice to use bpftool to read the bpf logs separately.
