### PR TITLE
feat: Snap OTLP tracing support

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -37,5 +37,7 @@ There are a small number of config options:
 | `remote-store-insecure` | `true`, `false`                  | `false`          | Send gRPC requests via plaintext instead of TLS.             |
 | `remote-store-grpc-headers` | Comma-separated key=value pairs | ``               | Additional gRPC headers to send with each request.           |
 | `config-path`           | Any string                       | ``               | Path to config file.                                         |
+| `otlp-address`          | Any string                       | ``               | Endpoint to send OTLP traces to. Leave empty to disable tracing. |
+| `otlp-exporter`         | `grpc`, `http`                   | `grpc`           | OTLP exporter transport. Only used when `otlp-address` is set. |
 
 Config options can be set with `sudo snap set parca-agent <option>=<value>`

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -77,3 +77,15 @@ remote_store_grpc_headers="$(snapctl get remote-store-grpc-headers)"
 if [[ -z "$remote_store_grpc_headers" ]]; then
     snapctl set remote-store-grpc-headers=""
 fi
+
+# OTLP tracing endpoint. Leave empty to disable tracing.
+otlp_address="$(snapctl get otlp-address)"
+if [[ -z "$otlp_address" ]]; then
+    snapctl set otlp-address=""
+fi
+
+# OTLP exporter transport: "grpc" (default) or "http".
+otlp_exporter="$(snapctl get otlp-exporter)"
+if [[ -z "$otlp_exporter" ]]; then
+    snapctl set otlp-exporter="grpc"
+fi

--- a/snap/local/parca-agent-wrapper
+++ b/snap/local/parca-agent-wrapper
@@ -29,6 +29,8 @@ metadata_external_labels="$(snapctl get metadata-external-labels)"
 config_path="$(snapctl get config-path)"
 off_cpu_threshold="$(snapctl get off-cpu-threshold)"
 grpc_headers="$(snapctl get remote-store-grpc-headers)"
+otlp_address="$(snapctl get otlp-address)"
+otlp_exporter="$(snapctl get otlp-exporter)"
 
 # Start building an array of command line options
 opts=(
@@ -54,6 +56,12 @@ if [[ -n "${grpc_headers}" ]]; then
     for header in "${headers[@]}"; do
         opts+=("--remote-store-grpc-headers=${header}")
     done
+fi
+
+# If an OTLP address has been set, enable tracing with the configured exporter.
+if [[ -n "${otlp_address}" ]]; then
+    opts+=("--otlp-address=${otlp_address}")
+    opts+=("--otlp-exporter=${otlp_exporter}")
 fi
 
 # Run parca-agent with the gathered arguments


### PR DESCRIPTION
This PR adds support for passing `otlp-address` and `otlp-exporter` to the snap's config options. Although it is possible to define any set of parameters via `config-path`, allowing users to configure traces export without needing to manage their own config file would be useful for our parca-agent charm. 

The changes have been tested locally:

<img width="926" height="636" alt="image" src="https://github.com/user-attachments/assets/22db11aa-4631-49ac-8726-2cebd6890b2b" />
