### PR TITLE
fix: return error for unreadable bearer token file

### DIFF
--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -14,6 +14,7 @@
 package flags
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -21,6 +22,8 @@ import (
 	"time"
 
 	"github.com/parca-dev/parca-agent/config"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestParse_OnlyRelabelConfigs(t *testing.T) {
@@ -42,39 +45,39 @@ func TestParse_OnlyRelabelConfigs(t *testing.T) {
 	// Save original args and restore after test
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	
+
 	// Set args with config path
 	os.Args = []string{"parca-agent", "--config-path", configPath}
-	
+
 	// Parse flags
 	flags, err := Parse()
 	if err != nil {
 		t.Fatalf("Failed to parse flags: %v", err)
 	}
-	
+
 	// Verify default values are still set
 	if flags.HTTPAddress != "127.0.0.1:7071" {
 		t.Errorf("Expected default HTTPAddress, got %s", flags.HTTPAddress)
 	}
-	
+
 	if flags.Log.Level != "info" {
 		t.Errorf("Expected default log level 'info', got %s", flags.Log.Level)
 	}
-	
+
 	// Also test config.LoadFile() to ensure relabel configs are loaded correctly
 	cfg, err := config.LoadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to load config file: %v", err)
 	}
-	
+
 	if cfg == nil {
 		t.Fatal("Expected config to be loaded, got nil")
 	}
-	
+
 	if len(cfg.RelabelConfigs) != 2 {
 		t.Errorf("Expected 2 relabel configs, got %d", len(cfg.RelabelConfigs))
 	}
-	
+
 	if len(cfg.RelabelConfigs) >= 2 {
 		if cfg.RelabelConfigs[0].TargetLabel != "exec" {
 			t.Errorf("Expected first relabel config target_label 'exec', got %s", cfg.RelabelConfigs[0].TargetLabel)
@@ -107,63 +110,63 @@ metadata-external-labels:
 	// Save original args and restore after test
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	
+
 	// Set args with config path
 	os.Args = []string{"parca-agent", "--config-path", configPath}
-	
+
 	// Parse flags
 	flags, err := Parse()
 	if err != nil {
 		t.Fatalf("Failed to parse flags: %v", err)
 	}
-	
+
 	// Verify values from config file
 	if flags.HTTPAddress != "0.0.0.0:8080" {
 		t.Errorf("Expected HTTPAddress from config, got %s", flags.HTTPAddress)
 	}
-	
+
 	if flags.Log.Level != "debug" {
 		t.Errorf("Expected log level 'debug' from config, got %s", flags.Log.Level)
 	}
-	
+
 	if flags.Log.Format != "json" {
 		t.Errorf("Expected log format 'json' from config, got %s", flags.Log.Format)
 	}
-	
+
 	if flags.Profiling.Duration != 10*time.Second {
 		t.Errorf("Expected profiling duration 10s from config, got %v", flags.Profiling.Duration)
 	}
-	
+
 	if flags.Profiling.CPUSamplingFrequency != 97 {
 		t.Errorf("Expected CPU sampling frequency 97 from config, got %d", flags.Profiling.CPUSamplingFrequency)
 	}
-	
+
 	if flags.RemoteStore.Address != "grpc.example.com:443" {
 		t.Errorf("Expected remote store address from config, got %s", flags.RemoteStore.Address)
 	}
-	
+
 	if flags.RemoteStore.Insecure != false {
 		t.Errorf("Expected remote store insecure=false from config, got %v", flags.RemoteStore.Insecure)
 	}
-	
+
 	if flags.Metadata.ExternalLabels["cluster"] != "production" {
 		t.Errorf("Expected external label 'cluster=production' from config, got %s", flags.Metadata.ExternalLabels["cluster"])
 	}
-	
+
 	if flags.Metadata.ExternalLabels["region"] != "us-west-2" {
 		t.Errorf("Expected external label 'region=us-west-2' from config, got %s", flags.Metadata.ExternalLabels["region"])
 	}
-	
+
 	// Also test config.LoadFile() - this config has no relabel configs
 	cfg, err := config.LoadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to load config file: %v", err)
 	}
-	
+
 	if cfg == nil {
 		t.Fatal("Expected config to be loaded, got nil")
 	}
-	
+
 	if len(cfg.RelabelConfigs) != 0 {
 		t.Errorf("Expected 0 relabel configs, got %d", len(cfg.RelabelConfigs))
 	}
@@ -208,87 +211,87 @@ offline-mode-rotation-interval: 15m
 	// Save original args and restore after test
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	
+
 	// Set args with config path
 	os.Args = []string{"parca-agent", "--config-path", configPath}
-	
+
 	// Parse flags
 	flags, err := Parse()
 	if err != nil {
 		t.Fatalf("Failed to parse flags: %v", err)
 	}
-	
+
 	// Verify CLI flags from config file
 	if flags.HTTPAddress != "0.0.0.0:9090" {
 		t.Errorf("Expected HTTPAddress from config, got %s", flags.HTTPAddress)
 	}
-	
+
 	if flags.Log.Level != "warn" {
 		t.Errorf("Expected log level 'warn' from config, got %s", flags.Log.Level)
 	}
-	
+
 	if flags.Profiling.Duration != 15*time.Second {
 		t.Errorf("Expected profiling duration 15s from config, got %v", flags.Profiling.Duration)
 	}
-	
+
 	if flags.Profiling.LabelTTL != 20*time.Minute {
 		t.Errorf("Expected label TTL 20m from config, got %v", flags.Profiling.LabelTTL)
 	}
-	
+
 	if !flags.Profiling.EnableErrorFrames {
 		t.Errorf("Expected enable_error_frames=true from config")
 	}
-	
+
 	if flags.RemoteStore.Address != "remote.parca.dev:443" {
 		t.Errorf("Expected remote store address from config, got %s", flags.RemoteStore.Address)
 	}
-	
+
 	if flags.RemoteStore.BearerTokenFile != "/etc/parca/token" {
 		t.Errorf("Expected bearer token file from config, got %s", flags.RemoteStore.BearerTokenFile)
 	}
-	
+
 	if !flags.RemoteStore.InsecureSkipVerify {
 		t.Errorf("Expected insecure_skip_verify=true from config")
 	}
-	
+
 	if !flags.Debuginfo.UploadDisable {
 		t.Errorf("Expected debuginfo upload_disable=true from config")
 	}
-	
+
 	if len(flags.Debuginfo.Directories) != 2 {
 		t.Errorf("Expected 2 debuginfo directories from config, got %d", len(flags.Debuginfo.Directories))
 	}
-	
+
 	if !flags.BPF.VerboseLogging {
 		t.Errorf("Expected BPF verbose_logging=true from config")
 	}
-	
+
 	if flags.BPF.MapScaleFactor != 2 {
 		t.Errorf("Expected BPF map_scale_factor=2 from config, got %d", flags.BPF.MapScaleFactor)
 	}
-	
+
 	if flags.OfflineMode.StoragePath != "/var/lib/parca-agent" {
 		t.Errorf("Expected offline mode storage_path from config, got %s", flags.OfflineMode.StoragePath)
 	}
-	
+
 	if flags.OfflineMode.RotationInterval != 15*time.Minute {
 		t.Errorf("Expected offline mode rotation_interval=15m from config, got %v", flags.OfflineMode.RotationInterval)
 	}
-	
+
 	// Also test config.LoadFile() to ensure relabel configs are loaded correctly
 	cfg, err := config.LoadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to load config file: %v", err)
 	}
-	
+
 	if cfg == nil {
 		t.Fatal("Expected config to be loaded, got nil")
 	}
-	
+
 	if len(cfg.RelabelConfigs) != 2 {
 		t.Errorf("Expected 2 relabel configs, got %d", len(cfg.RelabelConfigs))
 	}
-	
+
 	if len(cfg.RelabelConfigs) >= 2 {
 		if cfg.RelabelConfigs[0].TargetLabel != "exec" {
 			t.Errorf("Expected first relabel config target_label 'exec', got %s", cfg.RelabelConfigs[0].TargetLabel)
@@ -314,7 +317,7 @@ profiling-duration: 10s
 	// Save original args and restore after test
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	
+
 	// Set args with config path and override some values
 	os.Args = []string{
 		"parca-agent",
@@ -322,37 +325,37 @@ profiling-duration: 10s
 		"--http-address", "127.0.0.1:9999",
 		"--log-level", "error",
 	}
-	
+
 	// Parse flags
 	flags, err := Parse()
 	if err != nil {
 		t.Fatalf("Failed to parse flags: %v", err)
 	}
-	
+
 	// Verify command-line args override config file values
 	if flags.HTTPAddress != "127.0.0.1:9999" {
 		t.Errorf("Expected HTTPAddress from command line, got %s", flags.HTTPAddress)
 	}
-	
+
 	if flags.Log.Level != "error" {
 		t.Errorf("Expected log level 'error' from command line, got %s", flags.Log.Level)
 	}
-	
+
 	// Verify config file value that wasn't overridden
 	if flags.Profiling.Duration != 10*time.Second {
 		t.Errorf("Expected profiling duration 10s from config, got %v", flags.Profiling.Duration)
 	}
-	
+
 	// Also test config.LoadFile() - this config has no relabel configs
 	cfg, err := config.LoadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to load config file: %v", err)
 	}
-	
+
 	if cfg == nil {
 		t.Fatal("Expected config to be loaded, got nil")
 	}
-	
+
 	if len(cfg.RelabelConfigs) != 0 {
 		t.Errorf("Expected 0 relabel configs, got %d", len(cfg.RelabelConfigs))
 	}
@@ -369,25 +372,25 @@ func TestParse_WithConfigFile_EmptyConfig(t *testing.T) {
 	// Save original args and restore after test
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	
+
 	// Set args with config path
 	os.Args = []string{"parca-agent", "--config-path", configPath}
-	
+
 	// Parse flags - should not error, just use defaults
 	flags, err := Parse()
 	if err != nil {
 		t.Fatalf("Failed to parse flags: %v", err)
 	}
-	
+
 	// Verify default values are set
 	if flags.HTTPAddress != "127.0.0.1:7071" {
 		t.Errorf("Expected default HTTPAddress, got %s", flags.HTTPAddress)
 	}
-	
+
 	if flags.Log.Level != "info" {
 		t.Errorf("Expected default log level 'info', got %s", flags.Log.Level)
 	}
-	
+
 	// Also test config.LoadFile() - empty config should return ErrEmptyConfig
 	_, err = config.LoadFile(configPath)
 	if err == nil {
@@ -396,4 +399,19 @@ func TestParse_WithConfigFile_EmptyConfig(t *testing.T) {
 	if !errors.Is(err, config.ErrEmptyConfig) {
 		t.Errorf("Expected ErrEmptyConfig, got %v", err)
 	}
+}
+
+func TestSetupGrpcConnectionReturnsErrorForUnreadableBearerTokenFile(t *testing.T) {
+	t.Parallel()
+
+	f := FlagsRemoteStore{
+		Address:               "127.0.0.1:1",
+		BearerTokenFile:       filepath.Join(t.TempDir(), "missing-token"),
+		Insecure:              true,
+		GRPCConnectionTimeout: time.Millisecond,
+	}
+
+	_, err := f.setupGrpcConnection(context.Background(), nil, noop.NewTracerProvider())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read bearer token from file")
 }

--- a/flags/grpc.go
+++ b/flags/grpc.go
@@ -117,7 +117,7 @@ func (f FlagsRemoteStore) setupGrpcConnection(parent context.Context, metrics *g
 	if f.BearerTokenFile != "" {
 		b, err := os.ReadFile(f.BearerTokenFile)
 		if err != nil {
-			panic(fmt.Errorf("failed to read bearer token from file: %w", err))
+			return nil, fmt.Errorf("failed to read bearer token from file: %w", err)
 		}
 
 		opts = append(opts, grpc.WithPerRPCCredentials(
@@ -144,25 +144,25 @@ func (f FlagsRemoteStore) setupGrpcConnection(parent context.Context, metrics *g
 	unaryInterceptors := []grpc.UnaryClientInterceptor{
 		timeout.UnaryClientInterceptor(f.RPCUnaryTimeout), // 5m by default.
 		retry.UnaryClientInterceptor(
-				// Back-off with Jitter: scalar: 1s, jitterFraction: 0,1, 10 runs
-				// i: 1		t:969.91774ms		total:969.91774ms
-				// i: 2		t:1.914221005s		total:2.884138745s
-				// i: 3		t:3.788704363s		total:6.672843108s
-				// i: 4		t:8.285062088s		total:14.957905196s
-				// i: 5		t:14.480256611s		total:29.438161807s
-				// i: 6		t:32.586249789s		total:1m2.024411596s
-				// i: 7		t:1m6.755804584s	total:2m8.78021618s
-				// i: 8		t:2m3.116345957s	total:4m11.896562137s
-				// i: 9		t:4m3.895083732s	total:8m15.791645869s
-				// i: 10	t:9m19.350609671s	total:17m35.14225554s
-				retry.WithBackoff(retry.BackoffExponentialWithJitter(time.Second, 0.1)),
-				retry.WithMax(10),
-				// The passed in context has a `5m` timeout (see above), the whole invocation should finish within that time.
-				// However, by default all retried calls will use the parent context for their deadlines.
-				// This means, that unless you shorten the deadline of each call of the retry, you won't be able to retry the first call at all.
-				// `WithPerRetryTimeout` allows you to shorten the deadline of each retry call, allowing you to fit multiple retries in the single parent deadline.
-				retry.WithPerRetryTimeout(2*time.Minute),
-			),
+			// Back-off with Jitter: scalar: 1s, jitterFraction: 0,1, 10 runs
+			// i: 1		t:969.91774ms		total:969.91774ms
+			// i: 2		t:1.914221005s		total:2.884138745s
+			// i: 3		t:3.788704363s		total:6.672843108s
+			// i: 4		t:8.285062088s		total:14.957905196s
+			// i: 5		t:14.480256611s		total:29.438161807s
+			// i: 6		t:32.586249789s		total:1m2.024411596s
+			// i: 7		t:1m6.755804584s	total:2m8.78021618s
+			// i: 8		t:2m3.116345957s	total:4m11.896562137s
+			// i: 9		t:4m3.895083732s	total:8m15.791645869s
+			// i: 10	t:9m19.350609671s	total:17m35.14225554s
+			retry.WithBackoff(retry.BackoffExponentialWithJitter(time.Second, 0.1)),
+			retry.WithMax(10),
+			// The passed in context has a `5m` timeout (see above), the whole invocation should finish within that time.
+			// However, by default all retried calls will use the parent context for their deadlines.
+			// This means, that unless you shorten the deadline of each call of the retry, you won't be able to retry the first call at all.
+			// `WithPerRetryTimeout` allows you to shorten the deadline of each retry call, allowing you to fit multiple retries in the single parent deadline.
+			retry.WithPerRetryTimeout(2*time.Minute),
+		),
 		metrics.UnaryClientInterceptor(
 			grpc_prometheus.WithExemplarFromContext(exemplarFromContext),
 		),


### PR DESCRIPTION
## What
Small fix for a sharp edge in remote store auth. If `--remote-store-bearer-token-file` points at a missing/unreadable file, setup currently panics.

Now it returns the wrapped error like the TLS setup path does. Tiny thing, but no random crashy vibes.

## Repro
Before this patch:
`go test ./flags -run TestSetupGrpcConnectionReturnsErrorForUnreadableBearerTokenFile -count=1`

It panics from `setupGrpcConnection`.

## Checks
`go test ./flags -run TestSetupGrpcConnectionReturnsErrorForUnreadableBearerTokenFile -count=1`

`go test ./...`