### PR TITLE
Fixing the bug where wrong cpu label values were getting assigned to the samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ Parca Agent supports [Prometheus relabeling](https://prometheus.io/docs/promethe
 
 * `node`: The name of the node that the process is running on as specified by the `--node` flag.
 * `comm`: The command name of the process being profiled.
+* `cpu`: The CPU the sample was taken on. Can be disabled with `--metadata-disable-cpu-label`.
+* `thread_id`: The thread ID of the thread being profiled. Can be disabled with `--metadata-disable-thread-id-label`.
+* `thread_name`: The command name of the thread being profiled. Can be disabled with `--metadata-disable-thread-comm-label`.
 
 And optionally you can attach additional labels using the `--metadata-external-labels` flag.
 
@@ -274,8 +277,6 @@ Using relabeling the following labels can be attached to profiles:
 * `__meta_process_executable_stripped`: Whether the executable of the process being profiled is stripped from debuginfo.
 * `__meta_system_kernel_release`: The kernel release of the system.
 * `__meta_system_kernel_machine`: The kernel machine of the system (typically the architecture).
-* `__meta_thread_comm`: The command name of the thread being profiled.
-* `__meta_thread_id`: The PID of the thread being profiled.
 * `__meta_agent_revision`: The revision of the agent.
 * `__meta_kubernetes_namespace`: The namespace of the pod the process is running in.
 * `__meta_kubernetes_pod_name`: The name of the pod the process is running in.
@@ -310,7 +311,6 @@ Using relabeling the following labels can be attached to profiles:
 * `__meta_containerd_container_labelpresent_*`: Whether the label `*` of the container the process is running in is present.
 * `__meta_containerd_pod_name`: The name of the pod the process is running in.
 * `__meta_lxc_container_id`: The ID of the container the process is running in.
-* `__meta_cpu`: The CPU the sample was taken on.
 
 ## Security
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -313,6 +313,10 @@ type FlagsMetadata struct {
 
 	DisableCaching       bool `default:"false" help:"[deprecated] Disable caching of metadata."`
 	EnableProcessCmdline bool `default:"false" help:"[deprecated] Add /proc/[pid]/cmdline as a label, which may expose sensitive information like secrets in profiling data."`
+
+	DisableCPULabel        bool `default:"false" help:"Disable adding the cpu label to profiling data."`
+	DisableThreadIDLabel   bool `default:"false" help:"Disable adding the thread_id label to profiling data."`
+	DisableThreadCommLabel bool `default:"false" help:"Disable adding the thread_comm label to profiling data."`
 }
 
 // FlagsLocalStore provides local store configuration flags.


### PR DESCRIPTION
Bug: 
When viewing the data collected from the agent as flamechart, samples grouped by node + cpu, there were overlapping stacks, which cannot happen ideally. 

Root cause: 
The labels lru cache in the `parca-reporter` is only using tid as the cache key and when a thread gets scheduled across different cpu cores across the profiling ticks, we only use the labels cached from the first occurrence of the tid. 
So, if the tid when first seen was on cpu `1`, then it gets reported the same for all future occurrences, even though it can be seen on a different cpu core. 

Fix:
Made `pid` the label cache key and patching cpu, thread_id and thread_name labels on the fly. This reduced the memory footprint of this cache as well. 

Flags:
Added 3 more flags to control these labels, as they don't belong to the relabeling path anymore: 
- `--metadata-disable-cpu-label`
- `--metadata-disable-thread-id-label`
- `--metadata-disable-thread-comm-label`