### PR TITLE
fix: avoid nil dereference in symbol uploader when temp file creation fails

### DIFF
--- a/reporter/parca_uploader.go
+++ b/reporter/parca_uploader.go
@@ -275,7 +275,6 @@ func (u *ParcaSymbolUploader) attemptUpload(ctx context.Context, fileID libpf.Fi
 	} else {
 		f, err := os.Create(filepath.Join(u.tmp, fileID.StringNoQuotes()))
 		if err != nil {
-			os.Remove(f.Name())
 			return fmt.Errorf("create file: %w", err)
 		}
 		defer os.Remove(f.Name())


### PR DESCRIPTION
`attemptUpload` creates a temporary file before extracting debuginfo. If
`os.Create` fails, the current error path calls `os.Remove(f.Name())`, but `f`
is `nil` in that case, so `f.Name()` panics and crashes the agent.

I ran into this on a NixOS host after parca-agent panicked in the symbol
uploader while processing a wrapper binary under `/run/wrappers/...`. The
stack trace pointed back to the `os.Create` error path in
`reporter/parca_uploader.go`.

This change removes the `os.Remove(f.Name())` call from the `os.Create` error
branch. When file creation fails, there is no file to remove, and the function
now returns the original `create file` error instead of panicking.