### PR TITLE
Update OpenTelemetry eBPF profiler fork to 65c41ed6fabf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,4 +177,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260213155245-de73771437d3
+replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260216132358-65c41ed6fabf

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXh
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/parca-dev/oomprof v0.1.6 h1:potfd09aphNKqsIF54ZsiddTvksVMjQiaKnczFOsVGM=
 github.com/parca-dev/oomprof v0.1.6/go.mod h1:iqI6XrmiNWOa8m2vEIKo+GtQrqbWCMLFpBWuk8RuAPs=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260213155245-de73771437d3 h1:HSt2ADYliZPMxySaM+HOmgjXZSbeRiJoI7ACXtpo6Jo=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260213155245-de73771437d3/go.mod h1:yVpeERcH/++ahci/FAPA8l4TL+y0JY3T6z4xu/r3+HM=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260216132358-65c41ed6fabf h1:pq8W2RKcXZwEfkVtBVmyM8zf7nAEjD+mXBWbi/cQ5DM=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260216132358-65c41ed6fabf/go.mod h1:yVpeERcH/++ahci/FAPA8l4TL+y0JY3T6z4xu/r3+HM=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=


### PR DESCRIPTION
## Summary

Update OpenTelemetry eBPF profiler fork from `de73771437d3` to `65c41ed6fabf`

## Changes

- Disable multi-uprobe on kernels with prog array attach type restriction (65c41ed)
