### PR TITLE
Add bpf-cupti-event-scale-factor flag for GPU ringbuf sizing

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -58,6 +58,12 @@ const (
 	defaultMapScaleFactor = 0
 	// 1TB of executable address space
 	maxMapScaleFactor = 8
+
+	// Power-of-two scale factor over the 1 MiB cupti_events ringbuf base.
+	// 0 = 1 MiB (current default), 8 = 256 MiB. Bump on GPU nodes running CUDA
+	// graph workloads that show cuda.errors.ringbuf_full.
+	defaultCUPTIEventScaleFactor = 0
+	maxCUPTIEventScaleFactor     = 8
 )
 
 func Parse() (Flags, error) {
@@ -67,11 +73,13 @@ func Parse() (Flags, error) {
 	// Build Kong options
 	kongOptions := []kong.Option{
 		kong.Vars{
-			"hostname":                       hostname,
-			"default_cpu_sampling_frequency": strconv.Itoa(defaultCPUSamplingFrequency),
-			"default_map_scale_factor":       strconv.Itoa(defaultMapScaleFactor),
-			"max_map_scale_factor":           strconv.Itoa(maxMapScaleFactor),
-			"default_memlock_rlimit":         "0", // No limit by default. (flag is deprecated)
+			"hostname":                         hostname,
+			"default_cpu_sampling_frequency":   strconv.Itoa(defaultCPUSamplingFrequency),
+			"default_map_scale_factor":         strconv.Itoa(defaultMapScaleFactor),
+			"max_map_scale_factor":             strconv.Itoa(maxMapScaleFactor),
+			"default_cupti_event_scale_factor": strconv.Itoa(defaultCUPTIEventScaleFactor),
+			"max_cupti_event_scale_factor":     strconv.Itoa(maxCUPTIEventScaleFactor),
+			"default_memlock_rlimit":           "0", // No limit by default. (flag is deprecated)
 		},
 	}
 
@@ -82,11 +90,13 @@ func Parse() (Flags, error) {
 		// Create a new parser with YAML configuration support
 		parser, err := kong.New(&flags,
 			kong.Vars{
-				"hostname":                       hostname,
-				"default_cpu_sampling_frequency": strconv.Itoa(defaultCPUSamplingFrequency),
-				"default_map_scale_factor":       strconv.Itoa(defaultMapScaleFactor),
-				"max_map_scale_factor":           strconv.Itoa(maxMapScaleFactor),
-				"default_memlock_rlimit":         "0",
+				"hostname":                         hostname,
+				"default_cpu_sampling_frequency":   strconv.Itoa(defaultCPUSamplingFrequency),
+				"default_map_scale_factor":         strconv.Itoa(defaultMapScaleFactor),
+				"max_map_scale_factor":             strconv.Itoa(maxMapScaleFactor),
+				"default_cupti_event_scale_factor": strconv.Itoa(defaultCUPTIEventScaleFactor),
+				"max_cupti_event_scale_factor":     strconv.Itoa(maxCUPTIEventScaleFactor),
+				"default_memlock_rlimit":           "0",
 			},
 			kong.Configuration(kongyaml.Loader, flags.ConfigPath),
 		)
@@ -194,6 +204,11 @@ func (f Flags) Validate() ExitCode {
 	if f.BPF.MapScaleFactor > 8 {
 		return ParseError("eBPF map scaling factor %d exceeds limit (max: %d)",
 			f.BPF.MapScaleFactor, maxMapScaleFactor)
+	}
+
+	if f.BPF.CUPTIEventScaleFactor < 0 || f.BPF.CUPTIEventScaleFactor > maxCUPTIEventScaleFactor {
+		return ParseError("cupti_events scaling factor %d out of range (0-%d)",
+			f.BPF.CUPTIEventScaleFactor, maxCUPTIEventScaleFactor)
 	}
 
 	if f.BPF.VerifierLogLevel > 2 {
@@ -404,12 +419,13 @@ type FlagsHidden struct {
 }
 
 type FlagsBPF struct {
-	VerboseLogging   bool   `help:"Enable verbose BPF logging from eBPF code to ebpf trace_pipe."`
-	LogTracePipe     bool   `help:"Copy bpf trace_pipe to info logging."`
-	EventsBufferSize uint32 `default:"8192"                     help:"Size in pages of the events buffer."`
-	MapScaleFactor   int    `default:"${default_map_scale_factor}" help:"Scaling factor for eBPF map sizes. Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. Default is ${default_map_scale_factor} corresponding to 4GB of executable address space, max is ${max_map_scale_factor}."`
-	VerifierLogLevel uint32 `default:"0" help:"Log level of the eBPF verifier output (0,1,2). Default is 0."`
-	VerifierLogSize  int    `default:"0" help:"[deprecated] Unused."`
+	VerboseLogging        bool   `help:"Enable verbose BPF logging from eBPF code to ebpf trace_pipe."`
+	LogTracePipe          bool   `help:"Copy bpf trace_pipe to info logging."`
+	EventsBufferSize      uint32 `default:"8192"                     help:"Size in pages of the events buffer."`
+	MapScaleFactor        int    `default:"${default_map_scale_factor}" help:"Scaling factor for eBPF map sizes. Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. Default is ${default_map_scale_factor} corresponding to 4GB of executable address space, max is ${max_map_scale_factor}."`
+	CUPTIEventScaleFactor int    `default:"${default_cupti_event_scale_factor}" help:"Power-of-two scale factor over the 1 MiB cupti_events ringbuf base for GPU profiling. Every increase by 1 doubles the buffer. Increase on GPU nodes running CUDA graph workloads that show cuda.errors.ringbuf_full. Default is ${default_cupti_event_scale_factor} (1 MiB), max is ${max_cupti_event_scale_factor}."`
+	VerifierLogLevel      uint32 `default:"0" help:"Log level of the eBPF verifier output (0,1,2). Default is 0."`
+	VerifierLogSize       int    `default:"0" help:"[deprecated] Unused."`
 }
 
 type FlagsOfflineMode struct {

--- a/go.mod
+++ b/go.mod
@@ -189,4 +189,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260617152842-7fd00ff31304
+replace go.opentelemetry.io/ebpf-profiler => github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.202624-0.20260630131910-2f051e9329b8

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZH
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/parca-dev/oomprof v0.1.6 h1:potfd09aphNKqsIF54ZsiddTvksVMjQiaKnczFOsVGM=
 github.com/parca-dev/oomprof v0.1.6/go.mod h1:iqI6XrmiNWOa8m2vEIKo+GtQrqbWCMLFpBWuk8RuAPs=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260617152842-7fd00ff31304 h1:mGMlNzOTNcV/BDHTtEoiCi5vbySU5DcQHFj6COY1GpE=
-github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.0-20260617152842-7fd00ff31304/go.mod h1:VFrOyobZJf5qmHlPXImJXlfVWi5xb4SHx7cIqU1G908=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.202624-0.20260630131910-2f051e9329b8 h1:jqSPuVGxrzV/HU5VpD9x4doIhemE/EhJAZO3HoZic6I=
+github.com/parca-dev/opentelemetry-ebpf-profiler v0.0.202624-0.20260630131910-2f051e9329b8/go.mod h1:PIWChzqW1XvgamjPyaKO82tGO44rkiXhdDN8S9zoRq8=
 github.com/parca-dev/usdt v0.0.2 h1:bpKQycQ++zV8pwkMaJSxZS07XnEXqO3rkHcLYFJDTl4=
 github.com/parca-dev/usdt v0.0.2/go.mod h1:bjh3OTksk+pyP7WsHWlRKWaMSJTUr0gx0piZ/tAv6/w=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=

--- a/main.go
+++ b/main.go
@@ -468,6 +468,7 @@ func mainWithExitCode() flags.ExitCode {
 		IncludeTracers:         includeTracers,
 		SamplesPerSecond:       f.Profiling.CPUSamplingFrequency,
 		MapScaleFactor:         f.BPF.MapScaleFactor,
+		CUPTIEventScaleFactor:  f.BPF.CUPTIEventScaleFactor,
 		FilterErrorFrames:      !f.Profiling.EnableErrorFrames,
 		KernelVersionCheck:     !f.Hidden.IgnoreUnsafeKernelVersion,
 		BPFVerifierLogLevel:    f.BPF.VerifierLogLevel,

--- a/metrics/all.go
+++ b/metrics/all.go
@@ -22,7 +22,7 @@ const (
 	MetricTypeCounter = 1
 )
 
-var AllMetrics = map[otelmetrics.MetricID]Metric {
+var AllMetrics = map[otelmetrics.MetricID]Metric{
 	otelmetrics.IDInvalid: {
 		Desc:  "Leave out the 0 value. It's an indication of not explicitly initialized variables.",
 		Field: "",
@@ -1328,6 +1328,12 @@ var AllMetrics = map[otelmetrics.MetricID]Metric {
 	otelmetrics.IDBPFRingbufOutputErr: {
 		Desc:  "Number of bpf_ringbuf_output failures when sending trace events",
 		Field: "bpf.errors.ringbuf_output",
+		Type:  MetricTypeCounter,
+		Unit:  MetricUnitNone,
+	},
+	otelmetrics.IDCUPTIEventsRingbufFull: {
+		Desc:  "Number of cupti_events ringbuf reserve failures (GPU events dropped)",
+		Field: "cuda.errors.ringbuf_full",
 		Type:  MetricTypeCounter,
 		Unit:  MetricUnitNone,
 	},


### PR DESCRIPTION
Companion to parca-dev/opentelemetry-ebpf-profiler#309 (merged), which adds the `cupti_events` ringbuf sizing knob and the ringbuf-full drop metric. GPU graph launches fan out to many kernel-timing records and all GPU processes share that one ringbuf, so graph-heavy workloads (e.g. TRT-LLM decode) overflow the 1 MiB default and drop GPU events silently.

This bumps ebpf-profiler to the merged version and:

- **`--bpf-cupti-event-scale-factor`** — wires `tracer.Config.CUPTIEventScaleFactor` (power-of-two over the 1 MiB base; default 0 = unchanged), so GPU nodes can grow the buffer when they see drops. Validated to `[0, 8]`.
- **`cuda.errors.ringbuf_full`** — registers the new drop metric for export, so the previously-silent overflow is observable.

Draft pending validation on a real GPU node (watch `cuda.errors.ringbuf_full` go to zero as the scale factor is raised under a graph workload).