### PR TITLE
parcagpu: move from opentelemetry-ebpf-profiler fork into parca-agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/alecthomas/kong-yaml v0.2.0
 	github.com/apache/arrow-go/v18 v18.5.2
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
+	github.com/cilium/ebpf v0.21.0
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
 	github.com/containerd/containerd v1.7.29
 	github.com/docker/docker v28.5.1+incompatible
@@ -70,7 +71,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cilium/ebpf v0.21.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/containerd/containerd/api v1.8.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
@@ -183,4 +183,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260429133311-7288ac964422
+replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260502182110-df23ce511a35

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXh
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/parca-dev/oomprof v0.1.6 h1:potfd09aphNKqsIF54ZsiddTvksVMjQiaKnczFOsVGM=
 github.com/parca-dev/oomprof v0.1.6/go.mod h1:iqI6XrmiNWOa8m2vEIKo+GtQrqbWCMLFpBWuk8RuAPs=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260429133311-7288ac964422 h1:8EJpVyZdoRmsLoCTsicPyOeGcJDdopeexOLc5XnseW4=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260429133311-7288ac964422/go.mod h1:y3XTAEtULIqYiwVj4Sw8TmJuFzdC8WTrKmxh1RBtQjw=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260502182110-df23ce511a35 h1:RdlpJyA3re2243nsDTLGAAYTrQ4ZTp1nXCM43pOQ8I8=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260502182110-df23ce511a35/go.mod h1:y3XTAEtULIqYiwVj4Sw8TmJuFzdC8WTrKmxh1RBtQjw=
 github.com/parca-dev/usdt v0.0.2 h1:bpKQycQ++zV8pwkMaJSxZS07XnEXqO3rkHcLYFJDTl4=
 github.com/parca-dev/usdt v0.0.2/go.mod h1:bjh3OTksk+pyP7WsHWlRKWaMSJTUr0gx0piZ/tAv6/w=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=

--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/metrics"
-	"go.opentelemetry.io/ebpf-profiler/parcagpu"
 	"go.opentelemetry.io/ebpf-profiler/util"
+
 	"go.opentelemetry.io/otel"
 
 	"go.opentelemetry.io/ebpf-profiler/processmanager"
@@ -60,6 +60,7 @@ import (
 	"github.com/parca-dev/parca-agent/config"
 	"github.com/parca-dev/parca-agent/flags"
 	"github.com/parca-dev/parca-agent/oom"
+	"github.com/parca-dev/parca-agent/parcagpu"
 	"github.com/parca-dev/parca-agent/reporter"
 	"github.com/parca-dev/parca-agent/uploader"
 )

--- a/parcagpu/parcagpu.go
+++ b/parcagpu/parcagpu.go
@@ -1,0 +1,126 @@
+// Package parcagpu reads GPU timing events from the eBPF profiler's
+// cuda_timing_events perf buffer, marries them with symbolized CUDA stack
+// traces from the profiler's interpreter/gpu package, and reports the
+// completed traces directly via a TraceReporter. It is wired into the
+// profiler through processmanager.TraceInterceptor.
+package parcagpu
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/cilium/ebpf/perf"
+	log "github.com/sirupsen/logrus"
+
+	"go.opentelemetry.io/ebpf-profiler/interpreter/gpu"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/metrics"
+	"go.opentelemetry.io/ebpf-profiler/processmanager"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
+	"go.opentelemetry.io/ebpf-profiler/support"
+	"go.opentelemetry.io/ebpf-profiler/tracer"
+	"go.opentelemetry.io/ebpf-profiler/traceutil"
+)
+
+// Start starts a goroutine that reads GPU timing events and returns a TraceInterceptor
+// that diverts CUDA traces (post-symbolization) into the GPU fixer.
+// Completed CUDA traces are reported directly via rep.
+func Start(ctx context.Context, tr *tracer.Tracer,
+	rep reporter.TraceReporter) processmanager.TraceInterceptor {
+	gpuTimingEvents := tr.GetEbpfMaps()["cuda_timing_events"]
+
+	// Per-CPU buffer size for timing events. CuptiTimingEvent is ~300 bytes,
+	// so 1MB allows ~3400 events per CPU before overflow.
+	eventReader, err := perf.NewReader(gpuTimingEvents, 1024*1024 /* perCPUBufferSize */)
+	if err != nil {
+		log.Fatalf("Failed to setup perf reporting via %s: %v", gpuTimingEvents, err)
+	}
+
+	var lostEventsCount, readErrorCount, noDataCount atomic.Uint64
+
+	// processBatch processes a batch of timing events and reports completed traces.
+	processBatch := func(batch []gpu.CuptiTimingEvent) {
+		outputs := gpu.AddTimes(batch)
+		for i := range outputs {
+			outputs[i].Trace.Hash = traceutil.HashTrace(outputs[i].Trace)
+			if err := rep.ReportTraceEvent(outputs[i].Trace, outputs[i].Meta); err != nil {
+				log.Errorf("[parcagpu] failed to report CUDA trace: %v", err)
+			}
+		}
+	}
+
+	const batchSize = 100
+	go func() {
+		var data perf.Record
+		batch := make([]gpu.CuptiTimingEvent, 0, batchSize)
+
+		logTicker := time.NewTicker(5 * time.Second)
+		defer logTicker.Stop()
+
+		clearTicker := time.NewTicker(2 * time.Second)
+		defer clearTicker.Stop()
+
+		for {
+			select {
+			case <-logTicker.C:
+				lost := lostEventsCount.Swap(0)
+				readErr := readErrorCount.Swap(0)
+				noData := noDataCount.Swap(0)
+				if lost > 0 || readErr > 0 || noData > 0 {
+					log.Warnf("[cuda] timing event reader: lost=%d readErrors=%d noData=%d",
+						lost, readErr, noData)
+				}
+			case <-clearTicker.C:
+				// Periodically clean up all GPU trace fixers and report metrics.
+				// MaybeClearAll returns metrics for the caller to report via AddSlice,
+				// avoiding duplicate-metric warnings from the metrics system.
+				metrics.AddSlice(gpu.MaybeClearAll())
+			case <-ctx.Done():
+				eventReader.Close()
+				return
+			default:
+				if err := eventReader.ReadInto(&data); err != nil {
+					readErrorCount.Add(1)
+					continue
+				}
+				if data.LostSamples != 0 {
+					lostEventsCount.Add(data.LostSamples)
+					continue
+				}
+				if len(data.RawSample) == 0 {
+					noDataCount.Add(1)
+					continue
+				}
+				// Copy event into batch since data.RawSample is reused
+				ev := (*gpu.CuptiTimingEvent)(unsafe.Pointer(&data.RawSample[0]))
+				batch = append(batch, *ev)
+				if len(batch) >= batchSize {
+					go processBatch(batch)
+					batch = make([]gpu.CuptiTimingEvent, 0, batchSize)
+				}
+			}
+		}
+	}()
+
+	// Return the interceptor function that diverts CUDA traces post-symbolization.
+	// Any traces InterceptTrace returns as already-complete (graph launches, or
+	// single launches whose timing arrived early) are reported here directly;
+	// traces awaiting timing are retained in the fixer and emitted later from
+	// processBatch via AddTimes.
+	return func(trace *libpf.Trace, meta *samples.TraceEventMeta) bool {
+		if meta.Origin != support.TraceOriginCuda {
+			return false
+		}
+		outputs := gpu.InterceptTrace(trace, meta)
+		for i := range outputs {
+			outputs[i].Trace.Hash = traceutil.HashTrace(outputs[i].Trace)
+			if err := rep.ReportTraceEvent(outputs[i].Trace, outputs[i].Meta); err != nil {
+				log.Errorf("[parcagpu] failed to report CUDA trace: %v", err)
+			}
+		}
+		return true
+	}
+}


### PR DESCRIPTION
The package only depends on the profiler through public surfaces
(tracer.GetEbpfMaps, reporter.TraceReporter, interpreter/gpu,
processmanager.TraceInterceptor, support.TraceOriginCuda, libpf.CUDA),
so it has no reason to live inside the fork. Hosting it here removes
one piece of permanent divergence on the parca-agent →
opentelemetry-ebpf-profiler path. The fork keeps the eBPF-bound parts
(interpreter/gpu, libpf.CUDA frame type, support.TraceOriginCuda) which
are tied to the eBPF program format and can't be moved.

main.go: only the import path changes. The parcagpu.Start call site is
unchanged.

Note: this commit pairs with the fork-side removal of parcagpu/. The
go.mod replace directive still points at the pre-removal fork SHA;
bump it once the corresponding fork commit is published.
