### PR TITLE
Don't hardcode path to bash in test-oom.sh

### DIFF
--- a/oom/test-oom.sh
+++ b/oom/test-oom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is a test to ensure the parca-agent can detect and handle "self" OOMs,
 # ie the parent process watches the child for OOM events and reports them.


### PR DESCRIPTION
Bash is not at /bin/bash on all possible systems